### PR TITLE
feat(63): setup git branches and commits formats checking

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+# Send the commit message file path to the verification script
+node scripts/verify-commit.js $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+# Check branch name format before allowing commit
+node scripts/verify-branch.js
+
+# Run linting and formating checks
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prepare": "husky"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
@@ -33,6 +34,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "husky": "^9.1.7",
     "postcss": "^8.5.6",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -1042,6 +1045,11 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2417,6 +2425,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 

--- a/scripts/verify-branch.js
+++ b/scripts/verify-branch.js
@@ -1,0 +1,24 @@
+import { execSync } from 'node:child_process';
+
+// Get current branch name
+const branchName = execSync('git rev-parse --abbrev-ref HEAD')
+  .toString()
+  .trim();
+
+// Ignore main branches
+if (['develop', 'main', 'master'].includes(branchName)) {
+  process.exit(0);
+}
+
+// Regex to validate branch name format: type/123-task-description
+const branchRE =
+  /^(feat|fix|chore|docs|style|refactor|perf|test)\/\d+-[a-z0-9-]+$/;
+
+if (!branchRE.test(branchName)) {
+  console.error(`\n❌ Error: Invalid branch name: "${branchName}"`);
+  console.error(`👉 Expected format: type/123-task-description`);
+  console.error(`💡 Examples:`);
+  console.error(`   feat/123-setup-eslint`);
+  console.error(`   fix/456-button-bug\n`);
+  process.exit(1); // Block commit if branch name is invalid
+}

--- a/scripts/verify-commit.js
+++ b/scripts/verify-commit.js
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+
+// Git provides the commit message file path as the first argument
+const msgPath = process.argv[2];
+const msg = fs.readFileSync(msgPath, 'utf-8').trim();
+
+// Ignore merge commits
+if (msg.startsWith('Merge branch')) {
+  process.exit(0);
+}
+
+// Regex to validate commit message format: type(123): description (e.g., feat(123): add eslint)
+const commitRE = /^(feat|fix|chore|docs|style|refactor|perf|test)\(\d+\):\s.+/;
+
+if (!commitRE.test(msg)) {
+  console.error(`\n❌ Error: Invalid commit message format.`);
+  console.error(`Commit message: "${msg}"`);
+  console.error(`👉 Expected format: type(123): your task in a nutshell`);
+  console.error(`💡 Examples:`);
+  console.error(`   feat(123): setup eslint and prettier`);
+  console.error(`   fix(456): resolve button color issue\n`);
+  process.exit(1); // Block commit if message is invalid
+}


### PR DESCRIPTION
- Special tool and scripts added to check git branch name and commit message formats before they leave local machine.
- They restricts pushing improperly formatted branches and commits to repository.