### PR TITLE
Feat(81): edit form with validation image upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.1",
+    "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2418,6 +2421,9 @@ packages:
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.0:
     resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
@@ -4837,6 +4843,8 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.0: {}
 

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { render, screen, userEvent } from '@/utils/test-utils';
 
 import { Dropdown } from './Dropdown';
+import type { DropdownOption } from './Dropdown.types';
 
 const mockOptions = [
   { value: 'apple', label: 'Apple' },
@@ -44,43 +46,46 @@ describe('UI Component: Dropdown', () => {
     const handleChange = vi.fn();
 
     render(
-      <Dropdown
-        label="Fruits"
-        options={mockOptions}
-        onChange={handleChange}
-        selectedValues={[]}
-      />,
+      <Dropdown label="Fruits" options={mockOptions} onChange={handleChange} />,
     );
 
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByText(mockOptions[0].label));
 
-    expect(handleChange).toHaveBeenCalledWith(
-      [mockOptions[0]],
-      expect.any(Object),
-    );
+    expect(handleChange).toHaveBeenCalledWith([mockOptions[0]]);
   });
 
   it('should allow selecting multiple options', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
 
-    render(
-      <Dropdown
-        label="Fruits"
-        options={mockOptions}
-        onChange={handleChange}
-        selectedValues={[]}
-      />,
-    );
+    const ControlledDropdown = () => {
+      const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
+
+      const handleDropdownChange = (values: DropdownOption[]) => {
+        setSelectedValues(values.map((value) => value.value));
+        handleChange(values);
+      };
+
+      return (
+        <Dropdown
+          label="Fruits"
+          options={mockOptions}
+          onChange={handleDropdownChange}
+          selectedValues={selectedValues}
+        />
+      );
+    };
+
+    render(<ControlledDropdown />);
 
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByText('Apple'));
     await user.click(screen.getByText('Banana'));
 
-    expect(handleChange).toHaveBeenLastCalledWith(
-      [mockOptions[0], mockOptions[1]],
-      expect.any(Object),
-    );
+    expect(handleChange).toHaveBeenLastCalledWith([
+      mockOptions[0],
+      mockOptions[1],
+    ]);
   });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,8 @@
 import { Field } from '@base-ui/react/field';
 import { Select } from '@base-ui/react/select';
+import clsx from 'clsx';
 import { Check, ChevronsUpDownIcon } from 'lucide-react';
+import { twMerge } from 'tailwind-merge';
 
 import type { DropdownProps } from './Dropdown.types';
 
@@ -9,20 +11,61 @@ import styles from './Dropdown.module.css';
 export const Dropdown = ({
   label,
   options,
+  selectedValues,
+  selectClassName,
+  labelClassName,
   onChange,
   placeholder = 'Select options',
+  multiple = true,
 }: DropdownProps) => {
+  const selectedOptions = selectedValues
+    ? options.filter((option) => selectedValues.includes(option.value))
+    : undefined;
+
+  const value = selectedOptions
+    ? multiple
+      ? selectedOptions
+      : (selectedOptions[0] ?? null)
+    : undefined;
+
+  const handleValueChange = (
+    value: DropdownProps['options'][number] | DropdownProps['options'] | null,
+  ) => {
+    if (!value) {
+      onChange([]);
+      return;
+    }
+
+    onChange(Array.isArray(value) ? value : [value]);
+  };
+
   return (
     <Field.Root className={styles.Field}>
       <Field.Label
-        className={styles.Label}
+        className={twMerge(
+          clsx(
+            'cursor-default text-xs font-medium text-[var(--color-text)] uppercase',
+            labelClassName,
+          ),
+        )}
         nativeLabel={false}
         render={<div />}
       >
         {label}
       </Field.Label>
-      <Select.Root multiple onValueChange={onChange}>
-        <Select.Trigger className={styles.Select}>
+      <Select.Root
+        multiple={multiple}
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <Select.Trigger
+          className={twMerge(
+            clsx(
+              'm-0 box-border flex h-8 min-w-[14rem] items-center justify-between gap-3 rounded-md border border-[var(--color-gray-300)] bg-[var(--color-bg)] pr-3 pl-3.5 leading-6 text-[var(--color-text)] select-none hover:bg-[var(--color-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-1px] focus-visible:outline-[var(--color-blue)] data-[popup-open]:bg-[var(--color-text)]',
+              selectClassName,
+            ),
+          )}
+        >
           <Select.Value className={styles.Value} placeholder={placeholder} />
           <Select.Icon className={styles.SelectIcon}>
             <ChevronsUpDownIcon className="w-4" />

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -5,8 +5,11 @@ export interface DropdownOption {
 
 export interface DropdownProps {
   label: string;
+  selectClassName?: string;
+  labelClassName?: string;
   options: DropdownOption[];
   selectedValues?: string[];
   onChange: (values: DropdownOption[]) => void;
   placeholder?: string;
+  multiple?: boolean;
 }

--- a/src/components/ProductForm/ProductForm.test.tsx
+++ b/src/components/ProductForm/ProductForm.test.tsx
@@ -12,6 +12,7 @@ describe('Component: ProductForm', () => {
           name: 'MacBook Pro',
           price: '2499',
           categories: 'laptops, electronics',
+          status: 'active',
           description: 'Laptop for work',
           imagePreview: 'https://example.com/product.png',
         }}
@@ -25,6 +26,7 @@ describe('Component: ProductForm', () => {
     expect(
       screen.getByDisplayValue('laptops, electronics'),
     ).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveTextContent('Active');
     expect(screen.getByDisplayValue('Laptop for work')).toBeInTheDocument();
     expect(screen.getByAltText('Preview')).toHaveAttribute(
       'src',
@@ -87,6 +89,7 @@ describe('Component: ProductForm', () => {
         name: 'IPhone 16',
         price: '999.99',
         categories: 'phones, electronics',
+        status: 'draft',
         description: 'Flagship phone',
         imagePreview: null,
         imageFile: undefined,

--- a/src/components/ProductForm/ProductForm.test.tsx
+++ b/src/components/ProductForm/ProductForm.test.tsx
@@ -5,14 +5,37 @@ import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
 import { ProductForm } from './ProductForm';
 
 describe('Component: ProductForm', () => {
-  it('should render initial data', () => {
+  it('should render correctly in CREATE mode (no status field, no last update)', () => {
+    render(<ProductForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(
+      screen.getByRole('textbox', { name: 'Name Product' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('spinbutton', { name: 'Price' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Categories' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Description' }),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+    expect(screen.queryByText(/Last Update:/i)).not.toBeInTheDocument();
+  });
+
+  it('should render initial data, status field, and last update in EDIT mode', () => {
     render(
       <ProductForm
+        isEditMode={true}
+        updatedAt="2025-10-10T12:00:00Z"
         initialData={{
           name: 'MacBook Pro',
           price: '2499',
           categories: 'laptops, electronics',
-          status: 'active',
+          status: 'ACTIVE',
           description: 'Laptop for work',
           imagePreview: 'https://example.com/product.png',
         }}
@@ -26,17 +49,19 @@ describe('Component: ProductForm', () => {
     expect(
       screen.getByDisplayValue('laptops, electronics'),
     ).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toHaveTextContent('Active');
     expect(screen.getByDisplayValue('Laptop for work')).toBeInTheDocument();
     expect(screen.getByAltText('Preview')).toHaveAttribute(
       'src',
       'https://example.com/product.png',
     );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Active');
+
+    expect(screen.getByText(/Last Update:/i)).toBeInTheDocument();
   });
 
-  it('should show validation errors for required fields', async () => {
+  it('should show validation errors for required fields on submit', async () => {
     const user = userEvent.setup();
-
     render(<ProductForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
@@ -52,7 +77,7 @@ describe('Component: ProductForm', () => {
 
   it('should clear validation errors on input and submit valid form data', async () => {
     const user = userEvent.setup();
-    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+    const handleSubmit = vi.fn();
 
     render(<ProductForm onSubmit={handleSubmit} onCancel={vi.fn()} />);
 
@@ -60,9 +85,7 @@ describe('Component: ProductForm', () => {
 
     const nameInput = screen.getByRole('textbox', { name: 'Name Product' });
     const priceInput = screen.getByRole('spinbutton', { name: 'Price' });
-    const categoriesInput = screen.getByRole('textbox', {
-      name: 'Categories',
-    });
+    const categoriesInput = screen.getByRole('textbox', { name: 'Categories' });
     const descriptionInput = screen.getByRole('textbox', {
       name: 'Description',
     });
@@ -89,11 +112,22 @@ describe('Component: ProductForm', () => {
         name: 'IPhone 16',
         price: '999.99',
         categories: 'phones, electronics',
-        status: 'draft',
+        status: 'DRAFT',
         description: 'Flagship phone',
         imagePreview: null,
         imageFile: undefined,
       });
     });
+  });
+
+  it('should call onCancel when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleCancel = vi.fn();
+
+    render(<ProductForm onSubmit={vi.fn()} onCancel={handleCancel} />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(handleCancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -46,6 +46,8 @@ interface ProductFormProps {
   onSubmit: (data: ProductFormData) => void | Promise<void>;
   onCancel: () => void;
   isLoading?: boolean;
+  isEditMode?: boolean;
+  updatedAt?: string;
 }
 
 export const ProductForm: React.FC<ProductFormProps> = ({
@@ -53,6 +55,8 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   onSubmit,
   onCancel,
   isLoading,
+  isEditMode = false,
+  updatedAt,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const previewUrlRef = useRef<string | null>(null);
@@ -136,6 +140,19 @@ export const ProductForm: React.FC<ProductFormProps> = ({
 
   const isDisabled = isLoading || isSubmitting;
 
+  const availableStatusOptions =
+    initialData?.status && initialData.status !== 'DRAFT'
+      ? STATUS_OPTIONS.filter((opt) => opt.value !== 'DRAFT')
+      : STATUS_OPTIONS;
+
+  const formattedDate = updatedAt
+    ? new Date(updatedAt).toLocaleDateString('en-US', {
+        month: '2-digit',
+        day: '2-digit',
+        year: '2-digit',
+      })
+    : '';
+
   return (
     <div className="rounded-lg border border-gray-200 bg-[rgb(var(--color-bg-sec))] p-4 shadow-sm dark:border-gray-800">
       <form onSubmit={handleSubmit(handleSave)} className="flex flex-col gap-4">
@@ -215,24 +232,28 @@ export const ProductForm: React.FC<ProductFormProps> = ({
               />
             )}
           />
-          <Controller
-            control={control}
-            name="status"
-            render={({ field }) => (
-              <Dropdown
-                label="Status"
-                labelClassName="capitalize text-sm"
-                selectClassName="bg-white text-black hover:bg-gray-50 dark:hover:bg-gray-800 data-[popup-open]:bg-white"
-                options={STATUS_OPTIONS}
-                selectedValues={field.value ? [field.value] : []}
-                onChange={(values) =>
-                  field.onChange((values[0]?.value ?? 'DRAFT') as ProductStatus)
-                }
-                placeholder="Select status"
-                multiple={false}
-              />
-            )}
-          />
+          {isEditMode && (
+            <Controller
+              control={control}
+              name="status"
+              render={({ field }) => (
+                <Dropdown
+                  label="Status"
+                  labelClassName="capitalize text-sm"
+                  selectClassName="bg-white text-black hover:bg-gray-50 dark:hover:bg-gray-800 data-[popup-open]:bg-white"
+                  options={availableStatusOptions}
+                  selectedValues={field.value ? [field.value] : []}
+                  onChange={(values) =>
+                    field.onChange(
+                      (values[0]?.value ?? 'DRAFT') as ProductStatus,
+                    )
+                  }
+                  placeholder="Select status"
+                  multiple={false}
+                />
+              )}
+            />
+          )}
           <Controller
             control={control}
             name="description"
@@ -251,24 +272,32 @@ export const ProductForm: React.FC<ProductFormProps> = ({
           />
         </div>
 
-        <div className="mt-4 flex justify-end gap-3">
-          <button
-            type="submit"
-            disabled={isDisabled}
-            className={`cursor-pointer rounded-md border-0 bg-green-500 px-5 py-1.5 text-white hover:bg-green-500/90 dark:hover:bg-green-900/20 ${
-              isDisabled ? 'cursor-not-allowed opacity-50' : ''
-            }`}
-          >
-            {isDisabled ? 'Saving...' : 'Save'}
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isDisabled}
-            className="cursor-pointer rounded-md border border-gray-300 bg-white px-5 py-1.5 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-transparent dark:text-white dark:hover:bg-gray-800"
-          >
-            Cancel
-          </button>
+        <div className="mt-4 flex items-center justify-between">
+          <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            {isEditMode && updatedAt && (
+              <span>Last Update: {formattedDate}</span>
+            )}
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={isDisabled}
+              className={`cursor-pointer rounded-md border-0 bg-green-500 px-5 py-1.5 text-white hover:bg-green-500/90 dark:hover:bg-green-900/20 ${
+                isDisabled ? 'cursor-not-allowed opacity-50' : ''
+              }`}
+            >
+              {isDisabled ? 'Saving...' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isDisabled}
+              className="cursor-pointer rounded-md border border-gray-300 bg-white px-5 py-1.5 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-transparent dark:text-white dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </form>
     </div>

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -5,7 +5,7 @@ import { Image as ImageIcon } from 'lucide-react';
 import { z } from 'zod';
 
 import { Dropdown, Input, TextArea } from '@/components';
-import type { ProductFormData, ProductStatus } from '@/types';
+import type { ProductFormData, ProductStatusUpperCase } from '@/types';
 
 import type { DropdownOption } from '../Dropdown/Dropdown.types';
 
@@ -76,7 +76,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       name: initialData?.name || '',
       price: initialData?.price || '',
       categories: initialData?.categories || '',
-      status: initialData?.status || ('DRAFT' as ProductStatus),
+      status: initialData?.status || ('DRAFT' as ProductStatusUpperCase),
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
@@ -95,7 +95,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       name: initialData?.name || '',
       price: initialData?.price || '',
       categories: initialData?.categories || '',
-      status: initialData?.status || ('DRAFT' as ProductStatus),
+      status: initialData?.status || ('DRAFT' as ProductStatusUpperCase),
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
@@ -245,7 +245,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                   selectedValues={field.value ? [field.value] : []}
                   onChange={(values) =>
                     field.onChange(
-                      (values[0]?.value ?? 'DRAFT') as ProductStatus,
+                      (values[0]?.value ?? 'DRAFT') as ProductStatusUpperCase,
                     )
                   }
                   placeholder="Select status"

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -126,7 +126,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   const isDisabled = isLoading || isSubmitting;
 
   return (
-    <div className="bg-background rounded-lg border border-gray-200 p-4 shadow-sm dark:border-gray-800">
+    <div className="rounded-lg border border-gray-200 bg-[rgb(var(--color-bg-sec))] p-4 shadow-sm dark:border-gray-800">
       <form onSubmit={handleSubmit(handleSave)} className="flex flex-col gap-4">
         <div className="flex flex-col items-center gap-4">
           <div className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-lg bg-gray-200 dark:bg-gray-800">
@@ -165,6 +165,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                 label="Name Product"
                 placeholder="Name Product"
                 {...field}
+                inputClassName="bg-white text-black"
                 value={field.value ?? ''}
                 state={errors.name ? 'error' : 'default'}
                 helperText={errors.name?.message}
@@ -179,6 +180,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                 label="Price"
                 type="number"
                 placeholder="Price"
+                inputClassName="bg-white text-black"
                 {...field}
                 value={field.value ?? ''}
                 state={errors.price ? 'error' : 'default'}
@@ -194,6 +196,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                 label="Categories"
                 type="text"
                 placeholder="Categories"
+                inputClassName="bg-white text-black"
                 {...field}
                 value={field.value ?? ''}
                 state={errors.categories ? 'error' : 'default'}
@@ -209,7 +212,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                 label="Description"
                 placeholder="Description"
                 className="col-span-1 md:col-span-3"
-                textAreaClassName="resize-none text-sm"
+                textAreaClassName="resize-none text-sm bg-white"
                 {...field}
                 value={field.value ?? ''}
                 state={errors.description ? 'error' : 'default'}

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -4,8 +4,16 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Image as ImageIcon } from 'lucide-react';
 import { z } from 'zod';
 
-import { Input, TextArea } from '@/components';
-import type { ProductFormData } from '@/types';
+import { Dropdown, Input, TextArea } from '@/components';
+import type { ProductFormData, ProductStatus } from '@/types';
+
+import type { DropdownOption } from '../Dropdown/Dropdown.types';
+
+const STATUS_OPTIONS: DropdownOption[] = [
+  { label: 'Active', value: 'ACTIVE' },
+  { label: 'Inactive', value: 'INACTIVE' },
+  { label: 'Draft', value: 'DRAFT' },
+];
 
 const productFormSchema = z.object({
   name: z.string().trim().min(1, 'Product name is required'),
@@ -27,6 +35,7 @@ const productFormSchema = z.object({
           .filter(Boolean).length > 0,
       'Enter at least one category',
     ),
+  status: z.enum(['ACTIVE', 'INACTIVE', 'DRAFT']),
   description: z.string(),
   imagePreview: z.string().nullable(),
   imageFile: z.instanceof(File).optional(),
@@ -63,6 +72,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       name: initialData?.name || '',
       price: initialData?.price || '',
       categories: initialData?.categories || '',
+      status: initialData?.status || ('DRAFT' as ProductStatus),
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
@@ -81,6 +91,7 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       name: initialData?.name || '',
       price: initialData?.price || '',
       categories: initialData?.categories || '',
+      status: initialData?.status || ('DRAFT' as ProductStatus),
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
@@ -201,6 +212,24 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                 value={field.value ?? ''}
                 state={errors.categories ? 'error' : 'default'}
                 helperText={errors.categories?.message}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name="status"
+            render={({ field }) => (
+              <Dropdown
+                label="Status"
+                labelClassName="capitalize text-sm"
+                selectClassName="bg-white text-black hover:bg-gray-50 dark:hover:bg-gray-800 data-[popup-open]:bg-white"
+                options={STATUS_OPTIONS}
+                selectedValues={field.value ? [field.value] : []}
+                onChange={(values) =>
+                  field.onChange((values[0]?.value ?? 'DRAFT') as ProductStatus)
+                }
+                placeholder="Select status"
+                multiple={false}
               />
             )}
           />

--- a/src/hooks/useGetAdminProduct.ts
+++ b/src/hooks/useGetAdminProduct.ts
@@ -1,12 +1,15 @@
 import { useQuery } from '@apollo/client/react';
 
 import { GET_PRODUCT } from '@/services/graphql/productAdminService';
+import type { ProductStatus } from '@/types';
 
 interface GetProductData {
   product: {
     id: string;
     title: string;
     price: number;
+    updatedAt: string;
+    status: ProductStatus;
     description: string;
     categories: string[];
     imageUrl?: string;

--- a/src/hooks/useGetAdminProduct.ts
+++ b/src/hooks/useGetAdminProduct.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client/react';
 
 import { GET_PRODUCT } from '@/services/graphql/productAdminService';
-import type { ProductStatus } from '@/types';
+import type { ProductStatusUpperCase } from '@/types';
 
 interface GetProductData {
   product: {
@@ -9,7 +9,7 @@ interface GetProductData {
     title: string;
     price: number;
     updatedAt: string;
-    status: ProductStatus;
+    status: ProductStatusUpperCase;
     description: string;
     categories: string[];
     imageUrl?: string;

--- a/src/pages/Admin/CreateProduct/CreateProduct.tsx
+++ b/src/pages/Admin/CreateProduct/CreateProduct.tsx
@@ -3,7 +3,7 @@
 import { ProductForm } from '@/components/ProductForm';
 import { ROUTES } from '@/constants';
 import { useCreateAdminProduct } from '@/hooks/useCreateAdminProduct';
-import type { ProductFormData, ProductStatus } from '@/types';
+import type { ProductFormData } from '@/types';
 
 export const CreateProduct = () => {
   const navigate = useNavigate();
@@ -17,7 +17,6 @@ export const CreateProduct = () => {
       const input = {
         title: formData.name,
         price: parseFloat(formData.price),
-        status: 'DRAFT' as ProductStatus,
         description: formData.description,
         categories: formData.categories
           ? formData.categories

--- a/src/pages/Admin/CreateProduct/CreateProduct.tsx
+++ b/src/pages/Admin/CreateProduct/CreateProduct.tsx
@@ -17,6 +17,7 @@ export const CreateProduct = () => {
       const input = {
         title: formData.name,
         price: parseFloat(formData.price),
+        status: formData.status,
         description: formData.description,
         categories: formData.categories
           ? formData.categories

--- a/src/pages/Admin/CreateProduct/CreateProduct.tsx
+++ b/src/pages/Admin/CreateProduct/CreateProduct.tsx
@@ -3,7 +3,7 @@
 import { ProductForm } from '@/components/ProductForm';
 import { ROUTES } from '@/constants';
 import { useCreateAdminProduct } from '@/hooks/useCreateAdminProduct';
-import type { ProductFormData } from '@/types';
+import type { ProductFormData, ProductStatus } from '@/types';
 
 export const CreateProduct = () => {
   const navigate = useNavigate();
@@ -17,7 +17,7 @@ export const CreateProduct = () => {
       const input = {
         title: formData.name,
         price: parseFloat(formData.price),
-        status: formData.status,
+        status: 'DRAFT' as ProductStatus,
         description: formData.description,
         categories: formData.categories
           ? formData.categories
@@ -45,6 +45,7 @@ export const CreateProduct = () => {
         onSubmit={handleCreate}
         onCancel={handleCancel}
         isLoading={loading}
+        isEditMode={false}
       />
     </div>
   );

--- a/src/pages/Admin/EditProduct/EditProduct.tsx
+++ b/src/pages/Admin/EditProduct/EditProduct.tsx
@@ -33,6 +33,7 @@ export const EditProduct = () => {
         categories: product.categories?.join(', ') || '',
         status: product.status,
         imagePreview: product.imageUrl || null,
+        updatedAt: product.updatedAt,
       }
     : null;
 
@@ -76,6 +77,7 @@ export const EditProduct = () => {
       });
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
+      navigate(ROUTES.ADMIN_PRODUCTS);
     } catch (e) {
       console.error(e);
     }
@@ -93,6 +95,8 @@ export const EditProduct = () => {
         onSubmit={handleSubmit}
         onCancel={() => navigate(ROUTES.ADMIN_PRODUCTS)}
         isLoading={isUpdating}
+        isEditMode={true}
+        updatedAt={product?.updatedAt}
       />
     </div>
   );

--- a/src/pages/Admin/EditProduct/EditProduct.tsx
+++ b/src/pages/Admin/EditProduct/EditProduct.tsx
@@ -6,7 +6,7 @@ import { ProductForm } from '@/components/ProductForm';
 import { ROUTES } from '@/constants';
 import { useGetAdminProduct } from '@/hooks/useGetAdminProduct';
 import { useUpdateAdminProduct } from '@/hooks/useUpdateAdminProduct';
-import type { ProductFormData } from '@/types';
+import type { ProductFormData, ProductStatus } from '@/types';
 
 const ERROR_TEXTS = {
   SERVER: 'Server Error: Failed to load product data',
@@ -71,7 +71,7 @@ export const EditProduct = () => {
       await updateProduct(id, {
         title: formData.name,
         price: Number(formData.price),
-        status: formData.status,
+        status: formData.status as ProductStatus,
         description: formData.description,
         categories: formData.categories.split(',').map((c) => c.trim()),
       });

--- a/src/pages/Admin/EditProduct/EditProduct.tsx
+++ b/src/pages/Admin/EditProduct/EditProduct.tsx
@@ -31,6 +31,7 @@ export const EditProduct = () => {
         price: String(product.price),
         description: product.description || '',
         categories: product.categories?.join(', ') || '',
+        status: product.status,
         imagePreview: product.imageUrl || null,
       }
     : null;
@@ -69,6 +70,7 @@ export const EditProduct = () => {
       await updateProduct(id, {
         title: formData.name,
         price: Number(formData.price),
+        status: formData.status,
         description: formData.description,
         categories: formData.categories.split(',').map((c) => c.trim()),
       });

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -41,6 +41,8 @@ export const GET_PRODUCT = gql`
       id
       title
       price
+      updatedAt
+      status
       description
       categories
       productCode
@@ -55,6 +57,7 @@ export const UPDATE_PRODUCT = gql`
       id
       title
       price
+      status
       description
       categories
       imageUrl

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -1,4 +1,4 @@
-export type ProductStatus = 'active' | 'inactive' | 'draft';
+export type ProductStatus = 'ACTIVE' | 'INACTIVE' | 'DRAFT';
 
 export interface Product {
   _id?: string;
@@ -46,6 +46,7 @@ export interface ProductFormData {
   name: string;
   price: string;
   categories: string;
+  status: ProductStatus;
   description: string;
   imagePreview: string | null;
   imageFile?: File;

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -1,4 +1,5 @@
-export type ProductStatus = 'ACTIVE' | 'INACTIVE' | 'DRAFT';
+export type ProductStatus = 'active' | 'inactive' | 'draft';
+export type ProductStatusUpperCase = Uppercase<ProductStatus>;
 
 export interface Product {
   _id?: string;
@@ -46,7 +47,7 @@ export interface ProductFormData {
   name: string;
   price: string;
   categories: string;
-  status: ProductStatus;
+  status: ProductStatusUpperCase;
   description: string;
   imagePreview: string | null;
   imageFile?: File;


### PR DESCRIPTION
## Summary

This PR improves the admin product form by adding validation and product status support for create/edit flows.

## What Changed

- added `status` to product form data and aligned status values with backend enum format
- defaulted new products to `DRAFT`
- added an edit-only status dropdown in `ProductForm`
- displayed the last update date in edit mode
- updated product queries, mutation payloads, and hook typings to include `status` and `updatedAt`
- improved dropdown component support for controlled and single-select usage
- updated form and dropdown tests to cover the new behavior

## Notes

- create flow keeps status fixed to `DRAFT`
- edit flow allows updating status and redirects to the products list after successful save
