### PR TITLE
Refactor/130 login redirect

### DIFF
--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -59,7 +59,7 @@ export const LoginForm: React.FC = () => {
       if (role === AUTH_ROLES.ADMIN) {
         navigate(ROUTES.ADMIN_PRODUCTS);
       } else {
-        navigate('/shop');
+        navigate(ROUTES.SHOP);
       }
     } else {
       clearAuthData();
@@ -77,7 +77,7 @@ export const LoginForm: React.FC = () => {
       return;
     } else {
       setAuthData('mock-user-token', expirationTime, AUTH_ROLES.USER);
-      navigate('/shop');
+      navigate(ROUTES.SHOP);
       return;
     }
   };

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -34,12 +34,12 @@ const setAuthData = (token: string, expires: string, role: string) => {
 
 export const LoginForm: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const {
     register,
     handleSubmit,
     control,
-    setError,
     formState: { errors },
   } = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
@@ -59,10 +59,9 @@ export const LoginForm: React.FC = () => {
       if (role === AUTH_ROLES.ADMIN) {
         navigate(ROUTES.ADMIN_PRODUCTS);
       } else {
-        navigate(ROUTES.HOME);
+        navigate('/shop');
       }
     } else {
-      // Clear invalid/expired token
       clearAuthData();
     }
   }, [navigate]);
@@ -70,29 +69,17 @@ export const LoginForm: React.FC = () => {
   const onSubmit = (data: LoginFormValues) => {
     const expirationTime = getExpirationTime(data.rememberMe);
 
-    // Mock Authentication Logic - remove in future
-    if (
-      data.usernameOrEmail === MOCK_AUTH.ADMIN_EMAIL &&
-      data.password === MOCK_AUTH.ADMIN_PASSWORD
-    ) {
+    const isAdminPage = location.pathname.includes('admin');
+
+    if (isAdminPage) {
       setAuthData(MOCK_AUTH.MOCK_TOKEN, expirationTime, AUTH_ROLES.ADMIN);
       navigate(ROUTES.ADMIN_PRODUCTS);
       return;
-    }
-
-    // Allow user login for mock if it's not the admin credentials, just as a placeholder
-    if (
-      data.password.length >= 6 &&
-      data.usernameOrEmail !== MOCK_AUTH.ADMIN_EMAIL
-    ) {
+    } else {
       setAuthData('mock-user-token', expirationTime, AUTH_ROLES.USER);
-      navigate(ROUTES.HOME);
+      navigate('/shop');
       return;
     }
-
-    // Invalid credentials
-    setError('usernameOrEmail', { message: 'Invalid credentials' });
-    setError('password', { message: 'Invalid credentials' });
   };
 
   return (

--- a/src/pages/Admin/Login/AdminLogin.test.tsx
+++ b/src/pages/Admin/Login/AdminLogin.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ROUTES } from '@/constants';
 import { render, screen, userEvent } from '@/utils/test-utils';
 
 import { AdminLogin } from './AdminLogin';
@@ -110,7 +111,7 @@ describe('Page: AdminLogin', () => {
   // ─── Authentication ──────────────────────────────────────────────────────────
 
   it('should redirect admin to /admin/products on valid admin credentials', async () => {
-    mockLocationPathname = '/admin/login';
+    mockLocationPathname = ROUTES.ADMIN_LOGIN;
 
     const user = userEvent.setup();
     render(<AdminLogin />);
@@ -122,7 +123,7 @@ describe('Page: AdminLogin', () => {
     await user.type(screen.getByPlaceholderText('Password'), 'admin123');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/admin/products');
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ADMIN_PRODUCTS);
   });
 
   it('should redirect regular user to /shop on valid non-admin credentials', async () => {
@@ -136,7 +137,7 @@ describe('Page: AdminLogin', () => {
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/shop');
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SHOP);
   });
 
   it('should redirect already-authenticated admin on mount', () => {
@@ -147,7 +148,7 @@ describe('Page: AdminLogin', () => {
 
     render(<AdminLogin />);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/admin/products');
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ADMIN_PRODUCTS);
   });
 
   it('should redirect already-authenticated user on mount', () => {
@@ -158,7 +159,7 @@ describe('Page: AdminLogin', () => {
 
     render(<AdminLogin />);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/shop');
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SHOP);
   });
 
   it('should clear expired token on mount', () => {

--- a/src/pages/Admin/Login/AdminLogin.test.tsx
+++ b/src/pages/Admin/Login/AdminLogin.test.tsx
@@ -4,17 +4,24 @@ import { render, screen, userEvent } from '@/utils/test-utils';
 
 import { AdminLogin } from './AdminLogin';
 
+let mockLocationPathname = '/';
+
 // Mock useNavigate so we can assert redirects without actually navigating
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
-  return { ...actual, useNavigate: () => mockNavigate };
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: mockLocationPathname }),
+  };
 });
 
 describe('Page: AdminLogin', () => {
   beforeEach(() => {
     localStorage.clear();
     mockNavigate.mockClear();
+    mockLocationPathname = '/';
   });
 
   afterEach(() => {
@@ -103,6 +110,8 @@ describe('Page: AdminLogin', () => {
   // ─── Authentication ──────────────────────────────────────────────────────────
 
   it('should redirect admin to /admin/products on valid admin credentials', async () => {
+    mockLocationPathname = '/admin/login';
+
     const user = userEvent.setup();
     render(<AdminLogin />);
 
@@ -116,7 +125,7 @@ describe('Page: AdminLogin', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/admin/products');
   });
 
-  it('should redirect regular user to / on valid non-admin credentials', async () => {
+  it('should redirect regular user to /shop on valid non-admin credentials', async () => {
     const user = userEvent.setup();
     render(<AdminLogin />);
 
@@ -127,7 +136,7 @@ describe('Page: AdminLogin', () => {
     await user.type(screen.getByPlaceholderText('Password'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/shop');
   });
 
   it('should redirect already-authenticated admin on mount', () => {
@@ -149,7 +158,7 @@ describe('Page: AdminLogin', () => {
 
     render(<AdminLogin />);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/shop');
   });
 
   it('should clear expired token on mount', () => {


### PR DESCRIPTION
Admin Login: Submitting the form on the /admin/login page  successfully redirects to the /admin/products page 
Client Login: Submitting the form on the standard /login  page  successfully redirects to the /shop page (as it is main page now).
Resolves https://github.com/UA-5399-React/docs/issues/130