### PR TITLE
feat(128): add responsive for header, footer, show input field

### DIFF
--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -21,9 +21,9 @@ describe('UI Component: Footer', () => {
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 
-  it('should render the brand name TechnoWorld', () => {
+  it('should render the brand name TechnoWorld.', () => {
     render(<Footer />);
-    expect(screen.getAllByText('TechnoWorld')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('TechnoWorld.')[0]).toBeInTheDocument();
   });
 
   it('should render the store tagline', () => {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -17,62 +17,70 @@ export const Footer = () => {
 
   return (
     <footer
-      className={`px-16 py-12 transition-colors duration-300 ${
+      className={`px-4 py-10 transition-colors duration-300 lg:px-16 lg:py-12 ${
         isDark ? 'bg-white text-black' : 'bg-[#141718] text-white'
       }`}
     >
-      <div className="flex items-center justify-between pb-10">
-        <div className="flex items-center gap-6">
+      <div className="flex flex-col gap-6 pb-8 lg:flex-row lg:items-center lg:justify-between lg:pb-10">
+        <div className="flex flex-col gap-1 lg:flex-row lg:items-center lg:gap-6">
           <Link
             to={ROUTES.HOME}
-            className="text-2xl font-medium no-underline transition-colors duration-300"
+            className="text-xl font-medium no-underline transition-colors duration-300 md:text-2xl"
             style={{ color: 'inherit' }}
           >
-            TechnoWorld
+            TechnoWorld.
           </Link>
+
           <div
-            className={`h-6 border-l ${isDark ? 'border-gray-400' : 'border-gray-600'}`}
-          ></div>
+            className={`hidden h-6 border-l lg:block ${
+              isDark ? 'border-gray-400' : 'border-gray-600'
+            }`}
+          />
+
           <span
-            className={`text-sm ${isDark ? 'text-gray-600' : 'text-gray-300'}`}
+            className={`text-sm ${isDark ? 'text-gray-600' : 'text-gray-400'}`}
           >
             Gift & Decoration Store
           </span>
         </div>
 
-        <nav className="flex gap-8">
-          {NAV_LINKS.map(({ path, label }) => (
-            <NavLink
-              key={path}
-              to={path}
-              className={({ isActive }) =>
-                `text-sm font-medium no-underline transition-colors duration-300 ${
-                  isActive
-                    ? isDark
-                      ? 'text-black'
-                      : 'text-white'
-                    : isDark
-                      ? 'text-gray-500 hover:text-black'
-                      : 'text-gray-300 hover:text-white'
-                }`
-              }
-            >
-              {label}
-            </NavLink>
-          ))}
+        <nav>
+          <ul className="m-0 flex list-none flex-wrap gap-x-5 gap-y-3 p-0 lg:gap-8">
+            {NAV_LINKS.map(({ path, label }) => (
+              <li key={path}>
+                <NavLink
+                  to={path}
+                  className={({ isActive }) =>
+                    `text-sm font-medium no-underline transition-colors duration-300 ${
+                      isActive
+                        ? isDark
+                          ? 'text-black'
+                          : 'text-white'
+                        : isDark
+                          ? 'text-gray-500 hover:text-black'
+                          : 'text-gray-400 hover:text-white'
+                    }`
+                  }
+                >
+                  {label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
         </nav>
       </div>
 
       <div
         className={`border-t ${isDark ? 'border-gray-300' : 'border-gray-700'}`}
-      ></div>
-
+      />
       <div
-        className={`flex items-center justify-between pt-8 text-xs ${isDark ? 'text-gray-600' : 'text-gray-300'}`}
+        className={`flex flex-col gap-5 pt-6 text-xs lg:flex-row lg:items-center lg:justify-between lg:pt-8 ${
+          isDark ? 'text-gray-600' : 'text-gray-400'
+        }`}
       >
-        <div className="flex items-center gap-8">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center lg:gap-8">
           <span>Copyright © 2026 TechnoWorld. All rights reserved</span>
-          <div className="flex items-center gap-6 font-semibold">
+          <div className="flex items-center gap-4 font-semibold lg:gap-6">
             <Link
               to="#"
               className="no-underline transition-colors duration-300 hover:opacity-70"
@@ -90,15 +98,27 @@ export const Footer = () => {
           </div>
         </div>
 
-        <div className="flex items-center gap-6">
-          <Link to="#" className="transition-opacity hover:opacity-70">
-            <Instagram className="h-6 w-6 transition-all duration-300" />
+        <div className="flex items-center gap-5 lg:gap-6">
+          <Link
+            to="#"
+            className="transition-opacity hover:opacity-70"
+            style={{ color: 'inherit' }}
+          >
+            <Instagram className="h-5 w-5 transition-all duration-300 lg:h-6 lg:w-6" />
           </Link>
-          <Link to="#" className="transition-opacity hover:opacity-70">
-            <Facebook className="h-6 w-6 transition-all duration-300" />
+          <Link
+            to="#"
+            className="transition-opacity hover:opacity-70"
+            style={{ color: 'inherit' }}
+          >
+            <Facebook className="h-5 w-5 transition-all duration-300 lg:h-6 lg:w-6" />
           </Link>
-          <Link to="#" className="transition-opacity hover:opacity-70">
-            <Youtube className="h-6 w-6 transition-all duration-300" />
+          <Link
+            to="#"
+            className="transition-opacity hover:opacity-70"
+            style={{ color: 'inherit' }}
+          >
+            <Youtube className="h-5 w-5 transition-all duration-300 lg:h-6 lg:w-6" />
           </Link>
         </div>
       </div>

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -12,6 +12,25 @@ vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => mockUseTheme(),
 }));
 
+vi.mock('@/components/ui/SearchInput', () => ({
+  SearchInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder ?? 'Search'}
+      aria-label="Search input"
+    />
+  ),
+}));
+
 describe('UI Component: Header', () => {
   beforeEach(() => {
     mockSetTheme.mockClear();
@@ -27,22 +46,21 @@ describe('UI Component: Header', () => {
     expect(screen.getByRole('banner')).toBeInTheDocument();
   });
 
-  it('should render the brand link TechnoWorld.', () => {
+  it('should render brand links TechnoWorld.', () => {
     render(<Header />);
-    expect(
-      screen.getByRole('link', { name: 'TechnoWorld.' }),
-    ).toBeInTheDocument();
+    const brandLinks = screen.getAllByRole('link', { name: 'TechnoWorld.' });
+    expect(brandLinks.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should have correct href on the brand link', () => {
+  it('should have correct href on all brand links', () => {
     render(<Header />);
-    expect(screen.getByRole('link', { name: 'TechnoWorld.' })).toHaveAttribute(
-      'href',
-      ROUTES.HOME,
+    const brandLinks = screen.getAllByRole('link', { name: 'TechnoWorld.' });
+    brandLinks.forEach((link) =>
+      expect(link).toHaveAttribute('href', ROUTES.HOME),
     );
   });
 
-  it('should render all nav links', () => {
+  it('should render all desktop nav links', () => {
     render(<Header />);
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Shop' })).toBeInTheDocument();
@@ -83,10 +101,20 @@ describe('UI Component: Header', () => {
     expect(screen.getByRole('button', { name: 'Theme' })).toBeInTheDocument();
   });
 
-  it('should render the Cart link with correct href', () => {
+  it('should render Cart links with correct href', () => {
     render(<Header />);
-    const cartLink = screen.getByRole('link', { name: /cart/i });
-    expect(cartLink).toHaveAttribute('href', ROUTES.CART);
+    const cartLinks = screen.getAllByRole('link', { name: /cart/i });
+    expect(cartLinks.length).toBeGreaterThanOrEqual(1);
+    cartLinks.forEach((link) =>
+      expect(link).toHaveAttribute('href', ROUTES.CART),
+    );
+  });
+
+  it('should render the Open menu button', () => {
+    render(<Header />);
+    expect(
+      screen.getByRole('button', { name: 'Open menu' }),
+    ).toBeInTheDocument();
   });
 
   it('should render Moon icon when isDark is false', () => {
@@ -155,5 +183,158 @@ describe('UI Component: Header', () => {
     render(<Header />);
     await user.click(screen.getByRole('button', { name: 'Theme' }));
     expect(mockSetTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('should not render drawer by default', () => {
+    render(<Header />);
+    expect(
+      screen.queryByRole('button', { name: 'Close menu' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should open drawer when Open menu is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(
+      screen.getByRole('button', { name: 'Close menu' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should close drawer when Close menu is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    await user.click(screen.getByRole('button', { name: 'Close menu' }));
+    expect(
+      screen.queryByRole('button', { name: 'Close menu' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render Sign In link in drawer when open', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByRole('link', { name: 'Sign In' })).toBeInTheDocument();
+  });
+
+  it('should render Wishlist link in drawer when open', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByRole('link', { name: 'Wishlist' })).toBeInTheDocument();
+  });
+
+  it('should render Change Theme button in drawer when open', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(
+      screen.getByRole('button', { name: /change theme/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should lock body scroll when drawer is open', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('should unlock body scroll when drawer is closed', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    await user.click(screen.getByRole('button', { name: 'Close menu' }));
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('should apply dark drawer styles when isDark is true', async () => {
+    const user = userEvent.setup();
+    mockUseTheme.mockReturnValue({
+      theme: 'dark',
+      setTheme: mockSetTheme,
+      isDark: true,
+    });
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const wishlist = screen.getByRole('link', { name: 'Wishlist' });
+    expect(wishlist).toBeInTheDocument();
+  });
+
+  it('should render Sign In with correct style in dark theme drawer', async () => {
+    const user = userEvent.setup();
+    mockUseTheme.mockReturnValue({
+      theme: 'dark',
+      setTheme: mockSetTheme,
+      isDark: true,
+    });
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const signIn = screen.getByRole('link', { name: 'Sign In' });
+    expect(signIn).toHaveStyle({ color: '#000000' });
+  });
+
+  it('should render Sign In with correct style in light theme drawer', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const signIn = screen.getByRole('link', { name: 'Sign In' });
+    expect(signIn).toHaveStyle({ color: '#ffffff' });
+  });
+
+  it('should render Cart link in drawer with correct href', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const cartLinks = screen.getAllByRole('link', { name: /^Cart$/i });
+    expect(cartLinks.some((l) => l.getAttribute('href') === ROUTES.CART)).toBe(
+      true,
+    );
+  });
+
+  it('should render Cart link in dark theme drawer', async () => {
+    const user = userEvent.setup();
+    mockUseTheme.mockReturnValue({
+      theme: 'dark',
+      setTheme: mockSetTheme,
+      isDark: true,
+    });
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+    const cartLinks = screen.getAllByRole('link', { name: /^Cart$/i });
+    expect(cartLinks.some((l) => l.getAttribute('href') === ROUTES.CART)).toBe(
+      true,
+    );
+  });
+
+  it('should not show search input by default', () => {
+    render(<Header />);
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+
+  it('should show search input after clicking Search button', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
+  it('should hide search input after clicking Search button twice', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+
+  it('should clear search value when closing search', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await user.type(screen.getByPlaceholderText('Search'), 'keyboard');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    expect(screen.getByPlaceholderText('Search')).toHaveValue('');
   });
 });

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,17 @@
+import { useEffect, useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Moon, Search, ShoppingBag, Sun, UserCircle } from 'lucide-react';
+import {
+  Heart,
+  Menu,
+  Moon,
+  Search,
+  ShoppingBag,
+  Sun,
+  UserCircle,
+  X,
+} from 'lucide-react';
 
+import { SearchInput } from '@/components';
 import { ROUTES } from '@/constants';
 import { useTheme } from '@/hooks/useTheme';
 
@@ -13,6 +24,20 @@ const NAV_LINKS = [
 
 export const Header = () => {
   const { theme, setTheme, isDark } = useTheme();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [menuOpen]);
 
   const handleToggleTheme = () => {
     if (theme === 'system') {
@@ -25,73 +50,210 @@ export const Header = () => {
     }
   };
 
+  const closeMenu = () => {
+    setMenuOpen(false);
+    document.body.style.overflow = '';
+  };
+
   return (
-    <header className="bg-background text-text transition-colors duration-300">
-      <div className="flex h-20 items-center justify-between px-16">
-        <Link
-          to={ROUTES.HOME}
-          className="text-text text-2xl font-bold no-underline transition-colors duration-300"
-        >
-          TechnoWorld.
-        </Link>
-        <nav>
-          <ul className="m-0 flex list-none gap-8 p-0">
-            {NAV_LINKS.map(({ path, label, end }) => (
-              <li key={path}>
-                <NavLink
-                  to={path}
-                  end={end}
-                  className="text-base font-semibold no-underline transition-colors duration-300"
-                  style={({ isActive }) => ({
-                    color: isActive
-                      ? 'rgb(var(--color-text))'
-                      : 'rgb(var(--color-muted))',
-                  })}
-                >
-                  {label}
-                </NavLink>
-              </li>
-            ))}
-          </ul>
-        </nav>
-
-        <div className="flex items-center gap-6">
+    <>
+      <header className="bg-background text-text transition-colors duration-300">
+        <div className="flex h-16 items-center px-4 lg:hidden">
           <button
-            aria-label="Search"
-            className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+            className="cursor-pointer border-none bg-transparent p-0 text-inherit"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
           >
-            <Search className="h-6 w-6 transition-all duration-300" />
-          </button>
-
-          <button
-            aria-label="User"
-            className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
-          >
-            <UserCircle className="h-6 w-6 transition-all duration-300" />
-          </button>
-
-          <button
-            aria-label="Theme"
-            onClick={handleToggleTheme}
-            className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
-          >
-            {isDark ? (
-              <Sun className="h-6 w-6 transition-all duration-300" />
-            ) : (
-              <Moon className="h-6 w-6 transition-all duration-300" />
-            )}
+            <Menu className="h-6 w-6" />
           </button>
 
           <Link
-            to={ROUTES.CART}
-            className="flex items-center gap-2 text-inherit no-underline transition-opacity hover:opacity-70"
-            aria-label="Cart"
+            to={ROUTES.HOME}
+            className="text-text mx-auto text-xl font-bold no-underline"
           >
-            <ShoppingBag className="h-6 w-6 transition-all duration-300" />
-            <span className="bg-text text-background flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold transition-colors duration-300"></span>
+            TechnoWorld.
           </Link>
+
+          <div className="flex items-center gap-4">
+            <Link
+              to={ROUTES.CART}
+              className="text-inherit no-underline"
+              aria-label="Cart"
+            >
+              <ShoppingBag className="h-6 w-6" />
+            </Link>
+          </div>
         </div>
-      </div>
-    </header>
+        <div className="hidden h-20 items-center justify-between px-16 lg:flex">
+          <Link
+            to={ROUTES.HOME}
+            className="text-text text-2xl font-bold no-underline transition-colors duration-300"
+          >
+            TechnoWorld.
+          </Link>
+
+          <nav>
+            <ul className="m-0 flex list-none gap-8 p-0">
+              {NAV_LINKS.map(({ path, label, end }) => (
+                <li key={path}>
+                  <NavLink
+                    to={path}
+                    end={end}
+                    className={({ isActive }) =>
+                      `text-base font-semibold no-underline transition-colors duration-300 ${
+                        isActive
+                          ? 'text-[rgb(var(--color-text))]'
+                          : 'text-[rgb(var(--color-muted))] hover:text-[rgb(var(--color-text))]'
+                      }`
+                    }
+                  >
+                    {label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <div className="relative flex items-center gap-6">
+            <div className="relative flex items-center">
+              {searchOpen && (
+                <div className="absolute top-1/2 right-8 -translate-y-1/2">
+                  <SearchInput
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    className="w-72"
+                  />
+                </div>
+              )}
+              <button
+                aria-label="Search"
+                onClick={() => {
+                  setSearchOpen((prev) => !prev);
+                  if (searchOpen) setSearchValue('');
+                }}
+                className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+              >
+                <Search className="h-6 w-6" />
+              </button>
+            </div>
+
+            <button
+              aria-label="User"
+              className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+            >
+              <UserCircle className="h-6 w-6" />
+            </button>
+
+            <button
+              aria-label="Theme"
+              onClick={handleToggleTheme}
+              className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+            >
+              {theme === 'dark' ? (
+                <Sun className="h-6 w-6" />
+              ) : (
+                <Moon className="h-6 w-6" />
+              )}
+            </button>
+
+            <Link
+              to={ROUTES.CART}
+              className="flex items-center gap-2 text-inherit no-underline transition-opacity hover:opacity-70"
+              aria-label="Cart"
+            >
+              <ShoppingBag className="h-6 w-6" />
+              <span className="bg-text text-background flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold" />
+            </Link>
+          </div>
+        </div>
+      </header>
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/40" onClick={closeMenu} />
+
+          <div
+            className={`fixed top-0 bottom-0 left-0 z-50 flex w-72 flex-col shadow-2xl ${isDark ? 'bg-[#141718]' : 'bg-white'}`}
+          >
+            <div className="flex shrink-0 items-center justify-between px-6 py-5">
+              <span
+                className={`text-xl font-bold ${isDark ? 'text-white' : 'text-black'}`}
+              >
+                TechnoWorld.
+              </span>
+              <button
+                onClick={closeMenu}
+                className={`cursor-pointer border-none bg-transparent p-0 outline-none ${isDark ? 'text-white' : 'text-black'}`}
+                aria-label="Close menu"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="mx-6 mb-2 shrink-0">
+              <SearchInput
+                value={searchValue}
+                onChange={setSearchValue}
+                className="w-full"
+              />
+            </div>
+            <nav className="px-6 pt-2">
+              {NAV_LINKS.map(({ path, label, end }) => (
+                <NavLink
+                  key={path}
+                  to={path}
+                  end={end}
+                  onClick={closeMenu}
+                  className={`flex items-center border-b py-4 text-sm font-medium no-underline ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
+                >
+                  {label}
+                </NavLink>
+              ))}
+            </nav>
+            <div
+              className={`mt-auto shrink-0 border-t px-6 ${isDark ? 'border-gray-700' : 'border-gray-200'}`}
+            >
+              <button
+                onClick={handleToggleTheme}
+                className={`flex w-full cursor-pointer items-center justify-between border-x-0 border-t-0 border-b bg-transparent py-4 pr-0 pl-0 text-left [font-family:inherit] text-sm font-medium outline-none ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
+              >
+                <span>Change Theme</span>
+                {isDark ? (
+                  <Sun className="h-5 w-5 shrink-0 text-gray-400" />
+                ) : (
+                  <Moon className="h-5 w-5 shrink-0 text-gray-400" />
+                )}
+              </button>
+
+              <Link
+                to={ROUTES.CART}
+                onClick={closeMenu}
+                className={`flex items-center justify-between border-b py-4 text-sm font-medium no-underline ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
+              >
+                <span>Cart</span>
+                <ShoppingBag className="h-5 w-5 shrink-0 text-gray-400" />
+              </Link>
+
+              <Link
+                to="#"
+                onClick={closeMenu}
+                className={`flex items-center justify-between border-b py-4 text-sm font-medium no-underline ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
+              >
+                <span>Wishlist</span>
+                <Heart className="h-5 w-5 shrink-0 text-gray-400" />
+              </Link>
+            </div>
+            <div className="shrink-0 px-6 pt-2 pb-6">
+              <Link
+                to={ROUTES.HOME}
+                onClick={closeMenu}
+                className={`block w-full rounded-md py-3 text-center text-sm font-semibold no-underline transition-opacity hover:opacity-80 ${isDark ? 'bg-white' : 'bg-black'}`}
+                style={{ color: isDark ? '#000000' : '#ffffff' }}
+              >
+                Sign In
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
Made `Header` and `Footer` components fully responsive and added a search input field to the desktop header.
- Added mobile bar with burger menu, centered logo, and cart icon
- Implemented fly menu drawer with full navigation, search, cart, wishlist, change theme, and sign in
- Added expand-on-click `SearchInput` to the desktop bar
- Body scroll lock when burger menu is open
- Updated `Header` and `Footer` unit tests