### PR TITLE
fix(142): support for filtering by multiple categories

### DIFF
--- a/src/hooks/useAdminProduct.ts
+++ b/src/hooks/useAdminProduct.ts
@@ -29,7 +29,7 @@ export function useAdminProducts({
     ...(filters.status && { status: filters.status }),
     ...(filters.minPrice && { minPrice: parseFloat(filters.minPrice) }),
     ...(filters.maxPrice && { maxPrice: parseFloat(filters.maxPrice) }),
-    ...(filters.categories?.length && { category: filters.categories[0] }),
+    ...(filters.categories?.length && { category: filters.categories }),
     ...(filters.dateFrom && { updatedFrom: new Date(filters.dateFrom) }),
     ...(filters.dateTo && {
       updatedTo: new Date(filters.dateTo + 'T23:59:59.999').toISOString(),


### PR DESCRIPTION
Backend now supports multiple categories for filters.
Frontend could do it but was hardcoded to accept only first category applied, as backend didn't support multiple filters before.