### PR TITLE
fix(144): don't reset filters, search and sort on return from edit

### DIFF
--- a/src/components/ProductsFilters/ProductsFiltersBar.tsx
+++ b/src/components/ProductsFilters/ProductsFiltersBar.tsx
@@ -9,6 +9,10 @@ const TAG_OPTIONS = [
   { label: 'Laptop', value: 'Laptop' },
   { label: 'Apple', value: 'Apple' },
   { label: 'Audio', value: 'Audio' },
+  { label: 'Smartphone', value: 'Smartphone' },
+  { label: 'Accessories', value: 'Accessories' },
+  { label: 'Gaming', value: 'Gaming' },
+  { label: 'Samsung', value: 'Samsung' },
 ];
 
 const STATUS_OPTIONS = [

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -9,16 +9,13 @@ import {
   SortProductsDropdown,
   TableProducts,
 } from '@/components';
-import { DEFAULT_FILTER, ROUTES } from '@/constants';
+import { ROUTES } from '@/constants';
 import { useAdminProducts } from '@/hooks/useAdminProduct';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useDuplicate } from '@/hooks/useDuplicate';
+import { useAdminProductsStore } from '@/store/useAdminProductsStore';
 import { type ProductsFilters } from '@/types/filters';
-import type {
-  ProductSortField,
-  SortOrder,
-  SortValue,
-} from '@/types/productsSort';
+import type { SortValue } from '@/types/productsSort';
 import { buildSortValue, parseSortValue } from '@/utils/sorting';
 
 const LIMIT = 10;
@@ -26,17 +23,20 @@ const LIMIT = 10;
 export function AdminProducts() {
   const navigate = useNavigate();
 
+  const {
+    filters,
+    search,
+    page,
+    sort,
+    order,
+    setFilters,
+    setSearch,
+    setPage,
+    setSort,
+  } = useAdminProductsStore();
+
   // filters
-  const [filters, setFilters] = useState<ProductsFilters>(DEFAULT_FILTER);
   const [showFilters, setShowFilters] = useState(false);
-
-  // search
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
-
-  // sorting
-  const [sort, setSort] = useState<ProductSortField>('updatedAt');
-  const [order, setOrder] = useState<SortOrder>('desc');
 
   // debounce for product search
   const debouncedSearch = useDebouncedValue(search.trim(), 300);
@@ -66,9 +66,7 @@ export function AdminProducts() {
 
   const handleSortChange = (value: SortValue) => {
     const nextSort = parseSortValue(value);
-
-    setSort(nextSort.sort);
-    setOrder(nextSort.order);
+    setSort(nextSort.sort, nextSort.order);
     setPage(1);
   };
 

--- a/src/store/useAdminProductsStore.ts
+++ b/src/store/useAdminProductsStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+
+import { DEFAULT_FILTER } from '@/constants';
+import type { ProductsFilters } from '@/types/filters';
+import type { ProductSortField, SortOrder } from '@/types/productsSort';
+
+interface AdminProductsStore {
+  filters: ProductsFilters;
+  search: string;
+  page: number;
+  sort: ProductSortField;
+  order: SortOrder;
+  setFilters: (filters: ProductsFilters) => void;
+  setSearch: (serach: string) => void;
+  setPage: (page: number) => void;
+  setSort: (sort: ProductSortField, order: SortOrder) => void;
+  reset: () => void;
+}
+
+export const useAdminProductsStore = create<AdminProductsStore>((set) => ({
+  filters: DEFAULT_FILTER,
+  search: '',
+  page: 1,
+  sort: 'updatedAt',
+  order: 'desc',
+  setFilters: (filters) => set({ filters, page: 1 }),
+  setSearch: (search) =>
+    set({
+      search,
+      page: 1,
+    }),
+  setPage: (page) => set({ page }),
+  setSort: (sort, order) => set({ sort, order, page: 1 }),
+  reset: () =>
+    set({
+      filters: DEFAULT_FILTER,
+      search: '',
+      page: 1,
+      sort: 'updatedAt',
+      order: 'desc',
+    }),
+}));


### PR DESCRIPTION
**Problem:** on setting sort/search/filters -> going to edit -> returning to products, set sort/search/filters reset back to default.
**Reason:** Filters, sort and serach were stored using `useState`, so state didn't persist across pages.
**Fix:** used `zustand `state manager to store states

- created `/store/useAdminProductsStore` which stores states needed for `useAdminProducts` hook: filter, sort, page, search, order
- implemented it in `AdminProducts` page