### PR TITLE
feat(70): display product image from cloudinary on product card

### DIFF
--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Heart } from 'lucide-react';
+import { Heart, Image as ImageIcon } from 'lucide-react';
 
 import type { Product } from '@/types';
 
@@ -21,11 +21,17 @@ export const ProductCard = ({ product }: ProductCardProps) => {
         className="relative mb-3 cursor-pointer overflow-hidden rounded-md"
         onClick={handleCardClick}
       >
-        <img
-          src={imageUrl}
-          alt={title}
-          className="h-64 w-full object-cover transition-transform duration-300 group-hover:scale-105"
-        />
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={title}
+            className="h-64 w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-64 w-full items-center justify-center bg-gray-100 transition-transform duration-300 group-hover:scale-105 dark:bg-gray-800">
+            <ImageIcon className="h-16 w-16 text-gray-300 dark:text-gray-600" />
+          </div>
+        )}
         <div className="absolute right-0 bottom-0 left-0 translate-y-full px-4 pb-4 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
           <Button className="w-full rounded-md bg-[#141718] py-3 text-sm font-medium text-white transition-all outline-none hover:border hover:border-white">
             Add to Cart

--- a/src/components/ProductsGrid/ProductsGrid.tsx
+++ b/src/components/ProductsGrid/ProductsGrid.tsx
@@ -79,18 +79,19 @@ export const ProductsGrid: React.FC<ProductGridProps> = ({
 
   return (
     <div className={`grid gap-4 pb-12 sm:gap-5 lg:gap-6 ${gridClass}`}>
-      {products.map((product) =>
-        viewType === 'list' ? (
+      {products.map((product) => {
+        const key = product._id || product.id;
+        return viewType === 'list' ? (
           <ProductCard /// List view can have a different card design, so we can create a separate component if needed
-            key={product.id}
+            key={key}
             product={product}
           />
         ) : (
-          <div key={product.id} className="w-full min-w-0 overflow-hidden">
+          <div key={key} className="w-full min-w-0 overflow-hidden">
             <ProductCard product={product} />
           </div>
-        ),
-      )}
+        );
+      })}
     </div>
   );
 };

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Heart, Minus, Plus } from 'lucide-react';
+import { Heart, Image as ImageIcon, Minus, Plus } from 'lucide-react';
 
 import { productService } from '@/services/productService';
 
@@ -31,11 +31,15 @@ export const ProductDetails = () => {
       <div className="grid grid-cols-1 gap-12 md:grid-cols-2">
         <div className="flex flex-col gap-4">
           <div className="flex h-[500px] items-center justify-center overflow-hidden rounded-lg bg-gray-200">
-            <img
-              src={product.imageUrl}
-              alt={product.title}
-              className="h-full w-full object-cover"
-            />
+            {product.imageUrl ? (
+              <img
+                src={product.imageUrl}
+                alt={product.title}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <ImageIcon className="h-24 w-24 text-gray-400" />
+            )}
           </div>
         </div>
         <div className="flex flex-col">

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -10,7 +10,7 @@ export type ProductStatusUpperCase = Uppercase<ProductStatus>;
 export interface Product {
   _id?: string;
   id: string;
-  imageUrl: string;
+  imageUrl?: string;
   price: number;
   title: string;
   status: ProductStatus;


### PR DESCRIPTION
Displays the real product image from Cloudinary on `ProductCard` and `ProductDetails`.

## Changes

- **`ProductCard`** — renders `<img src={imageUrl}>` when URL is present; shows a neutral placeholder icon when absent
- **`ProductDetails`** — same conditional render for the large image block
- **`product.types.ts`** — `imageUrl: string` → `imageUrl?: string` to match server schema (optional field)
- **`ProductsGrid`** — React keys use `product._id || product.id` (API returns `_id`)

Closes #70
