### PR TITLE
Feat/152 admin categories layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { AuthLayout } from './components/AuthLayout';
 import { RegisterForm } from './components/RegisterForm';
 import { ROUTES } from './constants';
 import { Home } from './pages';
+import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
 import { EditProduct } from './pages/Admin/EditProduct/EditProduct';
 import { AdminProducts } from './pages/Admin/Products/AdminProducts';
@@ -23,6 +24,7 @@ function App() {
     CONTACT_US,
     CART,
     ADMIN,
+    ADMIN_CATEGORIES,
     ADMIN_PRODUCTS,
     ADMIN_SETTING,
     ADMIN_PRODUCT_CREATE,
@@ -50,6 +52,7 @@ function App() {
 
         <Route element={<ProtectedRoute />}>
           <Route path={ADMIN} element={<AdminLayout />}>
+            <Route path={ADMIN_CATEGORIES} element={<AdminCategories />} />
             <Route path={ADMIN_PRODUCTS} element={<AdminProducts />} />
             <Route path={ADMIN_SETTING} element={<AdminSettings />} />
             <Route path={ADMIN_PRODUCT_CREATE} element={<CreateProduct />} />

--- a/src/components/MobileSidebar/MobileSidebar.test.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.test.tsx
@@ -83,6 +83,9 @@ describe('UI Component: MobileSidebar', () => {
     renderWithTheme({ ...defaultProps, isSidebarOpen: true });
 
     expect(screen.getByText('ADMIN')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Categories' }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Products' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Logout/i })).toBeInTheDocument();
@@ -139,9 +142,11 @@ describe('UI Component: MobileSidebar', () => {
   it('should render Products and Settings links with correct hrefs', () => {
     renderWithTheme({ ...defaultProps, isSidebarOpen: true });
 
+    const categoriesLink = screen.getByRole('link', { name: 'Categories' });
     const productsLink = screen.getByRole('link', { name: 'Products' });
     const settingsLink = screen.getByRole('link', { name: 'Settings' });
 
+    expect(categoriesLink).toHaveAttribute('href', ROUTES.ADMIN_CATEGORIES);
     expect(productsLink).toHaveAttribute('href', ROUTES.ADMIN_PRODUCTS);
     expect(settingsLink).toHaveAttribute('href', ROUTES.ADMIN_SETTING);
   });

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 
 const MOBILE_LINKS = [
+  { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products' },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings' },
 ];

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -45,6 +45,7 @@ describe('UI Component: Sidebar', () => {
     vi.mocked(useAuth).mockReturnValue(defaultAuthMock);
     renderWithProviders(<Sidebar />);
 
+    expect(screen.getByText('Categories')).toBeInTheDocument();
     expect(screen.getByText('Products')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,10 @@
 import { NavLink, useNavigate } from 'react-router-dom';
-import { LogOut, PackageIcon, SettingsIcon } from 'lucide-react';
+import {
+  ChartBarStacked,
+  LogOut,
+  PackageIcon,
+  SettingsIcon,
+} from 'lucide-react';
 
 import { Button } from '@/components/Button';
 import { ROUTES } from '@/constants';
@@ -9,6 +14,11 @@ import { useTheme } from '@/hooks/useTheme';
 
 const SIDEBAR_LINKS = [
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products', icon: <PackageIcon /> },
+  {
+    to: ROUTES.ADMIN_CATEGORIES,
+    label: 'Categories',
+    icon: <ChartBarStacked />,
+  },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings', icon: <SettingsIcon /> },
 ];
 

--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Category } from '@/types';
+import { render, screen, userEvent } from '@/utils/test-utils';
+
+import { TableCategories } from './TableCategories';
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ isDark: false }),
+}));
+
+const mockCategories: Category[] = [
+  {
+    id: 'parent-1',
+    title: 'Laptops',
+    imageUrl: 'https://example.com/laptops.jpg',
+    description: 'Main laptops category',
+    parent: null,
+    depth: 1,
+    createdAt: '2025-10-10T12:00:00Z',
+    updatedAt: '2025-10-11T12:00:00Z',
+  },
+  {
+    id: 'child-1',
+    title: 'Ultrabooks',
+    imageUrl: null,
+    description: 'Slim laptops',
+    parent: 'parent-1',
+    depth: 2,
+    createdAt: '2025-10-12T12:00:00Z',
+    updatedAt: '2025-10-13T12:00:00Z',
+  },
+  {
+    id: 'parent-2',
+    title: 'Accessories',
+    imageUrl: null,
+    description: 'Category without children',
+    parent: null,
+    depth: 1,
+    createdAt: '2025-10-14T12:00:00Z',
+    updatedAt: '2025-10-15T12:00:00Z',
+  },
+  {
+    id: 'orphan-child',
+    title: 'Archived',
+    imageUrl: null,
+    description: 'Missing parent fallback',
+    parent: 'missing-parent',
+    depth: 2,
+    createdAt: '2025-10-16T12:00:00Z',
+    updatedAt: '2025-10-17T12:00:00Z',
+  },
+];
+
+describe('UI Component: TableCategories', () => {
+  it('should render the table and all column headers', () => {
+    render(<TableCategories items={[]} loading={false} />);
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.getByText('Category name')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Level')).toBeInTheDocument();
+    expect(screen.getByText('Created at')).toBeInTheDocument();
+    expect(screen.getByText('Updated at')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+  });
+
+  it('should show loading state', () => {
+    render(<TableCategories items={[]} loading={true} />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should show error state', () => {
+    render(
+      <TableCategories
+        items={[]}
+        loading={false}
+        error={new Error('Network failure')}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load categories')).toBeInTheDocument();
+    expect(screen.getByText('Network failure')).toBeInTheDocument();
+  });
+
+  it('should show empty state when there are no categories', () => {
+    render(<TableCategories items={[]} loading={false} />);
+
+    expect(screen.getByText('No categories found')).toBeInTheDocument();
+  });
+
+  it('should render parent rows and keep subcategories hidden by default', () => {
+    render(<TableCategories items={mockCategories} loading={false} />);
+
+    expect(screen.getByText('Laptops')).toBeInTheDocument();
+    expect(screen.getByText('Accessories')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+    expect(screen.queryByText('Ultrabooks')).not.toBeInTheDocument();
+  });
+
+  it('should expand and collapse subcategories on toggle click', async () => {
+    const user = userEvent.setup();
+    render(<TableCategories items={mockCategories} loading={false} />);
+
+    const toggleButton = screen.getByRole('button', { name: 'Expand Laptops' });
+    await user.click(toggleButton);
+
+    expect(screen.getByText('Ultrabooks')).toBeInTheDocument();
+    expect(screen.getByText('Slim laptops')).toBeInTheDocument();
+    expect(screen.getAllByText('Subcategory').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Collapse Laptops' }));
+
+    expect(screen.queryByText('Ultrabooks')).not.toBeInTheDocument();
+  });
+
+  it('should render image fallback and action buttons', async () => {
+    const user = userEvent.setup();
+    render(<TableCategories items={mockCategories} loading={false} />);
+
+    expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
+
+    const editButton = screen.getByRole('button', { name: 'Edit Accessories' });
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete Accessories',
+    });
+
+    expect(editButton).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+
+    await user.click(editButton);
+    await user.click(deleteButton);
+  });
+
+  it('should render formatted dates and parent category label', () => {
+    render(<TableCategories items={mockCategories} loading={false} />);
+
+    expect(screen.getAllByText('Parent category').length).toBeGreaterThan(0);
+    expect(screen.getByText('10/10/25')).toBeInTheDocument();
+    expect(screen.getByText('10/11/25')).toBeInTheDocument();
+  });
+});

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -54,7 +54,7 @@ function CategoryRow({
                 ? `Collapse ${category.title}`
                 : `Expand ${category.title}`
             }
-            className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border-2 bg-[rgb(var(--color-bg))] p-0 text-black hover:text-black"
+            className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border-2 border-[rgb(var(--color-text))] bg-[rgb(var(--color-bg))] p-0 text-[rgb(var(--color-text))]"
             onClick={() => onToggle(category.id)}
           >
             {isExpanded ? (

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -1,0 +1,267 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import { AlertCircle, Minus, Pencil, Plus, Trash } from 'lucide-react';
+
+import { useTheme } from '@/hooks/useTheme';
+import type { Category } from '@/types';
+
+import { Button } from '../Button';
+
+interface TableCategoriesProps {
+  items: Category[];
+  loading: boolean;
+  error?: Error | null;
+}
+
+const formatCategoryDate = (value: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: '2-digit',
+  }).format(new Date(value));
+
+const getLevelLabel = (depth: Category['depth']) =>
+  depth === 1 ? 'Parent category' : 'Subcategory';
+
+type CategoryRowProps = {
+  category: Category;
+  isChild?: boolean;
+  hasChildren: boolean;
+  isExpanded: boolean;
+  onToggle: (categoryId: string) => void;
+};
+
+function CategoryRow({
+  category,
+  isChild = false,
+  hasChildren,
+  isExpanded,
+  onToggle,
+}: CategoryRowProps) {
+  return (
+    <tr
+      className={clsx(
+        'h-[80px] text-[rgb(var(--color-text))]',
+        isChild ? 'bg-[rgb(var(--color-bg-sec))]' : 'bg-[rgb(var(--color-bg))]',
+      )}
+    >
+      <td className="w-[72px] text-center">
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={
+              isExpanded
+                ? `Collapse ${category.title}`
+                : `Expand ${category.title}`
+            }
+            className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border-2 bg-[rgb(var(--color-bg))] p-0 text-black hover:text-black"
+            onClick={() => onToggle(category.id)}
+          >
+            {isExpanded ? (
+              <Minus className="h-4 w-4" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+          </button>
+        ) : (
+          <span className="inline-block h-8 w-8" />
+        )}
+      </td>
+
+      <td className="w-[96px] text-center">
+        {category.imageUrl ? (
+          <img
+            alt={category.title}
+            className="mx-auto h-10 w-10 rounded-md object-cover"
+            src={category.imageUrl}
+          />
+        ) : (
+          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-md bg-[#E5E7EB] text-xs text-[#8A92A6]">
+            N/A
+          </div>
+        )}
+      </td>
+
+      <td className={clsx('font-medium', isChild && 'pl-6')}>
+        {category.title}
+      </td>
+      <td className="max-w-[280px] truncate text-start">
+        {category.description || '-'}
+      </td>
+      <td className="text-center">{getLevelLabel(category.depth)}</td>
+      <td className="text-center">{formatCategoryDate(category.createdAt)}</td>
+      <td className="text-center">{formatCategoryDate(category.updatedAt)}</td>
+      <td className="text-center">
+        <Button
+          aria-label={`Delete ${category.title}`}
+          className="bg-transparent text-[#DB162D] hover:bg-transparent"
+          type="button"
+        >
+          <Trash className="h-[20px] w-[20px]" />
+        </Button>
+        <Button
+          aria-label={`Edit ${category.title}`}
+          className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
+          type="button"
+        >
+          <Pencil className="h-[20px] w-[20px]" />
+        </Button>
+      </td>
+    </tr>
+  );
+}
+
+function TableCategoriesContent({
+  items,
+  loading,
+  error,
+  isDark,
+}: {
+  items: Category[];
+  loading: boolean;
+  error: Error | null;
+  isDark: boolean;
+}) {
+  const [expandedIds, setExpandedIds] = useState<string[]>([]);
+
+  if (loading) {
+    return (
+      <tr>
+        <td colSpan={8} className="py-8 text-center">
+          Loading...
+        </td>
+      </tr>
+    );
+  }
+
+  if (error) {
+    return (
+      <tr role="alert">
+        <td colSpan={8} className="py-8">
+          <div
+            className={clsx(
+              'mx-auto flex max-w-md items-center gap-3 rounded-lg border p-4',
+              {
+                'border-red-900/50 bg-red-950/30 text-red-300': isDark,
+                'border-red-200 bg-red-50 text-red-800': !isDark,
+              },
+            )}
+          >
+            <AlertCircle className="h-6 w-6 shrink-0" />
+            <div className="text-left">
+              <p className="font-medium">Failed to load categories</p>
+              <p className="text-sm">{error.message}</p>
+            </div>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <tr>
+        <td
+          colSpan={8}
+          className={clsx('py-8 text-center', {
+            'text-black': isDark,
+            'text-[#8A92A6]': !isDark,
+          })}
+        >
+          No categories found
+        </td>
+      </tr>
+    );
+  }
+
+  const childrenByParent = new Map<string, Category[]>();
+  const categoryIds = new Set(items.map((item) => item.id));
+
+  items.forEach((item) => {
+    if (!item.parent) return;
+
+    const siblings = childrenByParent.get(item.parent) ?? [];
+    siblings.push(item);
+    childrenByParent.set(item.parent, siblings);
+  });
+
+  const parentCategories = items.filter(
+    (item) => item.depth === 1 || !item.parent || !categoryIds.has(item.parent),
+  );
+
+  const toggleCategory = (categoryId: string) => {
+    setExpandedIds((prev) =>
+      prev.includes(categoryId)
+        ? prev.filter((id) => id !== categoryId)
+        : [...prev, categoryId],
+    );
+  };
+
+  return parentCategories.flatMap((parentCategory) => {
+    const childCategories = childrenByParent.get(parentCategory.id) ?? [];
+    const isExpanded = expandedIds.includes(parentCategory.id);
+
+    const rows = [
+      <CategoryRow
+        key={parentCategory.id}
+        category={parentCategory}
+        hasChildren={childCategories.length > 0}
+        isExpanded={isExpanded}
+        onToggle={toggleCategory}
+      />,
+    ];
+
+    if (isExpanded) {
+      rows.push(
+        ...childCategories.map((childCategory) => (
+          <CategoryRow
+            key={childCategory.id}
+            category={childCategory}
+            isChild
+            hasChildren={false}
+            isExpanded={false}
+            onToggle={toggleCategory}
+          />
+        )),
+      );
+    }
+
+    return rows;
+  });
+}
+
+export function TableCategories({
+  items,
+  loading,
+  error,
+}: TableCategoriesProps) {
+  const { isDark } = useTheme();
+
+  return (
+    <div className="mx-5 mt-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
+      <table className="[&_td]:px-4s w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#e5e7eb] [&_thead_th]:border-b [&_thead_th]:border-[#e5e7eb] [&_thead_th]:px-4">
+        <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
+          <tr>
+            <th className="w-[72px]"></th>
+            <th className="w-[96px]">Image</th>
+            <th className="text-left">Category name</th>
+            <th>Description</th>
+            <th>Level</th>
+            <th>Created at</th>
+            <th>Updated at</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <TableCategoriesContent
+            items={items}
+            loading={loading}
+            error={error ?? null}
+            isDark={isDark}
+          />
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -69,21 +69,25 @@ function CategoryRow({
       </td>
 
       <td className="w-[96px] text-center">
-        {category.imageUrl ? (
-          <img
-            alt={category.title}
-            className="mx-auto h-10 w-10 rounded-md object-cover"
-            src={category.imageUrl}
-          />
-        ) : (
-          <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-md bg-[#E5E7EB] text-xs text-[#8A92A6]">
-            N/A
-          </div>
-        )}
+        <div className={clsx('flex justify-center', isChild && 'pl-8')}>
+          {category.imageUrl ? (
+            <img
+              alt={category.title}
+              className="h-10 w-10 rounded-md object-cover"
+              src={category.imageUrl}
+            />
+          ) : (
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[#E5E7EB] text-xs text-[#8A92A6]">
+              N/A
+            </div>
+          )}
+        </div>
       </td>
 
-      <td className={clsx('font-medium', isChild && 'pl-6')}>
-        {category.title}
+      <td className="text-left">
+        <div className={clsx('font-medium', isChild && 'pl-8')}>
+          {category.title}
+        </div>
       </td>
       <td className="max-w-[280px] truncate text-start">
         {category.description || '-'}
@@ -239,7 +243,7 @@ export function TableCategories({
 
   return (
     <div className="mx-5 mt-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
-      <table className="[&_td]:px-4s w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#e5e7eb] [&_thead_th]:border-b [&_thead_th]:border-[#e5e7eb] [&_thead_th]:px-4">
+      <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#e5e7eb] [&_td]:px-4 [&_thead_th]:border-b [&_thead_th]:border-[#e5e7eb] [&_thead_th]:px-4">
         <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
           <tr>
             <th className="w-[72px]"></th>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,5 +18,6 @@ export { Sidebar } from './Sidebar/Sidebar';
 export { SortOrderButton } from './SortProducts/SortOrderButton/SortOrderButton';
 export { SortProductsDropdown } from './SortProducts/SortProductsDropdown/SortProductsDropdown';
 export { SortRadioItem } from './SortProducts/SortRadioItem/SortRadioItem';
+export { TableCategories } from './TableCategories/TableCategories';
 export { TableProducts } from './TableProducts/TableProducts';
 export { TextArea } from './TextArea';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,6 +12,7 @@ export const ROUTES = {
   LOGIN: '/login',
   CART: '/cart',
   ADMIN: '/admin',
+  ADMIN_CATEGORIES: '/admin/categories',
   ADMIN_PRODUCTS: '/admin/products',
   ADMIN_SETTING: '/admin/setting',
   ADMIN_PRODUCT_CREATE: '/admin/products/create',

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -3,6 +3,6 @@ import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 const uri = import.meta.env.VITE_GRAPHQL_URL ?? 'http://localhost:3000/graphql';
 
 export const apolloClient = new ApolloClient({
-  link: new HttpLink({ uri }),
+  link: new HttpLink({ uri, credentials: 'include' }),
   cache: new InMemoryCache(),
 });

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -1,0 +1,36 @@
+import {
+  AdminPageHeader,
+  Button,
+  Pagination,
+  SearchInput,
+  TableCategories,
+} from '@/components';
+import { useAdminCategories } from '@/hooks/useAdminCategories';
+
+export function AdminCategories() {
+  const { categories, loading, error } = useAdminCategories();
+
+  return (
+    <div>
+      <AdminPageHeader />
+
+      <div className="flex items-center justify-end border-b border-[#e5e7eb] px-4 py-3">
+        <Button variant="primary" type="button">
+          + Add Category
+        </Button>
+      </div>
+
+      <div className="mx-2 my-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] pb-4 shadow-md md:mx-5">
+        <div className="flex items-center justify-end gap-4 border-b border-[#e5e7eb] p-4">
+          <div className="flex items-center gap-4">
+            <SearchInput value="" onChange={() => {}} placeholder="Search" />
+          </div>
+        </div>
+
+        <TableCategories items={categories} loading={loading} error={error} />
+
+        <Pagination currentPage={1} totalPages={5} onPageChange={() => {}} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin categories page and route
- add categories entry to admin navigation
- implement categories table layout with accordion for subcategories
- add UI search, add category button, and pagination

## Notes
- search, pagination, edit, and delete are UI-only for now
- subcategories are displayed under parent categories with expandable rows

<img width="1894" height="804" alt="image" src="https://github.com/user-attachments/assets/c5b583b2-64dc-481e-89ee-f7165e7a0078" />
