### PR TITLE
feat(235): integrate product image upload flow on client

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,4 +7,5 @@ export * from './useLocalStorage';
 export * from './useLogin';
 export * from './useTheme';
 export * from './useUpdateAdminCategory';
+export * from './useUploadProductImage';
 export * from './useUsers';

--- a/src/hooks/useUploadProductImage.ts
+++ b/src/hooks/useUploadProductImage.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+import { uploadService } from '@/services';
+import type { UploadProductImageResponse } from '@/types';
+
+export function useUploadProductImage() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const uploadImage = async (
+    file: File,
+  ): Promise<UploadProductImageResponse> => {
+    try {
+      setLoading(true);
+      setError(null);
+      return await uploadService.uploadProductImage(file);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Image upload failed');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { uploadImage, loading, error };
+}

--- a/src/pages/Admin/CreateProduct/CreateProduct.tsx
+++ b/src/pages/Admin/CreateProduct/CreateProduct.tsx
@@ -1,20 +1,28 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AdminPageHeader } from '@/components';
 import { ProductForm } from '@/components/ProductForm';
 import { ROUTES } from '@/constants';
 import { useCreateAdminProduct } from '@/hooks/useCreateAdminProduct';
+import { useUploadProductImage } from '@/hooks/useUploadProductImage';
 import type { ProductFormData } from '@/types';
 
 export const CreateProduct = () => {
   const navigate = useNavigate();
   const { createProduct, loading } = useCreateAdminProduct();
+  const { uploadImage, loading: isUploading } = useUploadProductImage();
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   const handleCreate = async (formData: ProductFormData) => {
     try {
-      //TODO: temporary solution for image, you can replace it with actual image upload logic
-      const dummyImageUrl =
-        'https://images.unsplash.com/photo-1541807084-5c52b6b3adef?w=800&h=1200&fit=crop';
+      setUploadError(null);
+      let uploadedImage;
+
+      if (formData.imageFile) {
+        uploadedImage = await uploadImage(formData.imageFile);
+      }
+
       const input = {
         title: formData.name,
         price: parseFloat(formData.price),
@@ -22,15 +30,21 @@ export const CreateProduct = () => {
         categories: formData.categories
           ? formData.categories
               .split(',')
-              .map((category) => category.trim())
+              .map((c) => c.trim())
               .filter(Boolean)
           : [],
-        imageUrl: dummyImageUrl,
+        ...(uploadedImage && {
+          imageUrl: uploadedImage.imageUrl,
+          imagePublicId: uploadedImage.imagePublicId,
+        }),
       };
 
       await createProduct(input);
       navigate(ROUTES.ADMIN_PRODUCTS);
     } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Error creating product';
+      setUploadError(errorMessage);
       console.error('Error creating product:', err);
     }
   };
@@ -43,10 +57,15 @@ export const CreateProduct = () => {
     <div>
       <AdminPageHeader />
       <div className="mx-auto max-w-3xl p-6">
+        {uploadError && (
+          <div className="mb-4 rounded bg-red-100 p-3 text-red-700">
+            {uploadError}
+          </div>
+        )}
         <ProductForm
           onSubmit={handleCreate}
           onCancel={handleCancel}
-          isLoading={loading}
+          isLoading={loading || isUploading}
           isEditMode={false}
         />
       </div>

--- a/src/pages/Admin/EditProduct/EditProduct.tsx
+++ b/src/pages/Admin/EditProduct/EditProduct.tsx
@@ -7,6 +7,7 @@ import { ProductForm } from '@/components/ProductForm';
 import { ROUTES } from '@/constants';
 import { useGetAdminProduct } from '@/hooks/useGetAdminProduct';
 import { useUpdateAdminProduct } from '@/hooks/useUpdateAdminProduct';
+import { useUploadProductImage } from '@/hooks/useUploadProductImage';
 import type { ProductFormData, ProductStatus } from '@/types';
 
 const ERROR_TEXTS = {
@@ -18,6 +19,7 @@ export const EditProduct = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [showSuccess, setShowSuccess] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   const {
     product,
@@ -25,6 +27,7 @@ export const EditProduct = () => {
     error: fetchError,
   } = useGetAdminProduct(id);
   const { updateProduct, loading: isUpdating } = useUpdateAdminProduct();
+  const { uploadImage, loading: isUploading } = useUploadProductImage();
 
   const initialData = product
     ? {
@@ -69,17 +72,30 @@ export const EditProduct = () => {
 
   const handleSubmit = async (formData: ProductFormData) => {
     try {
+      setUploadError(null);
+      let uploadedImage;
+
+      if (formData.imageFile) {
+        uploadedImage = await uploadImage(formData.imageFile);
+      }
+
       await updateProduct(id, {
         title: formData.name,
         price: Number(formData.price),
         status: formData.status as ProductStatus,
         description: formData.description,
         categories: formData.categories.split(',').map((c) => c.trim()),
+        ...(uploadedImage && {
+          imageUrl: uploadedImage.imageUrl,
+          imagePublicId: uploadedImage.imagePublicId,
+        }),
       });
+
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
       navigate(ROUTES.ADMIN_PRODUCTS);
     } catch (e) {
+      setUploadError(e instanceof Error ? e.message : 'Failed to upload image');
       console.error(e);
     }
   };
@@ -93,11 +109,16 @@ export const EditProduct = () => {
             Product updated successfully!
           </div>
         )}
+        {uploadError && (
+          <div className="mb-4 rounded bg-red-100 p-3 text-red-700 dark:bg-red-900/20 dark:text-red-400">
+            {uploadError}
+          </div>
+        )}
         <ProductForm
           initialData={initialData}
           onSubmit={handleSubmit}
           onCancel={() => navigate(ROUTES.ADMIN_PRODUCTS)}
-          isLoading={isUpdating}
+          isLoading={isUpdating || isUploading}
           isEditMode={true}
           updatedAt={product?.updatedAt}
         />

--- a/src/services/authService.test.tsx
+++ b/src/services/authService.test.tsx
@@ -8,13 +8,15 @@ import {
   vi,
 } from 'vitest';
 
+import { API_BASE_URL } from '@/constants';
+
 import { authService, type LoginPayload } from './authService';
 
 // Change original global fetch for mock-function Vitest
 global.fetch = vi.fn();
 
 describe('Service: authService', () => {
-  const API_URL = 'http://localhost:3000'; // The same default as in service
+  const API_URL = API_BASE_URL;
 
   beforeEach(() => {
     // Clear calls and mocks before each test to avoid interference

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,9 +1,11 @@
+import { API_BASE_URL } from '@/constants';
+
 export interface LoginPayload {
   email: string;
   password: string;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = API_BASE_URL;
 
 export const authService = {
   login: async (data: LoginPayload) => {

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -47,6 +47,7 @@ export const GET_PRODUCT = gql`
       categories
       productCode
       imageUrl
+      imagePublicId
     }
   }
 `;
@@ -61,6 +62,7 @@ export const CREATE_PRODUCT = gql`
       description
       categories
       imageUrl
+      imagePublicId
     }
   }
 `;
@@ -75,6 +77,7 @@ export const UPDATE_PRODUCT = gql`
       description
       categories
       imageUrl
+      imagePublicId
     }
   }
 `;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,4 +12,5 @@ export {
   GET_PRODUCTS_PAGE,
 } from './graphql/productAdminService';
 export { productService } from './productService';
+export { uploadService } from './uploadService';
 export { userService } from './userService';

--- a/src/services/uploadService.test.ts
+++ b/src/services/uploadService.test.ts
@@ -1,0 +1,73 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from 'vitest';
+
+import { API_BASE_URL } from '@/constants';
+
+import { uploadService } from './uploadService';
+
+global.fetch = vi.fn();
+
+describe('Service: uploadService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads image as FormData and returns upload metadata', async () => {
+    const file = new File(['image-bytes'], 'product.png', {
+      type: 'image/png',
+    });
+    const mockResponse = {
+      imageUrl:
+        'https://res.cloudinary.com/demo/image/upload/products/test.png',
+      imagePublicId: 'products/test',
+    };
+
+    (global.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await uploadService.uploadProductImage(file);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = (global.fetch as Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+
+    expect(url).toBe(`${API_BASE_URL}/uploads/products`);
+    expect(options.method).toBe('POST');
+    expect(options.body).toBeInstanceOf(FormData);
+
+    const formData = options.body as FormData;
+    expect(formData.get('file')).toBe(file);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('throws backend error message when upload fails', async () => {
+    const file = new File(['image-bytes'], 'product.png', {
+      type: 'image/png',
+    });
+
+    (global.fetch as Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: 'Cloudinary upload failed' }),
+    });
+
+    await expect(uploadService.uploadProductImage(file)).rejects.toThrow(
+      'Cloudinary upload failed',
+    );
+  });
+});

--- a/src/services/uploadService.ts
+++ b/src/services/uploadService.ts
@@ -1,0 +1,24 @@
+import { API_BASE_URL } from '@/constants';
+import type { UploadProductImageResponse } from '@/types';
+
+export const uploadService = {
+  async uploadProductImage(file: File): Promise<UploadProductImageResponse> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(`${API_BASE_URL}/uploads/products`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorData = await response
+        .json()
+        .catch(() => ({ message: 'Image upload failed' }));
+
+      throw new Error(errorData.message || 'Image upload failed');
+    }
+
+    return response.json();
+  },
+};

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -10,7 +10,9 @@ export type ProductStatusUpperCase = Uppercase<ProductStatus>;
 export interface Product {
   _id?: string;
   id: string;
+  categories?: string[];
   imageUrl?: string;
+  imagePublicId?: string;
   price: number;
   title: string;
   status: ProductStatus;
@@ -57,4 +59,9 @@ export interface ProductFormData {
   description: string;
   imagePreview: string | null;
   imageFile?: File;
+}
+
+export interface UploadProductImageResponse {
+  imageUrl: string;
+  imagePublicId: string;
 }


### PR DESCRIPTION
## Summary
- integrate product image upload with backend `POST /uploads/products` endpoint on create/edit flows
- add dedicated upload service and hook for multipart upload + loading/error handling
- remove temporary image placeholder usage in create flow
- include returned `imageUrl` and `imagePublicId` in create/update payloads
- align auth service with shared `API_BASE_URL`
- add upload service tests and keep auth service tests env-safe

Closes UA-5399-React/docs#235

## Verification
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (`224/224` passed)
- browser smoke test:
  - login as admin
  - create product with image upload
  - edit product with image replacement
  - delete test product
  - remove uploaded Cloudinary test assets

## Notes
- upload flow works end-to-end against the current backend upload endpoint
- there is a separate existing project gap in product categories UX: backend now validates category IDs, while the current product form still exposes categories as a free-text field
- that categories mismatch is outside the scope of this issue and was not bundled into this PR
