### PR TITLE
Feat(242): add category search, pagination, and delete flow in admin panel

### DIFF
--- a/src/components/ProductForm/ProductForm.test.tsx
+++ b/src/components/ProductForm/ProductForm.test.tsx
@@ -1,6 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@/utils/test-utils';
 
 import { ProductForm } from './ProductForm';
 
@@ -15,6 +21,10 @@ vi.mock('@/hooks', () => ({
 }));
 
 describe('Component: ProductForm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should render correctly in CREATE mode (no status field, no last update)', () => {
     render(<ProductForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
 
@@ -147,5 +157,80 @@ describe('Component: ProductForm', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(handleCancel).toHaveBeenCalledOnce();
+  });
+
+  it('should open file picker, show preview, and revoke preview URL on unmount', async () => {
+    const user = userEvent.setup();
+    const createObjectURLMock = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:preview');
+    const revokeObjectURLMock = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined);
+
+    const { container, unmount } = render(
+      <ProductForm onSubmit={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click');
+
+    await user.click(screen.getByRole('button', { name: 'Choose File' }));
+    expect(clickSpy).toHaveBeenCalledOnce();
+
+    const file = new File(['image'], 'phone.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(file);
+    expect(screen.getByAltText('Preview')).toHaveAttribute(
+      'src',
+      'blob:preview',
+    );
+
+    fireEvent.change(fileInput, { target: { files: [] } });
+
+    unmount();
+
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:preview');
+  });
+
+  it('should update product status in edit mode', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+
+    render(
+      <ProductForm
+        isEditMode={true}
+        updatedAt="2025-10-10T12:00:00Z"
+        initialData={{
+          name: 'MacBook Pro',
+          price: '2499',
+          categories: 'laptop, electronics',
+          status: 'ACTIVE',
+          description: 'Laptop for work',
+          imagePreview: null,
+        }}
+        onSubmit={handleSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Status' }));
+    await user.click(screen.getByRole('option', { name: 'Inactive' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        name: 'MacBook Pro',
+        price: '2499',
+        categories: 'laptop, electronics',
+        status: 'INACTIVE',
+        description: 'Laptop for work',
+        imagePreview: null,
+        imageFile: undefined,
+      });
+    });
   });
 });

--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -9,6 +9,8 @@ vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({ isDark: false }),
 }));
 
+const mockDelete = vi.fn();
+
 const mockCategories: Category[] = [
   {
     id: 'parent-1',
@@ -54,7 +56,9 @@ const mockCategories: Category[] = [
 
 describe('UI Component: TableCategories', () => {
   it('should render the table and all column headers', () => {
-    render(<TableCategories items={[]} loading={false} />);
+    render(
+      <TableCategories items={[]} loading={false} onDelete={mockDelete} />,
+    );
 
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByText('Image')).toBeInTheDocument();
@@ -67,7 +71,7 @@ describe('UI Component: TableCategories', () => {
   });
 
   it('should show loading state', () => {
-    render(<TableCategories items={[]} loading={true} />);
+    render(<TableCategories items={[]} loading={true} onDelete={mockDelete} />);
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
@@ -78,6 +82,7 @@ describe('UI Component: TableCategories', () => {
         items={[]}
         loading={false}
         error={new Error('Network failure')}
+        onDelete={mockDelete}
       />,
     );
 
@@ -87,13 +92,21 @@ describe('UI Component: TableCategories', () => {
   });
 
   it('should show empty state when there are no categories', () => {
-    render(<TableCategories items={[]} loading={false} />);
+    render(
+      <TableCategories items={[]} loading={false} onDelete={mockDelete} />,
+    );
 
     expect(screen.getByText('No categories found')).toBeInTheDocument();
   });
 
   it('should render parent rows and keep subcategories hidden by default', () => {
-    render(<TableCategories items={mockCategories} loading={false} />);
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        onDelete={mockDelete}
+      />,
+    );
 
     expect(screen.getByText('Laptops')).toBeInTheDocument();
     expect(screen.getByText('Accessories')).toBeInTheDocument();
@@ -103,7 +116,13 @@ describe('UI Component: TableCategories', () => {
 
   it('should expand and collapse subcategories on toggle click', async () => {
     const user = userEvent.setup();
-    render(<TableCategories items={mockCategories} loading={false} />);
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        onDelete={mockDelete}
+      />,
+    );
 
     const toggleButton = screen.getByRole('button', { name: 'Expand Laptops' });
     await user.click(toggleButton);
@@ -119,7 +138,13 @@ describe('UI Component: TableCategories', () => {
 
   it('should render image fallback and action buttons', async () => {
     const user = userEvent.setup();
-    render(<TableCategories items={mockCategories} loading={false} />);
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        onDelete={mockDelete}
+      />,
+    );
 
     expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
 
@@ -127,16 +152,43 @@ describe('UI Component: TableCategories', () => {
     const deleteButton = screen.getByRole('button', {
       name: 'Delete Accessories',
     });
+    const parentDeleteButton = screen.getByRole('button', {
+      name: 'Delete Laptops',
+    });
 
     expect(editButton).toBeInTheDocument();
     expect(deleteButton).toBeInTheDocument();
+    expect(parentDeleteButton).toBeDisabled();
 
     await user.click(editButton);
     await user.click(deleteButton);
+
+    expect(mockDelete).toHaveBeenCalledWith(mockCategories[2]);
+  });
+
+  it('should disable delete button for currently deleting category', () => {
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        deletingId="parent-2"
+        onDelete={mockDelete}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Delete Accessories' }),
+    ).toBeDisabled();
   });
 
   it('should render formatted dates and parent category label', () => {
-    render(<TableCategories items={mockCategories} loading={false} />);
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        onDelete={mockDelete}
+      />,
+    );
 
     expect(screen.getAllByText('Parent category').length).toBeGreaterThan(0);
     expect(screen.getByText('10/10/25')).toBeInTheDocument();

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -46,11 +46,13 @@ function CategoryRow({
 }: CategoryRowProps) {
   const isDeleting = deletingId === category.id;
   const isDeleteDisabled = hasChildren || isDeleting;
-  const deleteButtonTitle = hasChildren
-    ? 'Delete subcategories first'
-    : isDeleting
-      ? 'Deleting category'
-      : 'Delete category';
+  let deleteButtonTitle = 'Delete category';
+
+  if (hasChildren) {
+    deleteButtonTitle = 'Delete subcategories first';
+  } else if (isDeleting) {
+    deleteButtonTitle = 'Deleting category';
+  }
 
   return (
     <tr

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -11,6 +11,8 @@ interface TableCategoriesProps {
   items: Category[];
   loading: boolean;
   error?: Error | null;
+  deletingId?: string | null;
+  onDelete: (category: Category) => void;
 }
 
 const formatCategoryDate = (value: string) =>
@@ -28,6 +30,8 @@ type CategoryRowProps = {
   isChild?: boolean;
   hasChildren: boolean;
   isExpanded: boolean;
+  deletingId?: string | null;
+  onDelete: (category: Category) => void;
   onToggle: (categoryId: string) => void;
 };
 
@@ -36,8 +40,18 @@ function CategoryRow({
   isChild = false,
   hasChildren,
   isExpanded,
+  deletingId,
+  onDelete,
   onToggle,
 }: CategoryRowProps) {
+  const isDeleting = deletingId === category.id;
+  const isDeleteDisabled = hasChildren || isDeleting;
+  const deleteButtonTitle = hasChildren
+    ? 'Delete subcategories first'
+    : isDeleting
+      ? 'Deleting category'
+      : 'Delete category';
+
   return (
     <tr
       className={clsx(
@@ -98,8 +112,11 @@ function CategoryRow({
       <td className="text-center">
         <Button
           aria-label={`Delete ${category.title}`}
-          className="bg-transparent text-[#DB162D] hover:bg-transparent"
+          className="bg-transparent text-[#DB162D] hover:bg-transparent disabled:cursor-not-allowed disabled:opacity-50"
           type="button"
+          disabled={isDeleteDisabled}
+          onClick={() => onDelete(category)}
+          title={deleteButtonTitle}
         >
           <Trash className="h-[20px] w-[20px]" />
         </Button>
@@ -120,11 +137,15 @@ function TableCategoriesContent({
   loading,
   error,
   isDark,
+  deletingId,
+  onDelete,
 }: {
   items: Category[];
   loading: boolean;
   error: Error | null;
   isDark: boolean;
+  deletingId?: string | null;
+  onDelete: (category: Category) => void;
 }) {
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
 
@@ -211,6 +232,8 @@ function TableCategoriesContent({
         category={parentCategory}
         hasChildren={childCategories.length > 0}
         isExpanded={isExpanded}
+        deletingId={deletingId}
+        onDelete={onDelete}
         onToggle={toggleCategory}
       />,
     ];
@@ -224,6 +247,8 @@ function TableCategoriesContent({
             isChild
             hasChildren={false}
             isExpanded={false}
+            deletingId={deletingId}
+            onDelete={onDelete}
             onToggle={toggleCategory}
           />
         )),
@@ -238,6 +263,8 @@ export function TableCategories({
   items,
   loading,
   error,
+  deletingId,
+  onDelete,
 }: TableCategoriesProps) {
   const { isDark } = useTheme();
 
@@ -263,6 +290,8 @@ export function TableCategories({
             loading={loading}
             error={error ?? null}
             isDark={isDark}
+            deletingId={deletingId}
+            onDelete={onDelete}
           />
         </tbody>
       </table>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -45,6 +45,7 @@ export const AUTH_ROLES = {
   USER: 'user',
 };
 
+export const ADMIN_PAGE_LIMIT = 10;
 export const NEW_ARRIVALS_LIMIT = 10;
 
 export * from './theme';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAdminCategories';
+export * from './useAdminCategoriesPage';
 export * from './useAuth';
 export * from './useCreateAdminCategory';
 export * from './useDeleteAdminCategory';

--- a/src/hooks/useAdminCategoriesPage.ts
+++ b/src/hooks/useAdminCategoriesPage.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client/react';
 
+import { ADMIN_PAGE_LIMIT } from '@/constants';
 import { GET_CATEGORIES_PAGE } from '@/services/graphql/categoryAdminService';
 import type { CategoriesPageResult } from '@/types';
 
@@ -11,7 +12,7 @@ type UseAdminCategoriesPageParams = {
 
 export function useAdminCategoriesPage({
   page = 1,
-  limit = 10,
+  limit = ADMIN_PAGE_LIMIT,
   search = '',
 }: UseAdminCategoriesPageParams = {}) {
   const normalizedSearch = search.trim();

--- a/src/hooks/useAdminCategoriesPage.ts
+++ b/src/hooks/useAdminCategoriesPage.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@apollo/client/react';
+
+import { GET_CATEGORIES_PAGE } from '@/services/graphql/categoryAdminService';
+import type { CategoriesPageResult } from '@/types';
+
+type UseAdminCategoriesPageParams = {
+  page?: number;
+  limit?: number;
+  search?: string;
+};
+
+export function useAdminCategoriesPage({
+  page = 1,
+  limit = 10,
+  search = '',
+}: UseAdminCategoriesPageParams = {}) {
+  const normalizedSearch = search.trim();
+
+  const { data, loading, error } = useQuery<{
+    categoriesPage: CategoriesPageResult;
+  }>(GET_CATEGORIES_PAGE, {
+    variables: {
+      page,
+      limit,
+      search: normalizedSearch.length ? normalizedSearch : null,
+    },
+    fetchPolicy: 'cache-and-network',
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const categoriesPage = data?.categoriesPage;
+
+  return {
+    categories: categoriesPage?.items ?? [],
+    loading,
+    error,
+    totalPages: categoriesPage?.totalPages ?? 1,
+    page: categoriesPage?.page ?? page,
+    total: categoriesPage?.total ?? 0,
+  };
+}

--- a/src/hooks/useAdminProduct.ts
+++ b/src/hooks/useAdminProduct.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client/react';
 
+import { ADMIN_PAGE_LIMIT } from '@/constants';
 import { GET_PRODUCTS_PAGE } from '@/services';
 import type { ProductsPageResult } from '@/types';
 import type { ProductsFilters } from '@/types/filters';
@@ -16,7 +17,7 @@ type UseAdminProductsParams = {
 
 export function useAdminProducts({
   page = 1,
-  limit = 10,
+  limit = ADMIN_PAGE_LIMIT,
   filters = {},
   search = '',
   sort = 'updatedAt',

--- a/src/hooks/useDeleteAdminCategory.ts
+++ b/src/hooks/useDeleteAdminCategory.ts
@@ -1,9 +1,6 @@
 import { useMutation } from '@apollo/client/react';
 
-import {
-  DELETE_CATEGORY,
-  GET_CATEGORIES_LIST,
-} from '@/services/graphql/categoryAdminService';
+import { DELETE_CATEGORY } from '@/services/graphql/categoryAdminService';
 
 interface DeleteCategoryData {
   deleteCategory: {
@@ -20,7 +17,7 @@ export function useDeleteAdminCategory() {
     DeleteCategoryData,
     DeleteCategoryVariables
   >(DELETE_CATEGORY, {
-    refetchQueries: [{ query: GET_CATEGORIES_LIST }],
+    refetchQueries: 'active',
     awaitRefetchQueries: true,
   });
 

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -1,17 +1,40 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
+import { act, render, screen, userEvent, waitFor } from '@/utils/test-utils';
 
 import { AdminCategories } from './AdminCategories';
 
 const useAdminCategoriesPageMock = vi.fn();
+const openConfirmModalMock = vi.fn();
+const deleteCategoryMock = vi.fn();
 
 vi.mock('@/hooks/useAdminCategoriesPage', () => ({
   useAdminCategoriesPage: (...args: unknown[]) =>
     useAdminCategoriesPageMock(...args),
 }));
 
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual('@/hooks');
+  return {
+    ...actual,
+    useConfirmModal: () => ({
+      openConfirmModal: openConfirmModalMock,
+    }),
+    useDeleteAdminCategory: () => ({
+      deleteCategory: deleteCategoryMock,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ isDark: false }),
+}));
+
 describe('Page: AdminCategories', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should read page from URL params', () => {
     window.history.pushState({}, '', '/admin/categories?page=2');
     useAdminCategoriesPageMock.mockReturnValue({
@@ -70,5 +93,96 @@ describe('Page: AdminCategories', () => {
     await waitFor(() => {
       expect(window.location.search).toContain('page=1');
     });
+  });
+
+  it('should open confirm modal when user clicks delete on leaf category', async () => {
+    const user = userEvent.setup();
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-1',
+          title: 'Laptops',
+          imageUrl: null,
+          description: 'Main laptops category',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-10T12:00:00Z',
+          updatedAt: '2025-10-11T12:00:00Z',
+        },
+        {
+          id: 'child-1',
+          title: 'Ultrabooks',
+          imageUrl: null,
+          description: 'Slim laptops',
+          parent: 'parent-1',
+          depth: 2,
+          createdAt: '2025-10-12T12:00:00Z',
+          updatedAt: '2025-10-13T12:00:00Z',
+        },
+        {
+          id: 'parent-2',
+          title: 'Accessories',
+          imageUrl: null,
+          description: 'Category without children',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-14T12:00:00Z',
+          updatedAt: '2025-10-15T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 3,
+    });
+
+    render(<AdminCategories />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Delete Accessories' }),
+    );
+
+    expect(openConfirmModalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete Category',
+        confirmText: 'Delete',
+      }),
+    );
+  });
+
+  it('should execute delete mutation when modal confirm callback is called', async () => {
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-2',
+          title: 'Accessories',
+          imageUrl: null,
+          description: 'Category without children',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-14T12:00:00Z',
+          updatedAt: '2025-10-15T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 1,
+    });
+    deleteCategoryMock.mockResolvedValue(undefined);
+
+    render(<AdminCategories />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete Accessories' }),
+    );
+
+    const modalConfig = openConfirmModalMock.mock.calls[0]?.[0];
+
+    await act(async () => {
+      await modalConfig.onConfirm();
+    });
+
+    expect(deleteCategoryMock).toHaveBeenCalledWith('parent-2');
   });
 });

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -17,14 +17,17 @@ vi.mock('@/hooks', async () => {
   const actual = await vi.importActual('@/hooks');
   return {
     ...actual,
-    useConfirmModal: () => ({
-      openConfirmModal: openConfirmModalMock,
-    }),
     useDeleteAdminCategory: () => ({
       deleteCategory: deleteCategoryMock,
     }),
   };
 });
+
+vi.mock('@/hooks/useConfirmModal', () => ({
+  useConfirmModal: () => ({
+    openConfirmModal: openConfirmModalMock,
+  }),
+}));
 
 vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({ isDark: false }),

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -57,6 +57,26 @@ describe('Page: AdminCategories', () => {
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
+  it('should fallback to page 1 when URL page param is invalid', () => {
+    window.history.pushState({}, '', '/admin/categories?page=0');
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      totalPages: 0,
+      total: 0,
+    });
+
+    render(<AdminCategories />);
+
+    expect(useAdminCategoriesPageMock).toHaveBeenCalledWith({
+      page: 1,
+      limit: 10,
+      search: '',
+    });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+  });
+
   it('should update URL params when user searches and changes page', async () => {
     const user = userEvent.setup();
     window.history.pushState({}, '', '/admin/categories?page=3');
@@ -187,5 +207,80 @@ describe('Page: AdminCategories', () => {
     });
 
     expect(deleteCategoryMock).toHaveBeenCalledWith('parent-2');
+  });
+
+  it('should show delete error message when mutation rejects with Error', async () => {
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-2',
+          title: 'Accessories',
+          imageUrl: null,
+          description: 'Category without children',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-14T12:00:00Z',
+          updatedAt: '2025-10-15T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 1,
+    });
+    deleteCategoryMock.mockRejectedValue(new Error('Category is in use'));
+
+    render(<AdminCategories />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete Accessories' }),
+    );
+
+    const modalConfig = openConfirmModalMock.mock.calls.at(-1)?.[0];
+
+    await act(async () => {
+      await modalConfig.onConfirm();
+    });
+
+    expect(
+      await screen.findByText('Failed to delete category'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Category is in use')).toBeInTheDocument();
+  });
+
+  it('should show fallback delete error message when mutation rejects with non-Error value', async () => {
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-2',
+          title: 'Accessories',
+          imageUrl: null,
+          description: 'Category without children',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-14T12:00:00Z',
+          updatedAt: '2025-10-15T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 1,
+    });
+    deleteCategoryMock.mockRejectedValue('boom');
+
+    render(<AdminCategories />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete Accessories' }),
+    );
+
+    const modalConfig = openConfirmModalMock.mock.calls.at(-1)?.[0];
+
+    await act(async () => {
+      await modalConfig.onConfirm();
+    });
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
   });
 });

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
+
+import { AdminCategories } from './AdminCategories';
+
+const useAdminCategoriesPageMock = vi.fn();
+
+vi.mock('@/hooks/useAdminCategoriesPage', () => ({
+  useAdminCategoriesPage: (...args: unknown[]) =>
+    useAdminCategoriesPageMock(...args),
+}));
+
+describe('Page: AdminCategories', () => {
+  it('should read page from URL params', () => {
+    window.history.pushState({}, '', '/admin/categories?page=2');
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      totalPages: 5,
+    });
+
+    render(<AdminCategories />);
+
+    expect(useAdminCategoriesPageMock).toHaveBeenCalledWith({
+      page: 2,
+      limit: 10,
+      search: '',
+    });
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should update URL params when user searches and changes page', async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, '', '/admin/categories?page=3');
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      totalPages: 5,
+    });
+
+    render(<AdminCategories />);
+
+    await user.type(screen.getByRole('textbox'), 'tv');
+
+    expect(window.location.search).toContain('page=1');
+    expect(window.location.search).not.toContain('search=');
+    expect(screen.getByRole('textbox')).toHaveValue('tv');
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+
+    expect(window.location.search).toContain('page=2');
+    expect(window.location.search).not.toContain('search=');
+  });
+
+  it('should reset page to 1 when current page has no items but categories exist', async () => {
+    window.history.pushState({}, '', '/admin/categories?page=100');
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      totalPages: 5,
+      total: 20,
+    });
+
+    render(<AdminCategories />);
+
+    await waitFor(() => {
+      expect(window.location.search).toContain('page=1');
+    });
+  });
+});

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -10,14 +10,13 @@ import {
   SearchInput,
   TableCategories,
 } from '@/components';
+import { ADMIN_PAGE_LIMIT } from '@/constants';
 import { useDeleteAdminCategory } from '@/hooks';
 import { useAdminCategoriesPage } from '@/hooks/useAdminCategoriesPage';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useTheme } from '@/hooks/useTheme';
 import type { Category } from '@/types';
-
-const LIMIT = 10;
 
 export function AdminCategories() {
   const { isDark } = useTheme();
@@ -31,12 +30,12 @@ export function AdminCategories() {
   const pageFromParams = Number(searchParams.get('page'));
   const currentPage =
     Number.isInteger(pageFromParams) && pageFromParams > 0 ? pageFromParams : 1;
-  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+  const debouncedSearch = useDebouncedValue(search.trim(), 500);
 
   const { categories, loading, error, totalPages, total } =
     useAdminCategoriesPage({
       page: currentPage,
-      limit: LIMIT,
+      limit: ADMIN_PAGE_LIMIT,
       search: debouncedSearch,
     });
 

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import clsx from 'clsx';
+import { AlertCircle } from 'lucide-react';
 
 import {
   AdminPageHeader,
@@ -8,14 +10,23 @@ import {
   SearchInput,
   TableCategories,
 } from '@/components';
+import { useDeleteAdminCategory } from '@/hooks';
 import { useAdminCategoriesPage } from '@/hooks/useAdminCategoriesPage';
+import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useTheme } from '@/hooks/useTheme';
+import type { Category } from '@/types';
 
 const LIMIT = 10;
 
 export function AdminCategories() {
+  const { isDark } = useTheme();
+  const { openConfirmModal } = useConfirmModal();
+  const { deleteCategory } = useDeleteAdminCategory();
   const [searchParams, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState('');
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const pageFromParams = Number(searchParams.get('page'));
   const currentPage =
@@ -61,6 +72,31 @@ export function AdminCategories() {
     }
   }, [categories.length, currentPage, loading, total, updateSearchParams]);
 
+  const handleDeleteCategory = (category: Category) => {
+    setDeleteError(null);
+
+    openConfirmModal({
+      title: 'Delete Category',
+      description: `Delete category "${category.title}"? Products will remain without this category.`,
+      isCritical: true,
+      confirmText: 'Delete',
+      onConfirm: async () => {
+        try {
+          setDeletingId(category.id);
+          await deleteCategory(category.id);
+        } catch (error) {
+          setDeleteError(
+            error instanceof Error
+              ? error.message
+              : 'Failed to delete category',
+          );
+        } finally {
+          setDeletingId(null);
+        }
+      },
+    });
+  };
+
   return (
     <div>
       <AdminPageHeader />
@@ -82,7 +118,34 @@ export function AdminCategories() {
           </div>
         </div>
 
-        <TableCategories items={categories} loading={loading} error={error} />
+        {deleteError ? (
+          <div className="px-5 pt-5">
+            <div
+              className={clsx(
+                'mx-auto flex max-w-md items-center gap-3 rounded-lg border p-4',
+                {
+                  'border-red-900/50 bg-red-950/30 text-red-300': isDark,
+                  'border-red-200 bg-red-50 text-red-800': !isDark,
+                },
+              )}
+              role="alert"
+            >
+              <AlertCircle className="h-6 w-6 shrink-0" />
+              <div className="text-left">
+                <p className="font-medium">Failed to delete category</p>
+                <p className="text-sm">{deleteError}</p>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <TableCategories
+          items={categories}
+          loading={loading}
+          error={error}
+          deletingId={deletingId}
+          onDelete={handleDeleteCategory}
+        />
 
         <Pagination
           currentPage={currentPage}

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -1,3 +1,6 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
 import {
   AdminPageHeader,
   Button,
@@ -5,10 +8,58 @@ import {
   SearchInput,
   TableCategories,
 } from '@/components';
-import { useAdminCategories } from '@/hooks/useAdminCategories';
+import { useAdminCategoriesPage } from '@/hooks/useAdminCategoriesPage';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+
+const LIMIT = 10;
 
 export function AdminCategories() {
-  const { categories, loading, error } = useAdminCategories();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState('');
+
+  const pageFromParams = Number(searchParams.get('page'));
+  const currentPage =
+    Number.isInteger(pageFromParams) && pageFromParams > 0 ? pageFromParams : 1;
+  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+
+  const { categories, loading, error, totalPages, total } =
+    useAdminCategoriesPage({
+      page: currentPage,
+      limit: LIMIT,
+      search: debouncedSearch,
+    });
+
+  const updateSearchParams = useCallback(
+    (updater: (params: URLSearchParams) => void) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        updater(next);
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const handlePageChange = (nextPage: number) => {
+    updateSearchParams((next) => {
+      next.set('page', String(nextPage));
+    });
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    updateSearchParams((next) => {
+      next.set('page', '1');
+    });
+  };
+
+  useEffect(() => {
+    if (!loading && currentPage > 1 && total > 0 && categories.length === 0) {
+      updateSearchParams((next) => {
+        next.set('page', '1');
+      });
+    }
+  }, [categories.length, currentPage, loading, total, updateSearchParams]);
 
   return (
     <div>
@@ -23,13 +74,21 @@ export function AdminCategories() {
       <div className="mx-2 my-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] pb-4 shadow-md md:mx-5">
         <div className="flex items-center justify-end gap-4 border-b border-[#e5e7eb] p-4">
           <div className="flex items-center gap-4">
-            <SearchInput value="" onChange={() => {}} placeholder="Search" />
+            <SearchInput
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search"
+            />
           </div>
         </div>
 
         <TableCategories items={categories} loading={loading} error={error} />
 
-        <Pagination currentPage={1} totalPages={5} onPageChange={() => {}} />
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages || 1}
+          onPageChange={handlePageChange}
+        />
       </div>
     </div>
   );

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -10,7 +10,7 @@ import {
   SortProductsDropdown,
   TableProducts,
 } from '@/components';
-import { ROUTES } from '@/constants';
+import { ADMIN_PAGE_LIMIT, ROUTES } from '@/constants';
 import { useAdminProducts } from '@/hooks/useAdminProduct';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
@@ -20,8 +20,6 @@ import { useAdminProductsStore } from '@/store/useAdminProductsStore';
 import { type ProductsFilters } from '@/types/filters';
 import type { SortValue } from '@/types/productsSort';
 import { buildSortValue, parseSortValue } from '@/utils/sorting';
-
-const LIMIT = 10;
 
 export function AdminProducts() {
   const navigate = useNavigate();
@@ -39,13 +37,13 @@ export function AdminProducts() {
   const [showFilters, setShowFilters] = useState(false);
 
   // debounce for product search
-  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+  const debouncedSearch = useDebouncedValue(search.trim(), 500);
   const { duplicateProduct } = useDuplicate();
   const { deleteProduct } = useDeleteAdminProduct();
 
   const { items, loading, error, totalPages } = useAdminProducts({
     page: currentPage,
-    limit: LIMIT,
+    limit: ADMIN_PAGE_LIMIT,
     search: debouncedSearch,
     filters,
     sort,

--- a/src/services/graphql/categoryAdminService.ts
+++ b/src/services/graphql/categoryAdminService.ts
@@ -22,6 +22,21 @@ export const GET_CATEGORIES_LIST = gql`
   ${CATEGORY_FIELDS}
 `;
 
+export const GET_CATEGORIES_PAGE = gql`
+  query GetCategoriesPage($limit: Int!, $page: Int!, $search: String) {
+    categoriesPage(limit: $limit, page: $page, search: $search) {
+      total
+      totalPages
+      page
+      limit
+      items {
+        ...CategoryFields
+      }
+    }
+  }
+  ${CATEGORY_FIELDS}
+`;
+
 export const GET_CATEGORY = gql`
   query GetCategory($id: ID!) {
     category(id: $id) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,6 +4,7 @@ export {
   CREATE_CATEGORY,
   DELETE_CATEGORY,
   GET_CATEGORIES_LIST,
+  GET_CATEGORIES_PAGE,
   GET_CATEGORY,
   UPDATE_CATEGORY,
 } from './graphql/categoryAdminService';

--- a/src/types/category.types.ts
+++ b/src/types/category.types.ts
@@ -9,6 +9,14 @@ export interface Category {
   updatedAt: string;
 }
 
+export interface CategoriesPageResult {
+  total: number;
+  totalPages: number;
+  page: number;
+  limit: number;
+  items: Category[];
+}
+
 export interface CreateCategoryInput {
   title: string;
   depth: 1 | 2;


### PR DESCRIPTION
This PR improves the admin categories page by adding search and pagination support, and by implementing the category delete flow.

### Changes:
- add category search on the admin categories page;
- add pagination for categories list;
- add delete action with confirmation modal;
- disable delete for categories that have subcategories;
- show delete error message if request fails;
- update tests for categories page and categories table.

### Notes:
- delete flow is UI-ready on the client side;
- final behavior depends on backend rules for category deletion and cleanup.