### PR TITLE
feat(218): add component orderCard with test and types

### DIFF
--- a/src/components/OrderCard/OrderCard.constants.ts
+++ b/src/components/OrderCard/OrderCard.constants.ts
@@ -1,0 +1,20 @@
+import type { Order } from '@/types/order.types';
+
+export const STATUS_LABELS: Record<Order['status'], string> = {
+  new: 'New',
+  processing: 'In progress',
+  shipping: 'In progress',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+export const IN_PROGRESS_STATUSES = new Set<Order['status']>([
+  'processing',
+  'shipping',
+]);
+
+export const PENDING_STATUSES = new Set<Order['status']>([
+  'new',
+  'processing',
+  'shipping',
+]);

--- a/src/components/OrderCard/OrderCard.mock.ts
+++ b/src/components/OrderCard/OrderCard.mock.ts
@@ -1,0 +1,32 @@
+import type { Order } from '@/types/order.types';
+
+export const MOCK_ORDERS: Order[] = [
+  {
+    id: '1',
+    orderNumber: '#3456_768',
+    createdAt: 'December 1, 2025',
+    status: 'shipping',
+    totalPrice: 1234.0,
+  },
+  {
+    id: '2',
+    orderNumber: '#3456_980',
+    createdAt: 'October 11, 2023',
+    status: 'completed',
+    totalPrice: 345.0,
+  },
+  {
+    id: '3',
+    orderNumber: '#3456_230',
+    createdAt: 'April 13, 2023',
+    status: 'cancelled',
+    totalPrice: 120.0,
+  },
+  {
+    id: '4',
+    orderNumber: '#3456_120',
+    createdAt: 'January 14, 2023',
+    status: 'processing',
+    totalPrice: 50.0,
+  },
+];

--- a/src/components/OrderCard/OrderCard.test.tsx
+++ b/src/components/OrderCard/OrderCard.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Order } from '@/types/order.types';
+import { render, screen, userEvent } from '@/utils/test-utils';
+
+import { OrderCard } from './OrderCard';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockOrderDelivered: Order = {
+  id: '1',
+  orderNumber: '#3456_980',
+  createdAt: 'October 11, 2023',
+  status: 'completed',
+  totalPrice: 345.0,
+};
+
+const mockOrderInProgress: Order = {
+  id: '2',
+  orderNumber: '#3456_768',
+  createdAt: 'December 1, 2025',
+  status: 'shipping',
+  totalPrice: 1234.0,
+};
+
+const mockOrderPending: Order = {
+  id: '3',
+  orderNumber: '#3456_120',
+  createdAt: 'January 14, 2023',
+  status: 'new',
+  totalPrice: 50.0,
+};
+
+describe('UI Component: OrderCard', () => {
+  it('should render order number and price', () => {
+    render(<OrderCard order={mockOrderDelivered} />);
+
+    expect(screen.getByText('#3456_980')).toBeInTheDocument();
+    expect(screen.getByText('$345.00')).toBeInTheDocument();
+  });
+
+  it('should render correct status label', () => {
+    render(<OrderCard order={mockOrderDelivered} />);
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('should render date without Exp. prefix for completed order', () => {
+    render(<OrderCard order={mockOrderDelivered} />);
+
+    expect(screen.getByText('October 11, 2023')).toBeInTheDocument();
+  });
+
+  it('should render date with Exp. prefix for pending order', () => {
+    render(<OrderCard order={mockOrderPending} />);
+
+    expect(screen.getByText('Exp. January 14, 2023')).toBeInTheDocument();
+  });
+
+  it('should render date with Exp. prefix for in progress order', () => {
+    render(<OrderCard order={mockOrderInProgress} />);
+
+    expect(screen.getByText('Exp. December 1, 2025')).toBeInTheDocument();
+  });
+
+  it('should render — when createdAt is undefined', () => {
+    render(
+      <OrderCard order={{ ...mockOrderDelivered, createdAt: undefined }} />,
+    );
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('should show Details button inline for non-progress orders', () => {
+    render(<OrderCard order={mockOrderDelivered} />);
+
+    expect(screen.getByText('Details')).toBeInTheDocument();
+  });
+
+  it('should show Details button centered for in progress orders', () => {
+    render(<OrderCard order={mockOrderInProgress} />);
+
+    const button = screen.getByText('Details').closest('button');
+    expect(button).toBeInTheDocument();
+    expect(button?.closest('.justify-center')).toBeInTheDocument();
+  });
+
+  it('should navigate to order details on Details click', async () => {
+    const user = userEvent.setup();
+    render(<OrderCard order={mockOrderDelivered} />);
+
+    await user.click(screen.getByText('Details'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/order/1');
+  });
+
+  it('should show In progress label for shipping status', () => {
+    render(<OrderCard order={mockOrderInProgress} />);
+
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+  });
+});

--- a/src/components/OrderCard/OrderCard.tsx
+++ b/src/components/OrderCard/OrderCard.tsx
@@ -1,0 +1,78 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+import { Button } from '@/components/Button';
+import type { Order } from '@/types/order.types';
+
+import {
+  IN_PROGRESS_STATUSES,
+  PENDING_STATUSES,
+  STATUS_LABELS,
+} from './OrderCard.constants';
+// import { OrderProgressBar } from '@/components/OrderProgressBar/OrderProgressBar';
+
+interface OrderCardProps {
+  order: Order;
+}
+
+const formatDate = (date: string | undefined, status: Order['status']) => {
+  if (!date) return '—';
+  return PENDING_STATUSES.has(status) ? `Exp. ${date}` : date;
+};
+
+export const OrderCard = ({ order }: OrderCardProps) => {
+  const { id, orderNumber, createdAt, status, totalPrice } = order;
+  const navigate = useNavigate();
+
+  const isInProgress = IN_PROGRESS_STATUSES.has(status);
+
+  const handleDetails = () => navigate(`/order/${id}`);
+
+  return (
+    <div className="border-b border-[rgb(var(--color-border,226,226,226))] py-6 last:border-b-0 dark:border-gray-700">
+      <div className="flex flex-wrap items-center gap-4">
+        <span className="w-32 shrink-0 text-sm text-[rgb(var(--color-text))]">
+          {orderNumber}
+        </span>
+
+        <span className="w-36 shrink-0 text-sm text-[rgb(var(--color-text))]">
+          {formatDate(createdAt, status)}
+        </span>
+
+        <span className="w-28 shrink-0 text-sm font-medium text-[rgb(var(--color-text))]">
+          {STATUS_LABELS[status]}
+        </span>
+
+        <span className="flex-1 text-sm font-semibold text-[rgb(var(--color-text))]">
+          ${totalPrice.toFixed(2)}
+        </span>
+
+        {!isInProgress && (
+          <Button
+            onClick={handleDetails}
+            className="flex items-center gap-2 rounded-md bg-[rgb(var(--color-bg-sec-inverted))] px-5 py-2.5 text-sm font-medium text-[rgb(var(--color-text-inverted))] transition-all duration-200 hover:opacity-80 active:scale-95"
+          >
+            Details
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      {isInProgress && (
+        <div className="mt-6">
+          {/* <OrderProgressBar currentStep={status as ProgressStep} /> */}
+
+          <div className="mt-5 flex justify-center">
+            <Button
+              onClick={handleDetails}
+              className="flex items-center gap-2 rounded-md bg-[rgb(var(--color-bg-sec-inverted))] px-5 py-2.5 text-sm font-medium text-[rgb(var(--color-text-inverted))] transition-colors duration-200 hover:opacity-80 active:scale-95"
+            >
+              Details
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/OrderCard/index.ts
+++ b/src/components/OrderCard/index.ts
@@ -1,0 +1,1 @@
+export { OrderCard as default, OrderCard } from './OrderCard';

--- a/src/types/order.types.ts
+++ b/src/types/order.types.ts
@@ -1,0 +1,15 @@
+export type OrderStatus =
+  | 'new'
+  | 'processing'
+  | 'shipping'
+  | 'completed'
+  | 'cancelled';
+export type ProgressStep = 'processed' | 'shipped' | 'completed';
+
+export interface Order {
+  id: string;
+  orderNumber: string;
+  createdAt?: string;
+  status: OrderStatus;
+  totalPrice: number;
+}


### PR DESCRIPTION
Implemented reusable `OrderCard` component for the user profile orders history page.
- Added `OrderCard` component that displays order number, date, status and total price
- Added `order.types.ts` 
- Added `OrderCard.constants.ts` with status labels
- Added `OrderCard.mock.ts` for local testing until API is ready
- Added unit tests covering render
- Date shows `Exp.` prefix for `new`, `processing`, `shipping` statuses

Note
- Mock data in `OrderCard.mock.ts` to be replaced once `GET /orders` endpoint is ready