### PR TITLE
Feat/233 users page layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
 import { EditProduct } from './pages/Admin/EditProduct/EditProduct';
 import { AdminProducts } from './pages/Admin/Products/AdminProducts';
 import { AdminSettings } from './pages/Admin/Settings/AdminSettings';
+import { AdminUsers } from './pages/Admin/Users/AdminUsers';
 import { Cart, ContactUs, NotFound, Shop } from './pages/Mocks';
 
 function App() {
@@ -26,6 +27,7 @@ function App() {
     ADMIN,
     ADMIN_CATEGORIES,
     ADMIN_PRODUCTS,
+    ADMIN_USERS,
     ADMIN_SETTING,
     ADMIN_PRODUCT_CREATE,
     ADMIN_PRODUCT_EDIT,
@@ -54,6 +56,7 @@ function App() {
           <Route path={ADMIN} element={<AdminLayout />}>
             <Route path={ADMIN_CATEGORIES} element={<AdminCategories />} />
             <Route path={ADMIN_PRODUCTS} element={<AdminProducts />} />
+            <Route path={ADMIN_USERS} element={<AdminUsers />} />
             <Route path={ADMIN_SETTING} element={<AdminSettings />} />
             <Route path={ADMIN_PRODUCT_CREATE} element={<CreateProduct />} />
             <Route path={ADMIN_PRODUCT_EDIT} element={<EditProduct />} />

--- a/src/components/Features/Features.tsx
+++ b/src/components/Features/Features.tsx
@@ -7,42 +7,46 @@ import {
 } from 'lucide-react';
 
 interface FeatureItem {
+  id: string;
   icon: LucideIcon;
   title: string;
   description: string;
 }
 const featuresData: FeatureItem[] = [
   {
+    id: 'shipping',
     icon: Truck,
     title: 'Free Shipping',
     description: 'Order above $200',
   },
   {
+    id: 'money-back',
     icon: Banknote,
     title: 'Money-back',
     description: '30 days guarantee',
   },
   {
+    id: 'secure',
     icon: Lock,
     title: 'Secure Payments',
     description: 'Secured by Stripe',
   },
   {
+    id: 'support',
     icon: PhoneCall,
     title: '24/7 Support',
     description: 'Phone and Email support',
   },
 ];
-
 export const Features: React.FC = () => {
   return (
     <section className="px-4 py-8 lg:px-16">
       <div className="grid grid-cols-2 gap-2 md:grid-cols-4 md:gap-6">
-        {featuresData.map((feature, index) => {
+        {featuresData.map((feature) => {
           const Icon = feature.icon;
           return (
             <div
-              key={index}
+              key={feature.id}
               className="flex flex-col items-start gap-3 bg-gray-100 px-4 py-6 md:gap-4 md:px-8 md:py-12"
             >
               <Icon

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   LogOut,
   PackageIcon,
   SettingsIcon,
+  UsersIcon,
 } from 'lucide-react';
 
 import { Button } from '@/components/Button';
@@ -19,6 +20,7 @@ const SIDEBAR_LINKS = [
     label: 'Categories',
     icon: <ChartBarStacked />,
   },
+  { to: ROUTES.ADMIN_USERS, label: 'Users', icon: <UsersIcon /> },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings', icon: <SettingsIcon /> },
 ];
 

--- a/src/components/UsersTable/UsersTable.test.tsx
+++ b/src/components/UsersTable/UsersTable.test.tsx
@@ -1,0 +1,72 @@
+import type { HTMLAttributes } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type * as LucideIcons from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockUsers } from '@/constants/mockUsers';
+
+import { UsersTable } from './UsersTable';
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof LucideIcons>();
+  return {
+    ...actual,
+    EllipsisVertical: (props: HTMLAttributes<HTMLDivElement>) => (
+      <div data-testid="ellipsis" {...props} />
+    ),
+    Pencil: (props: HTMLAttributes<HTMLDivElement>) => (
+      <div data-testid="pencil" {...props} />
+    ),
+    Trash: (props: HTMLAttributes<HTMLDivElement>) => (
+      <div data-testid="trash" {...props} />
+    ),
+  };
+});
+
+describe('UsersTable', () => {
+  const mockUpdate = vi.fn();
+
+  it('renders "No users found" when list is empty', () => {
+    render(<UsersTable items={[]} onUpdateUser={mockUpdate} />);
+    expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+  });
+
+  it('renders user information correctly', () => {
+    render(<UsersTable items={mockUsers} onUpdateUser={mockUpdate} />);
+
+    const firstUser = mockUsers[0];
+    const fullName = `${firstUser.firstName} ${firstUser.lastName}`;
+
+    expect(screen.getByText(fullName)).toBeInTheDocument();
+    expect(screen.getByText(firstUser.email)).toBeInTheDocument();
+  });
+
+  it('opens action menu and interacts with buttons', () => {
+    render(<UsersTable items={mockUsers} onUpdateUser={mockUpdate} />);
+
+    const firstUser = mockUsers[0];
+    const menuBtn = screen.getByLabelText(
+      new RegExp(`actions for ${firstUser.firstName}`, 'i'),
+    );
+
+    fireEvent.click(menuBtn);
+
+    const editBtn = screen.getByText(/edit/i);
+    const deleteBtn = screen.getByText(/delete/i);
+
+    expect(editBtn).toBeInTheDocument();
+    expect(deleteBtn).toBeInTheDocument();
+
+    fireEvent.click(editBtn);
+  });
+
+  it('renders dropdowns for status and role', () => {
+    render(<UsersTable items={mockUsers} onUpdateUser={mockUpdate} />);
+
+    const statusButtons = screen.getAllByRole('combobox', { name: /status/i });
+    const roleButtons = screen.getAllByRole('combobox', { name: /role/i });
+
+    expect(statusButtons.length).toBeGreaterThan(0);
+    expect(roleButtons.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -15,14 +15,14 @@ interface UsersTableProps {
 }
 
 const statusOptions = [
-  { label: 'Active', value: 'Active' },
-  { label: 'Blocked', value: 'Blocked' },
+  { label: 'Active', value: 'active' },
+  { label: 'Blocked', value: 'blocked' },
 ];
 
 const roleOptions = [
-  { label: 'Super Admin', value: 'Super Admin' },
-  { label: 'Admin', value: 'Admin' },
-  { label: 'Customer', value: 'Customer' },
+  { label: 'Super Admin', value: 'super_admin' },
+  { label: 'Admin', value: 'admin' },
+  { label: 'Customer', value: 'customer' },
 ];
 
 const getFullName = (user: AdminUser) => `${user.firstName} ${user.lastName}`;
@@ -34,24 +34,25 @@ const getActivityLabel = (date: string) => {
   return `${diffDays} days ago`;
 };
 
-const getStatusDropdownValue = (isActive: boolean) =>
-  isActive ? 'Active' : 'Blocked';
-
-const getRoleDropdownValue = (role: AdminUser['role']) => {
-  switch (role) {
-    case 'super_admin':
-      return 'Super Admin';
-    case 'admin':
-      return 'Admin';
-    case 'customer':
-      return 'Customer';
-    default:
-      return 'Customer';
-  }
-};
-
 export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
   const [openedMenuId, setOpenedMenuId] = useState<string | null>(null);
+
+  const handleStatusChange = (
+    userId: string,
+    selected: { value: string }[],
+  ) => {
+    const newValue = selected[0]?.value;
+    if (newValue) {
+      onUpdateUser(userId, 'isActive', newValue === 'active');
+    }
+  };
+
+  const handleRoleChange = (userId: string, selected: { value: string }[]) => {
+    const newValue = selected[0]?.value;
+    if (newValue) {
+      onUpdateUser(userId, 'role', newValue);
+    }
+  };
 
   if (!items.length) {
     return (
@@ -81,8 +82,8 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
         </thead>
         <tbody className="bg-white [&_td]:px-4 [&_td]:py-4">
           {items.map((user) => {
-            const currentStatus = getStatusDropdownValue(user.isActive);
-            const currentRole = getRoleDropdownValue(user.role);
+            const currentStatus = user.isActive ? 'active' : 'blocked';
+            const currentRole = user.role;
 
             return (
               <tr key={user.id} className="text-[rgb(var(--color-text))]">
@@ -106,18 +107,12 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                     labelClassName="hidden"
                     options={statusOptions}
                     selectedValues={[currentStatus]}
-                    onChange={(selected) => {
-                      const newValue = selected[0]?.value;
-
-                      if (newValue === 'Active') {
-                        onUpdateUser(user.id, 'isActive', true);
-                        return;
-                      }
-
-                      if (newValue === 'Blocked') {
-                        onUpdateUser(user.id, 'isActive', false);
-                      }
-                    }}
+                    onChange={(selected) =>
+                      handleStatusChange(
+                        user.id,
+                        selected as { value: string }[],
+                      )
+                    }
                     placeholder="Status"
                     multiple={false}
                     hasBorder={true}
@@ -127,7 +122,7 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                         '!flex !items-center !justify-between',
                         '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !shadow-none hover:!bg-white',
                         '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
-                        currentStatus === 'Active'
+                        currentStatus === 'active'
                           ? '!text-[#38CB89]'
                           : '!text-[#EF4444]',
                       )
@@ -143,23 +138,9 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                     labelClassName="hidden"
                     options={roleOptions}
                     selectedValues={[currentRole]}
-                    onChange={(selected) => {
-                      const newValue = selected[0]?.value;
-
-                      if (newValue === 'Super Admin') {
-                        onUpdateUser(user.id, 'role', 'super_admin');
-                        return;
-                      }
-
-                      if (newValue === 'Admin') {
-                        onUpdateUser(user.id, 'role', 'admin');
-                        return;
-                      }
-
-                      if (newValue === 'Customer') {
-                        onUpdateUser(user.id, 'role', 'customer');
-                      }
-                    }}
+                    onChange={(selected) =>
+                      handleRoleChange(user.id, selected as { value: string }[])
+                    }
                     placeholder="Role"
                     multiple={false}
                     hasBorder={true}

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -16,7 +16,7 @@ interface UsersTableProps {
 
 const statusOptions = [
   { label: 'Active', value: 'Active' },
-  { label: 'Block', value: 'Block' },
+  { label: 'Blocked', value: 'Blocked' },
 ];
 
 const roleOptions = [
@@ -35,7 +35,7 @@ const getActivityLabel = (date: string) => {
 };
 
 const getStatusDropdownValue = (isActive: boolean) =>
-  isActive ? 'Active' : 'Block';
+  isActive ? 'Active' : 'Blocked';
 
 const getRoleDropdownValue = (role: AdminUser['role']) => {
   switch (role) {
@@ -79,7 +79,6 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
             <th className="w-[80px]"></th>
           </tr>
         </thead>
-
         <tbody className="bg-white [&_td]:px-4 [&_td]:py-4">
           {items.map((user) => {
             const currentStatus = getStatusDropdownValue(user.isActive);
@@ -90,13 +89,11 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                 <td>
                   <div className="flex items-center gap-3">
                     <Checkbox className="h-[20px] w-[20px]" />
-
                     <img
                       src={user.avatarUrl}
                       alt={getFullName(user)}
                       className="h-10 w-10 rounded-full object-cover"
                     />
-
                     <span className="text-sm font-medium text-[#2C2C2C]">
                       {getFullName(user)}
                     </span>
@@ -106,17 +103,19 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                 <td>
                   <Dropdown
                     label="Status"
-                    labelClassName=" hidden"
+                    labelClassName="hidden"
                     options={statusOptions}
                     selectedValues={[currentStatus]}
                     onChange={(selected) => {
                       const newValue = selected[0]?.value;
-                      if (newValue) {
-                        onUpdateUser(
-                          user.id,
-                          'isActive',
-                          newValue === 'Active',
-                        );
+
+                      if (newValue === 'Active') {
+                        onUpdateUser(user.id, 'isActive', true);
+                        return;
+                      }
+
+                      if (newValue === 'Blocked') {
+                        onUpdateUser(user.id, 'isActive', false);
                       }
                     }}
                     placeholder="Status"
@@ -126,7 +125,7 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                       ' ' +
                       clsx(
                         '!flex !items-center !justify-between',
-                        '!h-8 !min-w-[106px] !rounded-full !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !shadow-none hover:!bg-white',
+                        '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !shadow-none hover:!bg-white',
                         '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
                         currentStatus === 'Active'
                           ? '!text-[#38CB89]'
@@ -141,17 +140,24 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                 <td>
                   <Dropdown
                     label="Role"
-                    labelClassName=" hidden"
+                    labelClassName="hidden"
                     options={roleOptions}
                     selectedValues={[currentRole]}
                     onChange={(selected) => {
                       const newValue = selected[0]?.value;
-                      if (newValue) {
-                        let mappedRole: AdminUser['role'] = 'customer';
-                        if (newValue === 'Super Admin')
-                          mappedRole = 'super_admin';
-                        if (newValue === 'Admin') mappedRole = 'admin';
-                        onUpdateUser(user.id, 'role', mappedRole);
+
+                      if (newValue === 'Super Admin') {
+                        onUpdateUser(user.id, 'role', 'super_admin');
+                        return;
+                      }
+
+                      if (newValue === 'Admin') {
+                        onUpdateUser(user.id, 'role', 'admin');
+                        return;
+                      }
+
+                      if (newValue === 'Customer') {
+                        onUpdateUser(user.id, 'role', 'customer');
                       }
                     }}
                     placeholder="Role"
@@ -161,7 +167,7 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
                       ' ' +
                       clsx(
                         '!flex !items-center !justify-between',
-                        '!h-8 !min-w-[112px] !rounded-full !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
+                        '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
                         '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
                       )
                     }

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import { EllipsisVertical, Pencil, Trash } from 'lucide-react';
+
+import { Button, Checkbox, Dropdown } from '@/components';
+import type { AdminUser } from '@/types/admin-user.types';
+
+interface UsersTableProps {
+  items: AdminUser[];
+  onUpdateUser: (
+    userId: string,
+    field: 'role' | 'isActive',
+    value: string | boolean,
+  ) => void;
+}
+
+const statusOptions = [
+  { label: 'Active', value: 'Active' },
+  { label: 'Block', value: 'Block' },
+];
+
+const roleOptions = [
+  { label: 'Super Admin', value: 'Super Admin' },
+  { label: 'Admin', value: 'Admin' },
+  { label: 'Customer', value: 'Customer' },
+];
+
+const getFullName = (user: AdminUser) => `${user.firstName} ${user.lastName}`;
+
+const getActivityLabel = (date: string) => {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const diffDays = Math.max(1, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+
+  return `${diffDays} days ago`;
+};
+
+const getStatusDropdownValue = (isActive: boolean) =>
+  isActive ? 'Active' : 'Block';
+
+const getRoleDropdownValue = (role: AdminUser['role']) => {
+  switch (role) {
+    case 'super_admin':
+      return 'Super Admin';
+    case 'admin':
+      return 'Admin';
+    case 'customer':
+      return 'Customer';
+    default:
+      return 'Customer';
+  }
+};
+
+export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
+  const [openedMenuId, setOpenedMenuId] = useState<string | null>(null);
+
+  if (!items.length) {
+    return (
+      <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white p-8 text-center text-[#8A92A6] shadow-md">
+        No users found
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white shadow-md">
+      <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#E5E7EB] [&_thead_th]:border-b [&_thead_th]:border-[#E5E7EB] [&_thead_th]:px-4">
+        <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
+          <tr>
+            <th className="w-[250px] text-left">
+              <div className="flex items-center gap-2">
+                <Checkbox className="h-[20px] w-[20px]" />
+                <span>User</span>
+              </div>
+            </th>
+            <th className="text-left">Status</th>
+            <th className="text-left">Email</th>
+            <th className="text-left">Role</th>
+            <th className="text-left">Activity</th>
+            <th className="w-[80px]"></th>
+          </tr>
+        </thead>
+
+        <tbody className="bg-white [&_td]:px-4 [&_td]:py-4">
+          {items.map((user) => {
+            const currentStatus = getStatusDropdownValue(user.isActive);
+            const currentRole = getRoleDropdownValue(user.role);
+
+            return (
+              <tr key={user.id} className="text-[rgb(var(--color-text))]">
+                <td>
+                  <div className="flex items-center gap-3">
+                    <Checkbox className="h-[20px] w-[20px]" />
+
+                    <img
+                      src={user.avatarUrl}
+                      alt={getFullName(user)}
+                      className="h-10 w-10 rounded-full object-cover"
+                    />
+
+                    <span className="text-sm font-medium text-[#2C2C2C]">
+                      {getFullName(user)}
+                    </span>
+                  </div>
+                </td>
+
+                <td>
+                  <Dropdown
+                    label="Status"
+                    labelClassName=" hidden"
+                    options={statusOptions}
+                    selectedValues={[currentStatus]}
+                    onChange={(selected) => {
+                      const newValue = selected[0]?.value;
+                      if (newValue) {
+                        onUpdateUser(
+                          user.id,
+                          'isActive',
+                          newValue === 'Active',
+                        );
+                      }
+                    }}
+                    placeholder="Status"
+                    multiple={false}
+                    hasBorder={true}
+                    selectClassName={
+                      ' ' +
+                      clsx(
+                        '!flex !items-center !justify-between',
+                        '!h-8 !min-w-[106px] !rounded-full !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !shadow-none hover:!bg-white',
+                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+                        currentStatus === 'Active'
+                          ? '!text-[#38CB89]'
+                          : '!text-[#EF4444]',
+                      )
+                    }
+                  />
+                </td>
+
+                <td className="text-sm text-[#525252]">{user.email}</td>
+
+                <td>
+                  <Dropdown
+                    label="Role"
+                    labelClassName=" hidden"
+                    options={roleOptions}
+                    selectedValues={[currentRole]}
+                    onChange={(selected) => {
+                      const newValue = selected[0]?.value;
+                      if (newValue) {
+                        let mappedRole: AdminUser['role'] = 'customer';
+                        if (newValue === 'Super Admin')
+                          mappedRole = 'super_admin';
+                        if (newValue === 'Admin') mappedRole = 'admin';
+                        onUpdateUser(user.id, 'role', mappedRole);
+                      }
+                    }}
+                    placeholder="Role"
+                    multiple={false}
+                    hasBorder={true}
+                    selectClassName={
+                      ' ' +
+                      clsx(
+                        '!flex !items-center !justify-between',
+                        '!h-8 !min-w-[112px] !rounded-full !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
+                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+                      )
+                    }
+                  />
+                </td>
+
+                <td className="text-sm text-[#525252]">
+                  {getActivityLabel(user.updatedAt)}
+                </td>
+
+                <td className="relative">
+                  <Button
+                    type="button"
+                    aria-label={`Actions for ${getFullName(user)}`}
+                    className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
+                    onClick={() =>
+                      setOpenedMenuId((prev) =>
+                        prev === user.id ? null : user.id,
+                      )
+                    }
+                  >
+                    <EllipsisVertical className="h-5 w-5" />
+                  </Button>
+
+                  {openedMenuId === user.id && (
+                    <>
+                      <div
+                        className="fixed inset-0 z-10"
+                        onClick={() => setOpenedMenuId(null)}
+                      />
+                      <div className="absolute top-12 right-0 z-20 w-[140px] rounded-xl border border-[#E5E7EB] bg-white shadow-lg">
+                        <Button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-none bg-transparent px-4 py-3 text-left text-sm text-[#2C2C2C] hover:bg-[#F9FAFB]"
+                        >
+                          <Pencil className="h-4 w-4" />
+                          Edit
+                        </Button>
+
+                        <div className="mx-3 border-t border-[#E5E7EB]" />
+
+                        <Button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-none bg-transparent px-4 py-3 text-left text-sm text-[#DB162D] hover:bg-[#F9FAFB]"
+                        >
+                          <Trash className="h-4 w-4" />
+                          Delete
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/UsersTable/index.ts
+++ b/src/components/UsersTable/index.ts
@@ -1,0 +1,1 @@
+export { UsersTable } from './UsersTable';

--- a/src/components/UsersToolbar/UsersToolbar.test.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.test.tsx
@@ -1,0 +1,186 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type * as LucideIcons from 'lucide-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UsersToolbar } from './UsersToolbar';
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof LucideIcons>();
+  return {
+    ...actual,
+    UserPlus: () => <div data-testid="user-plus-icon" />,
+  };
+});
+
+vi.mock('@/components', () => ({
+  Button: ({
+    children,
+    onClick,
+    type,
+    className,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    type?: 'button' | 'submit' | 'reset';
+    className?: string;
+  }) => (
+    <button type={type} onClick={onClick} className={className}>
+      {children}
+    </button>
+  ),
+
+  SearchInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="search-input"
+      value={value}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+
+  Dropdown: ({
+    label,
+    options,
+    selectedValues,
+    onChange,
+    placeholder,
+  }: {
+    label: string;
+    options: { label: string; value: string }[];
+    selectedValues: string[];
+    onChange: (selected: { label: string; value: string }[]) => void;
+    placeholder?: string;
+  }) => (
+    <div>
+      <label>{label}</label>
+      <select
+        aria-label={label}
+        data-testid={`dropdown-${label.toLowerCase()}`}
+        value={selectedValues[0] ?? ''}
+        onChange={(e) => {
+          const selectedOption = options.find(
+            (option) => option.value === e.target.value,
+          );
+
+          onChange(selectedOption ? [selectedOption] : []);
+        }}
+      >
+        <option value="">{placeholder}</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+describe('UsersToolbar', () => {
+  const defaultProps = {
+    searchValue: '',
+    setSearchValue: vi.fn(),
+    statusFilter: 'all',
+    setStatusFilter: vi.fn(),
+    roleFilter: 'all',
+    setRoleFilter: vi.fn(),
+    statusOptions: [
+      { label: 'All', value: 'all' },
+      { label: 'Active', value: 'active' },
+    ],
+    roleOptions: [
+      { label: 'All Roles', value: 'all' },
+      { label: 'Admin', value: 'admin' },
+    ],
+    onCreateUser: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders search input, create button and both dropdowns', () => {
+    render(<UsersToolbar {...defaultProps} />);
+
+    expect(screen.getByTestId('search-input')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /create user/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('user-plus-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('dropdown-status')).toBeInTheDocument();
+    expect(screen.getByTestId('dropdown-role')).toBeInTheDocument();
+  });
+
+  it('passes searchValue to SearchInput', () => {
+    render(<UsersToolbar {...defaultProps} searchValue="john" />);
+
+    expect(screen.getByTestId('search-input')).toHaveValue('john');
+  });
+
+  it('calls setSearchValue when typing in search input', () => {
+    render(<UsersToolbar {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'test user' },
+    });
+
+    expect(defaultProps.setSearchValue).toHaveBeenCalledTimes(1);
+    expect(defaultProps.setSearchValue).toHaveBeenCalledWith('test user');
+  });
+
+  it('calls onCreateUser when create button is clicked', () => {
+    render(<UsersToolbar {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create user/i }));
+
+    expect(defaultProps.onCreateUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls setStatusFilter when status dropdown changes', () => {
+    render(<UsersToolbar {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId('dropdown-status'), {
+      target: { value: 'active' },
+    });
+
+    expect(defaultProps.setStatusFilter).toHaveBeenCalledTimes(1);
+    expect(defaultProps.setStatusFilter).toHaveBeenCalledWith('active');
+  });
+
+  it('calls setRoleFilter when role dropdown changes', () => {
+    render(<UsersToolbar {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId('dropdown-role'), {
+      target: { value: 'admin' },
+    });
+
+    expect(defaultProps.setRoleFilter).toHaveBeenCalledTimes(1);
+    expect(defaultProps.setRoleFilter).toHaveBeenCalledWith('admin');
+  });
+
+  it('uses current selected status value', () => {
+    render(<UsersToolbar {...defaultProps} statusFilter="active" />);
+
+    expect(screen.getByTestId('dropdown-status')).toHaveValue('active');
+  });
+
+  it('uses current selected role value', () => {
+    render(<UsersToolbar {...defaultProps} roleFilter="admin" />);
+
+    expect(screen.getByTestId('dropdown-role')).toHaveValue('admin');
+  });
+
+  it('does not fail if onCreateUser is not provided', () => {
+    render(<UsersToolbar {...defaultProps} onCreateUser={undefined} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create user/i }));
+  });
+});

--- a/src/components/UsersToolbar/UsersToolbar.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.tsx
@@ -11,16 +11,12 @@ type FilterOption = {
 interface UsersToolbarProps {
   searchValue: string;
   setSearchValue: (value: string) => void;
-
   statusFilter: string;
   setStatusFilter: (value: string) => void;
-
   roleFilter: string;
   setRoleFilter: (value: string) => void;
-
   statusOptions: FilterOption[];
   roleOptions: FilterOption[];
-
   onCreateUser?: () => void;
 }
 
@@ -35,18 +31,6 @@ export function UsersToolbar({
   roleOptions,
   onCreateUser,
 }: UsersToolbarProps) {
-  const getStatusDisplayValue = (val: string) => {
-    if (val === 'all') return 'All';
-    const option = statusOptions.find((opt) => opt.value === val);
-    return option ? option.label : 'All';
-  };
-
-  const getRoleDisplayValue = (val: string) => {
-    if (val === 'all') return 'All Role';
-    const option = roleOptions.find((opt) => opt.value === val);
-    return option ? option.label : 'All Role';
-  };
-
   return (
     <div className="mb-6 flex flex-col gap-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -55,7 +39,6 @@ export function UsersToolbar({
           onChange={setSearchValue}
           placeholder="Search"
         />
-
         <Button
           type="button"
           onClick={onCreateUser}
@@ -65,14 +48,13 @@ export function UsersToolbar({
           Create user
         </Button>
       </div>
-
       <div className="flex flex-wrap gap-4">
         <Dropdown
           label="Status"
           labelClassName="sr-only"
           options={statusOptions}
-          selectedValues={[getStatusDisplayValue(statusFilter)]}
-          onChange={(selected) => setStatusFilter(selected[0]?.value ?? 'all')}
+          selectedValues={[statusFilter]}
+          onChange={(selected) => setStatusFilter(selected[0]?.value ?? 'All')}
           placeholder="All"
           multiple={false}
           hasBorder={false}
@@ -85,21 +67,22 @@ export function UsersToolbar({
             )
           }
         />
-
         <Dropdown
           label="Role"
           labelClassName="sr-only"
           options={roleOptions}
-          selectedValues={[getRoleDisplayValue(roleFilter)]}
-          onChange={(selected) => setRoleFilter(selected[0]?.value ?? 'all')}
-          placeholder="All Role"
+          selectedValues={[roleFilter]}
+          onChange={(selected) =>
+            setRoleFilter(selected[0]?.value ?? 'All Roles')
+          }
+          placeholder="All Roles"
           multiple={false}
           hasBorder={false}
           selectClassName={
             ' ' +
             clsx(
               '!flex !items-center !justify-between',
-              '!h-10 !min-w-[120px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
+              '!h-10 !min-w-[140px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
               '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
             )
           }

--- a/src/components/UsersToolbar/UsersToolbar.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.tsx
@@ -1,0 +1,110 @@
+import clsx from 'clsx';
+import { UserPlus } from 'lucide-react';
+
+import { Button, Dropdown, SearchInput } from '@/components';
+
+type FilterOption = {
+  label: string;
+  value: string;
+};
+
+interface UsersToolbarProps {
+  searchValue: string;
+  setSearchValue: (value: string) => void;
+
+  statusFilter: string;
+  setStatusFilter: (value: string) => void;
+
+  roleFilter: string;
+  setRoleFilter: (value: string) => void;
+
+  statusOptions: FilterOption[];
+  roleOptions: FilterOption[];
+
+  onCreateUser?: () => void;
+}
+
+export function UsersToolbar({
+  searchValue,
+  setSearchValue,
+  statusFilter,
+  setStatusFilter,
+  roleFilter,
+  setRoleFilter,
+  statusOptions,
+  roleOptions,
+  onCreateUser,
+}: UsersToolbarProps) {
+  const getStatusDisplayValue = (val: string) => {
+    if (val === 'all') return 'All';
+    const option = statusOptions.find((opt) => opt.value === val);
+    return option ? option.label : 'All';
+  };
+
+  const getRoleDisplayValue = (val: string) => {
+    if (val === 'all') return 'All Role';
+    const option = roleOptions.find((opt) => opt.value === val);
+    return option ? option.label : 'All Role';
+  };
+
+  return (
+    <div className="mb-6 flex flex-col gap-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <SearchInput
+          value={searchValue}
+          onChange={setSearchValue}
+          placeholder="Search"
+        />
+
+        <Button
+          type="button"
+          onClick={onCreateUser}
+          className="flex h-[48px] items-center gap-2 rounded-xl bg-[#1D4ED8] px-6 text-sm font-medium text-white hover:bg-[#1E40AF]"
+        >
+          <UserPlus className="h-[18px] w-[18px]" />
+          Create user
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        <Dropdown
+          label="Status"
+          labelClassName="sr-only"
+          options={statusOptions}
+          selectedValues={[getStatusDisplayValue(statusFilter)]}
+          onChange={(selected) => setStatusFilter(selected[0]?.value ?? 'all')}
+          placeholder="All"
+          multiple={false}
+          hasBorder={false}
+          selectClassName={
+            ' ' +
+            clsx(
+              '!flex !items-center !justify-between',
+              '!h-10 !min-w-[100px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
+              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+            )
+          }
+        />
+
+        <Dropdown
+          label="Role"
+          labelClassName="sr-only"
+          options={roleOptions}
+          selectedValues={[getRoleDisplayValue(roleFilter)]}
+          onChange={(selected) => setRoleFilter(selected[0]?.value ?? 'all')}
+          placeholder="All Role"
+          multiple={false}
+          hasBorder={false}
+          selectClassName={
+            ' ' +
+            clsx(
+              '!flex !items-center !justify-between',
+              '!h-10 !min-w-[120px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
+              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+            )
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/UsersToolbar/index.ts
+++ b/src/components/UsersToolbar/index.ts
@@ -1,0 +1,1 @@
+export { UsersToolbar } from './UsersToolbar';

--- a/src/components/UsersTopWidgets/UsersTopWidgets.test.tsx
+++ b/src/components/UsersTopWidgets/UsersTopWidgets.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UsersTopWidgets } from './UsersTopWidgets';
+
+describe('UsersTopWidgets', () => {
+  it('displays correct numeric values and labels', () => {
+    render(
+      <UsersTopWidgets totalUsers={150} activeAdmins={15} blockedUsers={7} />,
+    );
+
+    expect(screen.getByText('150')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+
+    expect(screen.getByText(/total users/i)).toBeInTheDocument();
+    expect(screen.getByText(/active admins/i)).toBeInTheDocument();
+    expect(screen.getByText(/blocked accounts/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/UsersTopWidgets/UsersTopWidgets.tsx
+++ b/src/components/UsersTopWidgets/UsersTopWidgets.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx';
+
+interface UsersTopWidgetsProps {
+  totalUsers: number;
+  activeAdmins: number;
+  blockedUsers: number;
+}
+
+const widgetItems = [
+  { id: 'total-users', label: 'Total Users', valueKey: 'totalUsers' },
+  { id: 'active-admins', label: 'Active Admins', valueKey: 'activeAdmins' },
+  {
+    id: 'blocked-accounts',
+    label: 'Blocked Accounts',
+    valueKey: 'blockedUsers',
+  },
+] as const;
+
+export function UsersTopWidgets({
+  totalUsers,
+  activeAdmins,
+  blockedUsers,
+}: UsersTopWidgetsProps) {
+  const values = {
+    totalUsers,
+    activeAdmins,
+    blockedUsers,
+  };
+
+  return (
+    <div className="mb-6 grid grid-cols-1 md:grid-cols-3">
+      {widgetItems.map((item, index) => (
+        <div
+          key={item.id}
+          className={clsx(
+            'flex flex-col items-center justify-center py-6',
+            index !== widgetItems.length - 1 &&
+              'md:border-r md:border-[#D9D9D9]',
+          )}
+        >
+          <p className="m-0 text-6xl font-medium text-[#2C2C2C]">
+            {values[item.valueKey]}
+          </p>
+          <p className="text-sm font-medium text-[#BDBDBD]">{item.label}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/UsersTopWidgets/index.ts
+++ b/src/components/UsersTopWidgets/index.ts
@@ -1,0 +1,1 @@
+export { UsersTopWidgets } from './UsersTopWidgets';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,3 +25,6 @@ export { SortRadioItem } from './SortProducts/SortRadioItem/SortRadioItem';
 export { TableCategories } from './TableCategories/TableCategories';
 export { TableProducts } from './TableProducts/TableProducts';
 export { TextArea } from './TextArea';
+export { UsersTable } from './UsersTable';
+export { UsersToolbar } from './UsersToolbar';
+export { UsersTopWidgets } from './UsersTopWidgets';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,6 +14,7 @@ export const ROUTES = {
   ADMIN: '/admin',
   ADMIN_CATEGORIES: '/admin/categories',
   ADMIN_PRODUCTS: '/admin/products',
+  ADMIN_USERS: '/admin/users',
   ADMIN_SETTING: '/admin/setting',
   ADMIN_PRODUCT_CREATE: '/admin/products/create',
   ADMIN_PRODUCT_EDIT: '/admin/products/:id',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,4 +48,6 @@ export const AUTH_ROLES = {
 
 export const NEW_ARRIVALS_LIMIT = 10;
 
+export const ITEMS_PER_PAGE = 10;
+
 export * from './theme';

--- a/src/constants/mockUsers.ts
+++ b/src/constants/mockUsers.ts
@@ -1,0 +1,100 @@
+import type { AdminUser } from '@/types/admin-user.types';
+
+export const mockUsers: AdminUser[] = [
+  {
+    id: '69b93ba7b300b74fd87e6489',
+    firstName: 'Super',
+    lastName: 'Admin',
+    email: 'superadmin@admin.com',
+    role: 'super_admin',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&h=200&fit=crop',
+    createdAt: '2026-03-17T11:31:51.737Z',
+    updatedAt: '2026-03-17T11:31:51.737Z',
+  },
+  {
+    id: '69b93ba7b300b74fd87e648c',
+    firstName: 'Admin',
+    lastName: 'User',
+    email: 'admin@admin.com',
+    role: 'admin',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop',
+    createdAt: '2026-03-17T11:31:51.971Z',
+    updatedAt: '2026-03-17T11:31:51.971Z',
+  },
+  {
+    id: '69b93ba8b300b74fd87e6490',
+    firstName: 'Test',
+    lastName: 'Customer',
+    email: 'customer@test.com',
+    role: 'customer',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&h=200&fit=crop',
+    createdAt: '2026-03-16T10:20:00.000Z',
+    updatedAt: '2026-03-16T10:20:00.000Z',
+  },
+  {
+    id: 'u4',
+    firstName: 'Andrew',
+    lastName: 'Bojangles',
+    email: 'example1@gmail.com',
+    role: 'admin',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?w=200&h=200&fit=crop',
+    createdAt: '2026-03-15T09:15:00.000Z',
+    updatedAt: '2026-03-15T09:15:00.000Z',
+  },
+  {
+    id: 'u5',
+    firstName: 'Andrew',
+    lastName: 'Bojangles',
+    email: 'example2@gmail.com',
+    role: 'customer',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=200&h=200&fit=crop',
+    createdAt: '2026-03-14T12:00:00.000Z',
+    updatedAt: '2026-03-14T12:00:00.000Z',
+  },
+  {
+    id: 'u6',
+    firstName: 'Andrew',
+    lastName: 'Bojangles',
+    email: 'example3@gmail.com',
+    role: 'super_admin',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?w=200&h=200&fit=crop',
+    createdAt: '2026-03-13T08:00:00.000Z',
+    updatedAt: '2026-03-13T08:00:00.000Z',
+  },
+  {
+    id: 'u7',
+    firstName: 'Andrew',
+    lastName: 'Bojangles',
+    email: 'example4@gmail.com',
+    role: 'admin',
+    isActive: true,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=200&h=200&fit=crop',
+    createdAt: '2026-03-12T14:30:00.000Z',
+    updatedAt: '2026-03-12T14:30:00.000Z',
+  },
+  {
+    id: 'u8',
+    firstName: 'Andrew',
+    lastName: 'Bojangles',
+    email: 'example5@gmail.com',
+    role: 'customer',
+    isActive: false,
+    avatarUrl:
+      'https://images.unsplash.com/photo-1504593811423-6dd665756598?w=200&h=200&fit=crop',
+    createdAt: '2026-03-11T16:45:00.000Z',
+    updatedAt: '2026-03-11T16:45:00.000Z',
+  },
+];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAdminCategories';
+export * from './useAdminUsers';
 export * from './useAuth';
 export * from './useCreateAdminCategory';
 export * from './useDeleteAdminCategory';

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
 
+import { ITEMS_PER_PAGE } from '@/constants';
 import { mockUsers } from '@/constants/mockUsers';
-
-const ITEMS_PER_PAGE = 10;
 
 export const useAdminUsers = () => {
   const [users, setUsers] = useState(mockUsers);

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react';
+
+import { mockUsers } from '@/constants/mockUsers';
+
+const ITEMS_PER_PAGE = 10;
+
+export const useAdminUsers = () => {
+  const [users, setUsers] = useState(mockUsers);
+  const [searchValue, setSearchValue] = useState('');
+  const [statusFilter, setStatusFilter] = useState('All');
+  const [roleFilter, setRoleFilter] = useState('All Roles');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalUsers = users.length;
+
+  const activeAdmins = users.filter(
+    (user) =>
+      (user.role === 'admin' || user.role === 'super_admin') && user.isActive,
+  ).length;
+
+  const blockedUsers = users.filter((user) => !user.isActive).length;
+
+  const totalPages = Math.ceil(users.length / ITEMS_PER_PAGE) || 1;
+
+  // TODO: implement filtering and search logic in a separate task
+  // Currently pagination is applied to the full users list
+  const paginatedUsers = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+
+    return users.slice(startIndex, endIndex);
+  }, [currentPage, users]);
+
+  const handleUpdateUser = (
+    userId: string,
+    field: 'role' | 'isActive',
+    newValue: string | boolean,
+  ) => {
+    setUsers((prevUsers) =>
+      prevUsers.map((user) =>
+        user.id === userId ? { ...user, [field]: newValue } : user,
+      ),
+    );
+  };
+
+  return {
+    searchValue,
+    setSearchValue,
+    statusFilter,
+    setStatusFilter,
+    roleFilter,
+    setRoleFilter,
+    currentPage,
+    setCurrentPage,
+    totalUsers,
+    activeAdmins,
+    blockedUsers,
+    totalPages,
+    paginatedUsers,
+    handleUpdateUser,
+  };
+};

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -1,64 +1,41 @@
-import { useMemo, useState } from 'react';
-
 import {
   Pagination,
   UsersTable,
   UsersToolbar,
   UsersTopWidgets,
 } from '@/components';
-import { mockUsers } from '@/constants/mockUsers';
-
-const ITEMS_PER_PAGE = 10;
+import { useAdminUsers } from '@/hooks';
 
 const statusOptions = [
-  { label: 'All', value: 'all' },
-  { label: 'Active', value: 'active' },
-  { label: 'Blocked', value: 'blocked' },
+  { label: 'All', value: 'All' },
+  { label: 'Active', value: 'Active' },
+  { label: 'Blocked', value: 'Blocked' },
 ];
 
 const roleOptions = [
-  { label: 'All Role', value: 'all' },
-  { label: 'Super Admin', value: 'super_admin' },
-  { label: 'Admin', value: 'admin' },
-  { label: 'Customer', value: 'customer' },
+  { label: 'All Roles', value: 'All Roles' },
+  { label: 'Super Admin', value: 'Super Admin' },
+  { label: 'Admin', value: 'Admin' },
+  { label: 'Customer', value: 'Customer' },
 ];
 
 export const AdminUsers = () => {
-  const [users, setUsers] = useState(mockUsers);
-  const [searchValue, setSearchValue] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [roleFilter, setRoleFilter] = useState('all');
-  const [currentPage, setCurrentPage] = useState(1);
-
-  const totalUsers = users.length;
-
-  const activeAdmins = users.filter(
-    (user) =>
-      (user.role === 'admin' || user.role === 'super_admin') && user.isActive,
-  ).length;
-
-  const blockedUsers = users.filter((user) => !user.isActive).length;
-
-  const totalPages = Math.ceil(users.length / ITEMS_PER_PAGE);
-
-  const paginatedUsers = useMemo(() => {
-    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-    const endIndex = startIndex + ITEMS_PER_PAGE;
-
-    return users.slice(startIndex, endIndex);
-  }, [currentPage, users]);
-
-  const handleUpdateUser = (
-    userId: string,
-    field: 'role' | 'isActive',
-    newValue: string | boolean,
-  ) => {
-    setUsers((prevUsers) =>
-      prevUsers.map((user) =>
-        user.id === userId ? { ...user, [field]: newValue } : user,
-      ),
-    );
-  };
+  const {
+    searchValue,
+    setSearchValue,
+    statusFilter,
+    setStatusFilter,
+    roleFilter,
+    setRoleFilter,
+    currentPage,
+    setCurrentPage,
+    totalUsers,
+    activeAdmins,
+    blockedUsers,
+    totalPages,
+    paginatedUsers,
+    handleUpdateUser,
+  } = useAdminUsers();
 
   return (
     <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">
@@ -68,7 +45,6 @@ export const AdminUsers = () => {
           activeAdmins={activeAdmins}
           blockedUsers={blockedUsers}
         />
-
         <UsersToolbar
           searchValue={searchValue}
           setSearchValue={setSearchValue}
@@ -79,16 +55,12 @@ export const AdminUsers = () => {
           statusOptions={statusOptions}
           roleOptions={roleOptions}
         />
-
         <UsersTable items={paginatedUsers} onUpdateUser={handleUpdateUser} />
-
-        <div className="mx-5 mt-6 flex justify-center">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={setCurrentPage}
-          />
-        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
       </div>
     </section>
   );

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -7,59 +7,47 @@ import {
 import { useAdminUsers } from '@/hooks';
 
 const statusOptions = [
-  { label: 'All', value: 'All' },
-  { label: 'Active', value: 'Active' },
-  { label: 'Blocked', value: 'Blocked' },
+  { label: 'All', value: 'all' },
+  { label: 'Active', value: 'active' },
+  { label: 'Blocked', value: 'blocked' },
 ];
 
 const roleOptions = [
-  { label: 'All Roles', value: 'All Roles' },
-  { label: 'Super Admin', value: 'Super Admin' },
-  { label: 'Admin', value: 'Admin' },
-  { label: 'Customer', value: 'Customer' },
+  { label: 'All Roles', value: 'all' },
+  { label: 'Super Admin', value: 'super_admin' },
+  { label: 'Admin', value: 'admin' },
+  { label: 'Customer', value: 'customer' },
 ];
 
 export const AdminUsers = () => {
-  const {
-    searchValue,
-    setSearchValue,
-    statusFilter,
-    setStatusFilter,
-    roleFilter,
-    setRoleFilter,
-    currentPage,
-    setCurrentPage,
-    totalUsers,
-    activeAdmins,
-    blockedUsers,
-    totalPages,
-    paginatedUsers,
-    handleUpdateUser,
-  } = useAdminUsers();
+  const usersState = useAdminUsers();
 
   return (
     <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">
       <div className="mx-auto">
         <UsersTopWidgets
-          totalUsers={totalUsers}
-          activeAdmins={activeAdmins}
-          blockedUsers={blockedUsers}
+          totalUsers={usersState.totalUsers}
+          activeAdmins={usersState.activeAdmins}
+          blockedUsers={usersState.blockedUsers}
         />
         <UsersToolbar
-          searchValue={searchValue}
-          setSearchValue={setSearchValue}
-          statusFilter={statusFilter}
-          setStatusFilter={setStatusFilter}
-          roleFilter={roleFilter}
-          setRoleFilter={setRoleFilter}
+          searchValue={usersState.searchValue}
+          setSearchValue={usersState.setSearchValue}
+          statusFilter={usersState.statusFilter}
+          setStatusFilter={usersState.setStatusFilter}
+          roleFilter={usersState.roleFilter}
+          setRoleFilter={usersState.setRoleFilter}
           statusOptions={statusOptions}
           roleOptions={roleOptions}
         />
-        <UsersTable items={paginatedUsers} onUpdateUser={handleUpdateUser} />
+        <UsersTable
+          items={usersState.paginatedUsers}
+          onUpdateUser={usersState.handleUpdateUser}
+        />
         <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
+          currentPage={usersState.currentPage}
+          totalPages={usersState.totalPages}
+          onPageChange={usersState.setCurrentPage}
         />
       </div>
     </section>

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from 'react';
+
+import {
+  Pagination,
+  UsersTable,
+  UsersToolbar,
+  UsersTopWidgets,
+} from '@/components';
+import { mockUsers } from '@/constants/mockUsers';
+
+const ITEMS_PER_PAGE = 10;
+
+const statusOptions = [
+  { label: 'All', value: 'all' },
+  { label: 'Active', value: 'active' },
+  { label: 'Blocked', value: 'blocked' },
+];
+
+const roleOptions = [
+  { label: 'All Role', value: 'all' },
+  { label: 'Super Admin', value: 'super_admin' },
+  { label: 'Admin', value: 'admin' },
+  { label: 'Customer', value: 'customer' },
+];
+
+export const AdminUsers = () => {
+  const [users, setUsers] = useState(mockUsers);
+  const [searchValue, setSearchValue] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalUsers = users.length;
+
+  const activeAdmins = users.filter(
+    (user) =>
+      (user.role === 'admin' || user.role === 'super_admin') && user.isActive,
+  ).length;
+
+  const blockedUsers = users.filter((user) => !user.isActive).length;
+
+  const totalPages = Math.ceil(users.length / ITEMS_PER_PAGE);
+
+  const paginatedUsers = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+
+    return users.slice(startIndex, endIndex);
+  }, [currentPage, users]);
+
+  const handleUpdateUser = (
+    userId: string,
+    field: 'role' | 'isActive',
+    newValue: string | boolean,
+  ) => {
+    setUsers((prevUsers) =>
+      prevUsers.map((user) =>
+        user.id === userId ? { ...user, [field]: newValue } : user,
+      ),
+    );
+  };
+
+  return (
+    <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">
+      <div className="mx-auto">
+        <UsersTopWidgets
+          totalUsers={totalUsers}
+          activeAdmins={activeAdmins}
+          blockedUsers={blockedUsers}
+        />
+
+        <UsersToolbar
+          searchValue={searchValue}
+          setSearchValue={setSearchValue}
+          statusFilter={statusFilter}
+          setStatusFilter={setStatusFilter}
+          roleFilter={roleFilter}
+          setRoleFilter={setRoleFilter}
+          statusOptions={statusOptions}
+          roleOptions={roleOptions}
+        />
+
+        <UsersTable items={paginatedUsers} onUpdateUser={handleUpdateUser} />
+
+        <div className="mx-5 mt-6 flex justify-center">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/types/admin-user.types.ts
+++ b/src/types/admin-user.types.ts
@@ -1,0 +1,13 @@
+export type UserRole = 'super_admin' | 'admin' | 'customer';
+
+export interface AdminUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: UserRole;
+  isActive: boolean;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
This PR implements the static layout and UI components for the Admin Users page as per task #233. It establishes the page structure, sets up mock data, and prepares the local state for future search and filtering logic (to be implemented in #234).

Implemented Changes:
- Page Layout and Routing: Added the AdminUsers page, registered the /admin/users route in App.tsx, and added the navigation link to the Sidebar.
- Top Widgets: Implemented dynamic statistic cards calculating Total Users, Active Admins, and Blocked Accounts based on the current users array.
- Toolbar: Added the search input and Status/Role dropdowns.
- Users Table: Implemented a table with user avatars, emails, and activity timestamps.
- Pagination :  added a pagination with sliding window logic and ... separators. Currently, it slices the main mock array to display items per page.
- Architecture (useAdminUsers): Extracted all page-level business logic into a dedicated feature hook src/hooks/useAdminUsers.ts to keep the UI component clean and follow separation of concerns.
Resolves https://github.com/UA-5399-React/docs/issues/233
<img width="1911" height="1008" alt="image" src="https://github.com/user-attachments/assets/7df21bda-7906-493a-8697-e9949f15729a" />

