### PR TITLE
fix(224, 215): apply theme to auth layout and add clear button to search input

### DIFF
--- a/src/components/AuthLayout/AuthLayout.tsx
+++ b/src/components/AuthLayout/AuthLayout.tsx
@@ -5,8 +5,8 @@ import duckLogo from '@/assets/images/duck.svg';
 
 export const AuthLayout: React.FC = () => {
   return (
-    <div className="flex min-h-screen w-full flex-col font-sans text-gray-900 lg:flex-row">
-      <div className="flex w-full flex-col items-center justify-center bg-[#f4f5f6] py-12 lg:w-1/2 lg:py-0">
+    <div className="flex min-h-screen w-full flex-col font-sans text-[rgb(var(--color-text))] lg:flex-row">
+      <div className="flex w-full flex-col items-center justify-center bg-[rgb(var(--color-bg-sec))] py-12 lg:w-1/2 lg:py-0">
         <div className="flex flex-col items-center justify-center text-center">
           <img
             src={duckLogo}
@@ -16,7 +16,7 @@ export const AuthLayout: React.FC = () => {
         </div>
       </div>
 
-      <div className="flex w-full flex-1 items-center justify-center bg-white py-12 lg:w-1/2 lg:py-0">
+      <div className="flex w-full flex-1 items-center justify-center bg-[rgb(var(--color-bg))] py-12 lg:w-1/2 lg:py-0">
         <Outlet />
       </div>
     </div>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Search } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 
 type SearchInputProps = {
   value: string;
@@ -46,6 +46,8 @@ export function SearchInput({
     'text-[rgb(var(--color-muted))]': !disabled && !error,
   });
 
+  const showClear = value.length > 0 && !disabled;
+
   return (
     <div className={clsx('relative w-[320px]', className)}>
       <Search
@@ -64,7 +66,8 @@ export function SearchInput({
         aria-invalid={error || undefined}
         className={clsx(
           'box-border h-[44px] w-full rounded-[8px] border',
-          'py-[10px] pr-[14px] pl-[42px]',
+          'py-[10px] pl-[42px]',
+          showClear ? 'pr-[38px]' : 'pr-[14px]',
           'text-[16px] leading-[24px] font-normal',
           'shadow-[0_1px_2px_0_rgb(var(--color-shadow)/0.05)]',
           borderClass,
@@ -72,6 +75,17 @@ export function SearchInput({
           focusClass,
         )}
       />
+
+      {showClear && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label="Clear search"
+          className="absolute top-1/2 right-[12px] -translate-y-1/2 text-[rgb(var(--color-muted))] hover:text-[rgb(var(--color-text))]"
+        >
+          <X size={15} />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Changes

**fix #224 — Theme does not work on Login page**
\`AuthLayout\` was using hardcoded \`bg-[#f4f5f6]\` and \`bg-white\` which don't respond to the dark/light theme. Replaced with CSS variable equivalents (\`--color-bg-sec\` and \`--color-bg\`) so the Login and Register pages now correctly reflect the selected theme.

**feat #215 — Add "Clear" button to search input**
Added an \`×\` button that appears inside \`SearchInput\` when the field has a value. Clicking it calls \`onChange('')\` to reset. Right padding on the input adjusts dynamically to prevent text overlapping the button. Works only when not disabled.

Closes UA-5399-React/docs#224
Closes UA-5399-React/docs#215