### PR TITLE
Feat/234 implement search filter userspage

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -34,10 +34,12 @@ export const Dropdown = ({
       return;
     }
 
-    const values = Array.isArray(value) ? value : [value];
+    const selectedValues = Array.isArray(value) ? value : [value];
 
-    const selected = values
-      .map((v) => options.find((option) => option.value === v))
+    const selected = selectedValues
+      .map((selectedValue) =>
+        options.find((option) => option.value === selectedValue),
+      )
       .filter(Boolean) as DropdownProps['options'];
 
     onChange(selected);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -24,7 +24,7 @@ export const Dropdown = ({
 
   const value = selectedOptions
     ? multiple
-      ? selectedOptions.map((o) => o.value)
+      ? selectedOptions.map((option) => option.value)
       : (selectedOptions[0]?.value ?? null)
     : undefined;
 
@@ -33,10 +33,13 @@ export const Dropdown = ({
       onChange([]);
       return;
     }
-    const vals = Array.isArray(value) ? value : [value];
-    const selected = vals
-      .map((v) => options.find((o) => o.value === v))
+
+    const values = Array.isArray(value) ? value : [value];
+
+    const selected = values
+      .map((v) => options.find((option) => option.value === v))
       .filter(Boolean) as DropdownProps['options'];
+
     onChange(selected);
   };
 
@@ -55,20 +58,24 @@ export const Dropdown = ({
       >
         {label}
       </Field.Label>
+
       <Select.Root
         multiple={multiple}
         onValueChange={handleValueChange}
         value={value}
+        items={options}
       >
         <Select.Trigger
           className={styles.Select + clsx(selectClassName)}
           data-border={hasBorder}
         >
           <Select.Value className={styles.Value} placeholder={placeholder} />
+
           <Select.Icon className={styles.SelectIcon}>
             <ChevronDown className="w-4" />
           </Select.Icon>
         </Select.Trigger>
+
         <Select.Portal>
           <Select.Positioner
             className={styles.Positioner}
@@ -76,15 +83,16 @@ export const Dropdown = ({
             alignItemWithTrigger={false}
           >
             <Select.Popup className={styles.Popup}>
-              {options.map((value) => (
+              {options.map((option) => (
                 <Select.Item
-                  key={value.value}
-                  value={value.value}
+                  key={option.value}
+                  value={option.value}
                   className={styles.Item}
                 >
                   <Select.ItemText className={styles.ItemText}>
-                    {value.label}
+                    {option.label}
                   </Select.ItemText>
+
                   <Select.ItemIndicator className={styles.ItemIndicator}>
                     <Check className={styles.ItemIndicatorIcon} />
                   </Select.ItemIndicator>

--- a/src/components/ProductForm/ProductForm.test.tsx
+++ b/src/components/ProductForm/ProductForm.test.tsx
@@ -81,7 +81,7 @@ describe('Component: ProductForm', () => {
     );
 
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
-      'ACTIVE',
+      /active/i,
     );
 
     expect(screen.getByText(/Last Update:/i)).toBeInTheDocument();

--- a/src/components/UsersTable/UsersTable.test.tsx
+++ b/src/components/UsersTable/UsersTable.test.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import type * as LucideIcons from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -9,6 +9,7 @@ import { UsersTable } from './UsersTable';
 
 vi.mock('lucide-react', async (importOriginal) => {
   const actual = await importOriginal<typeof LucideIcons>();
+
   return {
     ...actual,
     EllipsisVertical: (props: HTMLAttributes<HTMLDivElement>) => (
@@ -28,6 +29,7 @@ describe('UsersTable', () => {
 
   it('renders "No users found" when list is empty', () => {
     render(<UsersTable items={[]} onUpdateUser={mockUpdate} />);
+
     expect(screen.getByText(/no users found/i)).toBeInTheDocument();
   });
 
@@ -37,8 +39,15 @@ describe('UsersTable', () => {
     const firstUser = mockUsers[0];
     const fullName = `${firstUser.firstName} ${firstUser.lastName}`;
 
-    expect(screen.getByText(fullName)).toBeInTheDocument();
-    expect(screen.getByText(firstUser.email)).toBeInTheDocument();
+    const avatar = screen.getByRole('img', { name: fullName });
+    expect(avatar).toBeInTheDocument();
+
+    const row = avatar.closest('tr');
+    expect(row).not.toBeNull();
+
+    expect(
+      within(row as HTMLTableRowElement).getByText(firstUser.email),
+    ).toBeInTheDocument();
   });
 
   it('opens action menu and interacts with buttons', () => {

--- a/src/components/UsersToolbar/UsersToolbar.test.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.test.tsx
@@ -1,11 +1,24 @@
+import type { ComponentProps, ReactNode } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type * as LucideIcons from 'lucide-react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_USER_ROLE_FILTER,
+  DEFAULT_USER_STATUS_FILTER,
+  USER_ROLE_OPTIONS,
+  USER_STATUS_OPTIONS,
+} from '@/constants/adminUsers';
+import type {
+  UserRoleFilter,
+  UserStatusFilter,
+} from '@/types/admin-user.types';
 
 import { UsersToolbar } from './UsersToolbar';
 
 vi.mock('lucide-react', async (importOriginal) => {
   const actual = await importOriginal<typeof LucideIcons>();
+
   return {
     ...actual,
     UserPlus: () => <div data-testid="user-plus-icon" />,
@@ -19,7 +32,7 @@ vi.mock('@/components', () => ({
     type,
     className,
   }: {
-    children: React.ReactNode;
+    children: ReactNode;
     onClick?: () => void;
     type?: 'button' | 'submit' | 'reset';
     className?: string;
@@ -85,22 +98,21 @@ vi.mock('@/components', () => ({
 }));
 
 describe('UsersToolbar', () => {
-  const defaultProps = {
+  const setSearchValue = vi.fn<(value: string) => void>();
+  const setStatusFilter = vi.fn<(value: UserStatusFilter) => void>();
+  const setRoleFilter = vi.fn<(value: UserRoleFilter) => void>();
+  const onCreateUser = vi.fn<() => void>();
+
+  const defaultProps: ComponentProps<typeof UsersToolbar> = {
     searchValue: '',
-    setSearchValue: vi.fn(),
-    statusFilter: 'all',
-    setStatusFilter: vi.fn(),
-    roleFilter: 'all',
-    setRoleFilter: vi.fn(),
-    statusOptions: [
-      { label: 'All', value: 'all' },
-      { label: 'Active', value: 'active' },
-    ],
-    roleOptions: [
-      { label: 'All Roles', value: 'all' },
-      { label: 'Admin', value: 'admin' },
-    ],
-    onCreateUser: vi.fn(),
+    setSearchValue,
+    statusFilter: DEFAULT_USER_STATUS_FILTER,
+    setStatusFilter,
+    roleFilter: DEFAULT_USER_ROLE_FILTER,
+    setRoleFilter,
+    statusOptions: USER_STATUS_OPTIONS.map((option) => ({ ...option })),
+    roleOptions: USER_ROLE_OPTIONS.map((option) => ({ ...option })),
+    onCreateUser,
   };
 
   beforeEach(() => {
@@ -132,8 +144,8 @@ describe('UsersToolbar', () => {
       target: { value: 'test user' },
     });
 
-    expect(defaultProps.setSearchValue).toHaveBeenCalledTimes(1);
-    expect(defaultProps.setSearchValue).toHaveBeenCalledWith('test user');
+    expect(setSearchValue).toHaveBeenCalledTimes(1);
+    expect(setSearchValue).toHaveBeenCalledWith('test user');
   });
 
   it('calls onCreateUser when create button is clicked', () => {
@@ -141,7 +153,13 @@ describe('UsersToolbar', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /create user/i }));
 
-    expect(defaultProps.onCreateUser).toHaveBeenCalledTimes(1);
+    expect(onCreateUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail if onCreateUser is not provided', () => {
+    render(<UsersToolbar {...defaultProps} onCreateUser={undefined} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create user/i }));
   });
 
   it('calls setStatusFilter when status dropdown changes', () => {
@@ -151,8 +169,19 @@ describe('UsersToolbar', () => {
       target: { value: 'active' },
     });
 
-    expect(defaultProps.setStatusFilter).toHaveBeenCalledTimes(1);
-    expect(defaultProps.setStatusFilter).toHaveBeenCalledWith('active');
+    expect(setStatusFilter).toHaveBeenCalledTimes(1);
+    expect(setStatusFilter).toHaveBeenCalledWith('active');
+  });
+
+  it('falls back to default status filter when status is cleared', () => {
+    render(<UsersToolbar {...defaultProps} statusFilter="active" />);
+
+    fireEvent.change(screen.getByTestId('dropdown-status'), {
+      target: { value: '' },
+    });
+
+    expect(setStatusFilter).toHaveBeenCalledTimes(1);
+    expect(setStatusFilter).toHaveBeenCalledWith(DEFAULT_USER_STATUS_FILTER);
   });
 
   it('calls setRoleFilter when role dropdown changes', () => {
@@ -162,8 +191,19 @@ describe('UsersToolbar', () => {
       target: { value: 'admin' },
     });
 
-    expect(defaultProps.setRoleFilter).toHaveBeenCalledTimes(1);
-    expect(defaultProps.setRoleFilter).toHaveBeenCalledWith('admin');
+    expect(setRoleFilter).toHaveBeenCalledTimes(1);
+    expect(setRoleFilter).toHaveBeenCalledWith('admin');
+  });
+
+  it('falls back to default role filter when role is cleared', () => {
+    render(<UsersToolbar {...defaultProps} roleFilter="admin" />);
+
+    fireEvent.change(screen.getByTestId('dropdown-role'), {
+      target: { value: '' },
+    });
+
+    expect(setRoleFilter).toHaveBeenCalledTimes(1);
+    expect(setRoleFilter).toHaveBeenCalledWith(DEFAULT_USER_ROLE_FILTER);
   });
 
   it('uses current selected status value', () => {
@@ -176,11 +216,5 @@ describe('UsersToolbar', () => {
     render(<UsersToolbar {...defaultProps} roleFilter="admin" />);
 
     expect(screen.getByTestId('dropdown-role')).toHaveValue('admin');
-  });
-
-  it('does not fail if onCreateUser is not provided', () => {
-    render(<UsersToolbar {...defaultProps} onCreateUser={undefined} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /create user/i }));
   });
 });

--- a/src/components/UsersToolbar/UsersToolbar.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.tsx
@@ -2,6 +2,14 @@ import clsx from 'clsx';
 import { UserPlus } from 'lucide-react';
 
 import { Button, Dropdown, SearchInput } from '@/components';
+import {
+  DEFAULT_USER_ROLE_FILTER,
+  DEFAULT_USER_STATUS_FILTER,
+} from '@/constants/adminUsers';
+import type {
+  UserRoleFilter,
+  UserStatusFilter,
+} from '@/types/admin-user.types';
 
 type FilterOption = {
   label: string;
@@ -11,10 +19,10 @@ type FilterOption = {
 interface UsersToolbarProps {
   searchValue: string;
   setSearchValue: (value: string) => void;
-  statusFilter: string;
-  setStatusFilter: (value: string) => void;
-  roleFilter: string;
-  setRoleFilter: (value: string) => void;
+  statusFilter: UserStatusFilter;
+  setStatusFilter: (value: UserStatusFilter) => void;
+  roleFilter: UserRoleFilter;
+  setRoleFilter: (value: UserRoleFilter) => void;
   statusOptions: FilterOption[];
   roleOptions: FilterOption[];
   onCreateUser?: () => void;
@@ -54,7 +62,12 @@ export function UsersToolbar({
           labelClassName="sr-only"
           options={statusOptions}
           selectedValues={[statusFilter]}
-          onChange={(selected) => setStatusFilter(selected[0]?.value ?? 'All')}
+          onChange={(selected) =>
+            setStatusFilter(
+              (selected[0]?.value as UserStatusFilter) ??
+                DEFAULT_USER_STATUS_FILTER,
+            )
+          }
           placeholder="All"
           multiple={false}
           hasBorder={false}
@@ -73,7 +86,10 @@ export function UsersToolbar({
           options={roleOptions}
           selectedValues={[roleFilter]}
           onChange={(selected) =>
-            setRoleFilter(selected[0]?.value ?? 'All Roles')
+            setRoleFilter(
+              (selected[0]?.value as UserRoleFilter) ??
+                DEFAULT_USER_ROLE_FILTER,
+            )
           }
           placeholder="All Roles"
           multiple={false}

--- a/src/constants/adminUsers.ts
+++ b/src/constants/adminUsers.ts
@@ -1,0 +1,20 @@
+import type {
+  UserRoleFilter,
+  UserStatusFilter,
+} from '@/types/admin-user.types';
+
+export const DEFAULT_USER_STATUS_FILTER: UserStatusFilter = 'all';
+export const DEFAULT_USER_ROLE_FILTER: UserRoleFilter = 'all';
+
+export const USER_STATUS_OPTIONS = [
+  { label: 'All', value: 'all' },
+  { label: 'Active', value: 'active' },
+  { label: 'Blocked', value: 'blocked' },
+] as const;
+
+export const USER_ROLE_OPTIONS = [
+  { label: 'All Roles', value: 'all' },
+  { label: 'Super Admin', value: 'super_admin' },
+  { label: 'Admin', value: 'admin' },
+  { label: 'Customer', value: 'customer' },
+] as const;

--- a/src/hooks/useAdminUsers.test.ts
+++ b/src/hooks/useAdminUsers.test.ts
@@ -1,0 +1,215 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ITEMS_PER_PAGE } from '@/constants';
+import { mockUsers } from '@/constants/mockUsers';
+
+import { useAdminUsers } from './useAdminUsers';
+
+describe('useAdminUsers', () => {
+  it('returns correct widget values for the full users list', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: '',
+        statusFilter: 'all',
+        roleFilter: 'all',
+      }),
+    );
+
+    const expectedTotalUsers = mockUsers.length;
+    const expectedActiveAdmins = mockUsers.filter(
+      (user) =>
+        (user.role === 'admin' || user.role === 'super_admin') && user.isActive,
+    ).length;
+    const expectedBlockedUsers = mockUsers.filter(
+      (user) => !user.isActive,
+    ).length;
+    const expectedFilteredCount = mockUsers.length;
+    const expectedTotalPages = Math.max(
+      1,
+      Math.ceil(expectedFilteredCount / ITEMS_PER_PAGE),
+    );
+
+    expect(result.current.totalUsers).toBe(expectedTotalUsers);
+    expect(result.current.activeAdmins).toBe(expectedActiveAdmins);
+    expect(result.current.blockedUsers).toBe(expectedBlockedUsers);
+    expect(result.current.filteredUsersCount).toBe(expectedFilteredCount);
+    expect(result.current.totalPages).toBe(expectedTotalPages);
+    expect(result.current.paginatedUsers).toEqual(
+      mockUsers.slice(0, ITEMS_PER_PAGE),
+    );
+  });
+
+  it('filters users by full name, ignoring case and extra spaces', () => {
+    const targetUser = mockUsers[0];
+    const searchValue = `  ${targetUser.firstName.toUpperCase()} ${targetUser.lastName.toUpperCase()}  `;
+
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: searchValue,
+        statusFilter: 'all',
+        roleFilter: 'all',
+      }),
+    );
+
+    const expectedUsers = mockUsers.filter((user) => {
+      const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+      return fullName.includes(
+        `${targetUser.firstName} ${targetUser.lastName}`.toLowerCase(),
+      );
+    });
+
+    expect(result.current.filteredUsersCount).toBe(expectedUsers.length);
+    expect(result.current.paginatedUsers).toEqual(expectedUsers);
+  });
+
+  it('filters users by email', () => {
+    const targetUser = mockUsers[0];
+
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: targetUser.email,
+        statusFilter: 'all',
+        roleFilter: 'all',
+      }),
+    );
+
+    expect(result.current.filteredUsersCount).toBe(1);
+    expect(result.current.paginatedUsers[0].email).toBe(targetUser.email);
+  });
+
+  it('filters users by active status', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: '',
+        statusFilter: 'active',
+        roleFilter: 'all',
+      }),
+    );
+
+    const expectedUsers = mockUsers.filter((user) => user.isActive);
+
+    expect(result.current.filteredUsersCount).toBe(expectedUsers.length);
+    expect(result.current.paginatedUsers).toEqual(
+      expectedUsers.slice(0, ITEMS_PER_PAGE),
+    );
+    expect(result.current.paginatedUsers.every((user) => user.isActive)).toBe(
+      true,
+    );
+  });
+
+  it('filters users by blocked status', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: '',
+        statusFilter: 'blocked',
+        roleFilter: 'all',
+      }),
+    );
+
+    const expectedUsers = mockUsers.filter((user) => !user.isActive);
+
+    expect(result.current.filteredUsersCount).toBe(expectedUsers.length);
+    expect(result.current.paginatedUsers).toEqual(
+      expectedUsers.slice(0, ITEMS_PER_PAGE),
+    );
+    expect(result.current.paginatedUsers.every((user) => !user.isActive)).toBe(
+      true,
+    );
+  });
+
+  it('filters users by role', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: '',
+        statusFilter: 'all',
+        roleFilter: 'admin',
+      }),
+    );
+
+    const expectedUsers = mockUsers.filter((user) => user.role === 'admin');
+
+    expect(result.current.filteredUsersCount).toBe(expectedUsers.length);
+    expect(result.current.paginatedUsers).toEqual(
+      expectedUsers.slice(0, ITEMS_PER_PAGE),
+    );
+    expect(
+      result.current.paginatedUsers.every((user) => user.role === 'admin'),
+    ).toBe(true);
+  });
+
+  it('combines search, status and role filters together', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: 'admin',
+        statusFilter: 'active',
+        roleFilter: 'super_admin',
+      }),
+    );
+
+    const expectedUsers = mockUsers.filter((user) => {
+      const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+      const email = user.email.toLowerCase();
+
+      const matchesSearch =
+        fullName.includes('admin') || email.includes('admin');
+      const matchesStatus = user.isActive;
+      const matchesRole = user.role === 'super_admin';
+
+      return matchesSearch && matchesStatus && matchesRole;
+    });
+
+    expect(result.current.filteredUsersCount).toBe(expectedUsers.length);
+    expect(result.current.paginatedUsers).toEqual(expectedUsers);
+  });
+
+  it('updates user fields through handleUpdateUser', () => {
+    const targetUser = mockUsers.find((user) => user.isActive);
+
+    expect(targetUser).toBeDefined();
+
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: '',
+        statusFilter: 'blocked',
+        roleFilter: 'all',
+      }),
+    );
+
+    const blockedCountBefore = mockUsers.filter(
+      (user) => !user.isActive,
+    ).length;
+
+    act(() => {
+      result.current.handleUpdateUser(targetUser!.id, 'isActive', false);
+    });
+
+    expect(result.current.blockedUsers).toBe(blockedCountBefore + 1);
+    expect(
+      result.current.paginatedUsers.some((user) => user.id === targetUser!.id),
+    ).toBe(true);
+  });
+
+  it('returns empty paginatedUsers when no users match filters', () => {
+    const { result } = renderHook(() =>
+      useAdminUsers({
+        currentPage: 1,
+        search: 'user-that-does-not-exist',
+        statusFilter: 'all',
+        roleFilter: 'all',
+      }),
+    );
+
+    expect(result.current.filteredUsersCount).toBe(0);
+    expect(result.current.paginatedUsers).toEqual([]);
+    expect(result.current.totalPages).toBe(1);
+  });
+});

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -2,13 +2,25 @@ import { useMemo, useState } from 'react';
 
 import { ITEMS_PER_PAGE } from '@/constants';
 import { mockUsers } from '@/constants/mockUsers';
+import type {
+  UserRoleFilter,
+  UserStatusFilter,
+} from '@/types/admin-user.types';
 
-export const useAdminUsers = () => {
+type UseAdminUsersParams = {
+  currentPage: number;
+  search: string;
+  statusFilter: UserStatusFilter;
+  roleFilter: UserRoleFilter;
+};
+
+export const useAdminUsers = ({
+  currentPage,
+  search,
+  statusFilter,
+  roleFilter,
+}: UseAdminUsersParams) => {
   const [users, setUsers] = useState(mockUsers);
-  const [searchValue, setSearchValue] = useState('');
-  const [statusFilter, setStatusFilter] = useState('All');
-  const [roleFilter, setRoleFilter] = useState('All Roles');
-  const [currentPage, setCurrentPage] = useState(1);
 
   const totalUsers = users.length;
 
@@ -19,16 +31,40 @@ export const useAdminUsers = () => {
 
   const blockedUsers = users.filter((user) => !user.isActive).length;
 
-  const totalPages = Math.ceil(users.length / ITEMS_PER_PAGE) || 1;
+  const normalizedSearch = search.trim().toLowerCase();
 
-  // TODO: implement filtering and search logic in a separate task
-  // Currently pagination is applied to the full users list
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => {
+      const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+      const email = user.email.toLowerCase();
+
+      const matchesSearch =
+        !normalizedSearch ||
+        fullName.includes(normalizedSearch) ||
+        email.includes(normalizedSearch);
+
+      const matchesStatus =
+        statusFilter === 'all' ||
+        (statusFilter === 'active' && user.isActive) ||
+        (statusFilter === 'blocked' && !user.isActive);
+
+      const matchesRole = roleFilter === 'all' || user.role === roleFilter;
+
+      return matchesSearch && matchesStatus && matchesRole;
+    });
+  }, [users, normalizedSearch, statusFilter, roleFilter]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredUsers.length / ITEMS_PER_PAGE),
+  );
+
   const paginatedUsers = useMemo(() => {
     const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
     const endIndex = startIndex + ITEMS_PER_PAGE;
 
-    return users.slice(startIndex, endIndex);
-  }, [currentPage, users]);
+    return filteredUsers.slice(startIndex, endIndex);
+  }, [currentPage, filteredUsers]);
 
   const handleUpdateUser = (
     userId: string,
@@ -43,19 +79,12 @@ export const useAdminUsers = () => {
   };
 
   return {
-    searchValue,
-    setSearchValue,
-    statusFilter,
-    setStatusFilter,
-    roleFilter,
-    setRoleFilter,
-    currentPage,
-    setCurrentPage,
     totalUsers,
     activeAdmins,
     blockedUsers,
     totalPages,
     paginatedUsers,
+    filteredUsersCount: filteredUsers.length,
     handleUpdateUser,
   };
 };

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -1,26 +1,153 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
 import {
   Pagination,
   UsersTable,
   UsersToolbar,
   UsersTopWidgets,
 } from '@/components';
+import {
+  DEFAULT_USER_ROLE_FILTER,
+  DEFAULT_USER_STATUS_FILTER,
+  USER_ROLE_OPTIONS,
+  USER_STATUS_OPTIONS,
+} from '@/constants/adminUsers';
 import { useAdminUsers } from '@/hooks';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import type {
+  UserRoleFilter,
+  UserStatusFilter,
+} from '@/types/admin-user.types';
 
-const statusOptions = [
-  { label: 'All', value: 'all' },
-  { label: 'Active', value: 'active' },
-  { label: 'Blocked', value: 'blocked' },
+const USERS_QUERY_PARAMS = {
+  SEARCH: 'search',
+  STATUS: 'status',
+  ROLE: 'role',
+  PAGE: 'page',
+} as const;
+
+const VALID_STATUS_FILTERS: UserStatusFilter[] = ['all', 'active', 'blocked'];
+
+const VALID_ROLE_FILTERS: UserRoleFilter[] = [
+  'all',
+  'super_admin',
+  'admin',
+  'customer',
 ];
 
-const roleOptions = [
-  { label: 'All Roles', value: 'all' },
-  { label: 'Super Admin', value: 'super_admin' },
-  { label: 'Admin', value: 'admin' },
-  { label: 'Customer', value: 'customer' },
-];
+const isValidStatusFilter = (value: string | null): value is UserStatusFilter =>
+  value !== null && VALID_STATUS_FILTERS.includes(value as UserStatusFilter);
+
+const isValidRoleFilter = (value: string | null): value is UserRoleFilter =>
+  value !== null && VALID_ROLE_FILTERS.includes(value as UserRoleFilter);
+
+const getValidPage = (value: string | null) => {
+  const page = Number(value);
+
+  return Number.isInteger(page) && page > 0 ? page : 1;
+};
 
 export const AdminUsers = () => {
-  const usersState = useAdminUsers();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const searchFromParams = searchParams.get(USERS_QUERY_PARAMS.SEARCH) ?? '';
+
+  const statusFromParams = isValidStatusFilter(
+    searchParams.get(USERS_QUERY_PARAMS.STATUS),
+  )
+    ? (searchParams.get(USERS_QUERY_PARAMS.STATUS) as UserStatusFilter)
+    : DEFAULT_USER_STATUS_FILTER;
+
+  const roleFromParams = isValidRoleFilter(
+    searchParams.get(USERS_QUERY_PARAMS.ROLE),
+  )
+    ? (searchParams.get(USERS_QUERY_PARAMS.ROLE) as UserRoleFilter)
+    : DEFAULT_USER_ROLE_FILTER;
+
+  const currentPage = getValidPage(searchParams.get(USERS_QUERY_PARAMS.PAGE));
+
+  const [searchValue, setSearchValue] = useState(searchFromParams);
+  const debouncedSearch = useDebouncedValue(searchValue.trim(), 500);
+
+  useEffect(() => {
+    setSearchValue(searchFromParams);
+  }, [searchFromParams]);
+
+  const updateSearchParams = useCallback(
+    (updater: (params: URLSearchParams) => void) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        updater(next);
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  useEffect(() => {
+    const currentSearchParam =
+      searchParams.get(USERS_QUERY_PARAMS.SEARCH) ?? '';
+
+    if (debouncedSearch === currentSearchParam) {
+      return;
+    }
+
+    updateSearchParams((next) => {
+      if (debouncedSearch) {
+        next.set(USERS_QUERY_PARAMS.SEARCH, debouncedSearch);
+      } else {
+        next.delete(USERS_QUERY_PARAMS.SEARCH);
+      }
+
+      next.set(USERS_QUERY_PARAMS.PAGE, '1');
+    });
+  }, [debouncedSearch, searchParams, updateSearchParams]);
+
+  const handleStatusFilterChange = (value: UserStatusFilter) => {
+    updateSearchParams((next) => {
+      if (value === DEFAULT_USER_STATUS_FILTER) {
+        next.delete(USERS_QUERY_PARAMS.STATUS);
+      } else {
+        next.set(USERS_QUERY_PARAMS.STATUS, value);
+      }
+
+      next.set(USERS_QUERY_PARAMS.PAGE, '1');
+    });
+  };
+
+  const handleRoleFilterChange = (value: UserRoleFilter) => {
+    updateSearchParams((next) => {
+      if (value === DEFAULT_USER_ROLE_FILTER) {
+        next.delete(USERS_QUERY_PARAMS.ROLE);
+      } else {
+        next.set(USERS_QUERY_PARAMS.ROLE, value);
+      }
+
+      next.set(USERS_QUERY_PARAMS.PAGE, '1');
+    });
+  };
+
+  const handlePageChange = (page: number) => {
+    updateSearchParams((next) => {
+      next.set(USERS_QUERY_PARAMS.PAGE, String(page));
+    });
+  };
+
+  const usersState = useAdminUsers({
+    currentPage,
+    search: debouncedSearch,
+    statusFilter: statusFromParams,
+    roleFilter: roleFromParams,
+  });
+
+  useEffect(() => {
+    if (currentPage > usersState.totalPages) {
+      updateSearchParams((next) => {
+        next.set(USERS_QUERY_PARAMS.PAGE, '1');
+      });
+    }
+  }, [currentPage, usersState.totalPages, updateSearchParams]);
 
   return (
     <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">
@@ -30,24 +157,27 @@ export const AdminUsers = () => {
           activeAdmins={usersState.activeAdmins}
           blockedUsers={usersState.blockedUsers}
         />
+
         <UsersToolbar
-          searchValue={usersState.searchValue}
-          setSearchValue={usersState.setSearchValue}
-          statusFilter={usersState.statusFilter}
-          setStatusFilter={usersState.setStatusFilter}
-          roleFilter={usersState.roleFilter}
-          setRoleFilter={usersState.setRoleFilter}
-          statusOptions={statusOptions}
-          roleOptions={roleOptions}
+          searchValue={searchValue}
+          setSearchValue={setSearchValue}
+          statusFilter={statusFromParams}
+          setStatusFilter={handleStatusFilterChange}
+          roleFilter={roleFromParams}
+          setRoleFilter={handleRoleFilterChange}
+          statusOptions={[...USER_STATUS_OPTIONS]}
+          roleOptions={[...USER_ROLE_OPTIONS]}
         />
+
         <UsersTable
           items={usersState.paginatedUsers}
           onUpdateUser={usersState.handleUpdateUser}
         />
+
         <Pagination
-          currentPage={usersState.currentPage}
+          currentPage={currentPage}
           totalPages={usersState.totalPages}
-          onPageChange={usersState.setCurrentPage}
+          onPageChange={handlePageChange}
         />
       </div>
     </section>

--- a/src/types/admin-user.types.ts
+++ b/src/types/admin-user.types.ts
@@ -1,5 +1,8 @@
 export type UserRole = 'super_admin' | 'admin' | 'customer';
 
+export type UserStatusFilter = 'all' | 'active' | 'blocked';
+export type UserRoleFilter = 'all' | UserRole;
+
 export interface AdminUser {
   id: string;
   firstName: string;


### PR DESCRIPTION
- added debounced search by name and email
- added status and role filters
- connected filtering to useAdminUsers
- updated pagination to use filtered users
- synced page/filter/search state with query params
- reset page to 1 on search/filter change
- added handling for invalid page values in URL
- fixed dropdown selected value display to show labels instead of raw values
- added unit tests for hook and toolbar behavior
-
Resolves https://github.com/UA-5399-React/docs/issues/234