### PR TITLE
docs(261): add color usage convention for Tailwind CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ The Button component demonstrates Tailwind utility classes:
 <Button variant="outline">Outline</Button>
 ```
 
+### Color Usage Convention
+
+Preferred by default:
+
+- semantic theme tokens from `tailwind.config.js`, for example `text-primary`
+
+Allowed when a semantic token is not needed:
+
+- standard Tailwind palette classes, for example `text-blue-800`
+
+Avoid arbitrary color values in class names, such as:
+
+- `text-[rgb(var(--color-primary))]`
+- `text-[#3e12ac]`
+
+Rule of thumb:
+
+- prefer semantic tokens when the color has UI meaning
+- use standard Tailwind palette classes when a semantic token is not needed
+- use arbitrary colors only as a rare exception with a strong technical reason
+
 ## 🛠️ Development
 
 ### Install dependencies


### PR DESCRIPTION
Add a short guideline to `README.md` for Tailwind color usage.

The convention should clarify that:
- semantic theme tokens are preferred by default
- standard Tailwind palette classes are allowed when no semantic token is needed
- arbitrary color values should be avoided except for rare technical cases
