### PR TITLE
feat(259): add roled based ui for admin and customer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { LoginForm } from './components';
 import { AdminLayout } from './components/AdminLayout/AdminLayout';
 import { AuthLayout } from './components/AuthLayout';
 import { RegisterForm } from './components/RegisterForm';
-import { ROUTES } from './constants';
+import { AUTH_ROLES, ROUTES } from './constants';
 import { Cart, Home } from './pages';
 import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
@@ -57,10 +57,19 @@ function App() {
             <Route index element={<Navigate to={ADMIN_PRODUCTS} replace />} />
             <Route path={ADMIN_CATEGORIES} element={<AdminCategories />} />
             <Route path={ADMIN_PRODUCTS} element={<AdminProducts />} />
-            <Route path={ADMIN_USERS} element={<AdminUsers />} />
-            <Route path={ADMIN_SETTING} element={<AdminSettings />} />
             <Route path={ADMIN_PRODUCT_CREATE} element={<CreateProduct />} />
             <Route path={ADMIN_PRODUCT_EDIT} element={<EditProduct />} />
+            <Route
+              element={
+                <ProtectedRoute
+                  allowedRoles={[AUTH_ROLES.SUPER_ADMIN]}
+                  redirectTo={ADMIN_PRODUCTS}
+                />
+              }
+            >
+              <Route path={ADMIN_USERS} element={<AdminUsers />} />
+              <Route path={ADMIN_SETTING} element={<AdminSettings />} />
+            </Route>
           </Route>
         </Route>
       </Routes>

--- a/src/components/LoginForm/LoginForm.test.tsx
+++ b/src/components/LoginForm/LoginForm.test.tsx
@@ -133,22 +133,26 @@ describe('Feature: LoginForm', () => {
     });
   });
 
-  it('should redirect to shop for a regular user role', async () => {
+  it('should redirect to shop for a customer role', async () => {
     const user = userEvent.setup();
     mockMutateAsync.mockResolvedValueOnce(true);
-    (authService.getMe as Mock).mockResolvedValueOnce({ role: 'user' }); // Mocking a non-admin role
+    (authService.getMe as Mock).mockResolvedValueOnce({
+      role: AUTH_ROLES.CUSTOMER,
+    });
 
     render(<LoginForm />);
 
     await user.type(
       screen.getByPlaceholderText(/Your email address/i),
-      'user@test.com',
+      'customer@test.com',
     );
     await user.type(screen.getByPlaceholderText(/Password/i), 'password123');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
     await waitFor(() => {
-      expect(localStorage.getItem(MOCK_AUTH.ROLE_KEY)).toBe('user');
+      expect(localStorage.getItem(MOCK_AUTH.ROLE_KEY)).toBe(
+        AUTH_ROLES.CUSTOMER,
+      );
       expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SHOP);
     });
   });

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -6,9 +6,10 @@ import { z } from 'zod';
 
 import { Checkbox } from '@/components';
 import { Input } from '@/components';
-import { AUTH_ROLES, MOCK_AUTH, ROUTES } from '@/constants';
+import { MOCK_AUTH, ROUTES } from '@/constants';
 import { useLogin } from '@/hooks/useLogin';
 import { authService } from '@/services/authService';
+import { canAccessAdminPanel, isAuthRole } from '@/utils/permissions';
 
 const loginSchema = z.object({
   email: z.string().min(1, 'Username or email is required'),
@@ -51,10 +52,11 @@ export const LoginForm: React.FC = () => {
   useEffect(() => {
     const token = localStorage.getItem(MOCK_AUTH.TOKEN_KEY);
     const expires = localStorage.getItem(MOCK_AUTH.EXPIRES_KEY);
-    const role = localStorage.getItem(MOCK_AUTH.ROLE_KEY);
+    const storedRole = localStorage.getItem(MOCK_AUTH.ROLE_KEY);
+    const role = isAuthRole(storedRole) ? storedRole : null;
 
     if (token && expires && Date.now() < Number(expires)) {
-      if (role === AUTH_ROLES.ADMIN || role === AUTH_ROLES.SUPER_ADMIN) {
+      if (canAccessAdminPanel(role)) {
         navigate(ROUTES.ADMIN);
       } else {
         navigate(ROUTES.SHOP);
@@ -74,10 +76,7 @@ export const LoginForm: React.FC = () => {
       localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, expirationTime);
       localStorage.setItem(MOCK_AUTH.ROLE_KEY, user.role);
 
-      if (
-        user.role === AUTH_ROLES.ADMIN ||
-        user.role === AUTH_ROLES.SUPER_ADMIN
-      ) {
+      if (canAccessAdminPanel(isAuthRole(user.role) ? user.role : null)) {
         navigate(ROUTES.ADMIN);
       } else {
         navigate(ROUTES.SHOP);

--- a/src/components/MobileSidebar/MobileSidebar.test.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ROUTES } from '@/constants';
+import { AUTH_ROLES, type AuthRole, ROUTES } from '@/constants';
 import { ThemeProvider } from '@/contexts/ThemeProvider';
 import { useAuth } from '@/hooks/useAuth';
 import { render, screen, userEvent } from '@/utils/test-utils';
@@ -35,8 +35,10 @@ const defaultAuthMock = {
   logout: vi.fn(),
   isAdmin: true,
   isSuperAdmin: false,
+  isCustomer: false,
+  canAccessAdminPanel: true,
   isAuth: true,
-  role: 'admin' as string | null,
+  role: AUTH_ROLES.ADMIN as AuthRole | null,
 };
 
 const defaultProps = {
@@ -88,7 +90,9 @@ describe('UI Component: MobileSidebar', () => {
       screen.getByRole('link', { name: 'Categories' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Products' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Settings' }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Logout/i })).toBeInTheDocument();
   });
 
@@ -128,6 +132,7 @@ describe('UI Component: MobileSidebar', () => {
     vi.mocked(useAuth).mockReturnValue({
       ...defaultAuthMock,
       isAdmin: false,
+      canAccessAdminPanel: true,
       logout: mockLogout,
     });
 
@@ -140,15 +145,30 @@ describe('UI Component: MobileSidebar', () => {
     expect(mockNavigate).toHaveBeenCalledWith(ROUTES.LOGIN);
   });
 
-  it('should render Products and Settings links with correct hrefs', () => {
+  it('should render Products and Categories links with correct hrefs for admin', () => {
     renderWithTheme({ ...defaultProps, isSidebarOpen: true });
 
     const categoriesLink = screen.getByRole('link', { name: 'Categories' });
     const productsLink = screen.getByRole('link', { name: 'Products' });
-    const settingsLink = screen.getByRole('link', { name: 'Settings' });
 
     expect(categoriesLink).toHaveAttribute('href', ROUTES.ADMIN_CATEGORIES);
     expect(productsLink).toHaveAttribute('href', ROUTES.ADMIN_PRODUCTS);
-    expect(settingsLink).toHaveAttribute('href', ROUTES.ADMIN_SETTING);
+  });
+
+  it('should render super admin links when role is super_admin', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...defaultAuthMock,
+      isAdmin: false,
+      isSuperAdmin: true,
+      canAccessAdminPanel: true,
+      role: AUTH_ROLES.SUPER_ADMIN,
+    });
+
+    renderWithTheme({ ...defaultProps, isSidebarOpen: true });
+
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      ROUTES.ADMIN_SETTING,
+    );
   });
 });

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -4,6 +4,7 @@ import { LogOutIcon, MenuIcon, XIcon } from 'lucide-react';
 import { Button } from '@/components';
 import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
+import { canAccessAdminRoute } from '@/utils/permissions';
 
 const MOBILE_LINKS = [
   { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
@@ -20,8 +21,11 @@ export const MobileSidebar = ({
   isSidebarOpen,
   onSidebarChange,
 }: MobileSidebarProps) => {
-  const { logout } = useAuth();
+  const { logout, role } = useAuth();
   const navigate = useNavigate();
+  const visibleLinks = MOBILE_LINKS.filter(({ to }) =>
+    canAccessAdminRoute(role, to),
+  );
 
   const handleLogout = () => {
     logout();
@@ -50,7 +54,7 @@ export const MobileSidebar = ({
 
             <nav className="px-4">
               <ul className="list-none p-0">
-                {MOBILE_LINKS.map(({ to, label }) => (
+                {visibleLinks.map(({ to, label }) => (
                   <li
                     key={to}
                     className="x-4 mt-4 h-[40px] border-b border-gray-200"

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -37,7 +37,12 @@ describe('Feature: ProtectedRoute', () => {
   // Successful scenario
   it('should render <Outlet /> if user is authenticated AND is an admin', () => {
     // Set up the hook as if an admin has logged in
-    (useAuth as Mock).mockReturnValue({ isAuth: true, isAdmin: true });
+    (useAuth as Mock).mockReturnValue({
+      isAuth: true,
+      isAdmin: true,
+      isSuperAdmin: false,
+      role: 'admin',
+    });
 
     render(<ProtectedRoute />);
 
@@ -49,11 +54,12 @@ describe('Feature: ProtectedRoute', () => {
   });
 
   it('should redirect to SHOP if user is authenticated but NOT an admin', () => {
-    // User is logged in but has role user
+    // User is logged in but has customer role
     (useAuth as Mock).mockReturnValue({
       isAuth: true,
       isAdmin: false,
       isSuperAdmin: false,
+      role: 'customer',
     });
 
     render(<ProtectedRoute />);
@@ -73,6 +79,7 @@ describe('Feature: ProtectedRoute', () => {
       isAuth: true,
       isAdmin: false,
       isSuperAdmin: true,
+      role: 'super_admin',
     });
 
     render(<ProtectedRoute />);
@@ -84,7 +91,12 @@ describe('Feature: ProtectedRoute', () => {
   // Failure scenario 2: Not authenticated at all (guest)
   it('should redirect to login if user is NOT authenticated', () => {
     // Neither token nor role
-    (useAuth as Mock).mockReturnValue({ isAuth: false, isAdmin: false });
+    (useAuth as Mock).mockReturnValue({
+      isAuth: false,
+      isAdmin: false,
+      isSuperAdmin: false,
+      role: null,
+    });
 
     render(<ProtectedRoute />);
 
@@ -93,5 +105,26 @@ describe('Feature: ProtectedRoute', () => {
     const navigateElement = screen.getByTestId('mock-navigate');
     expect(navigateElement).toBeInTheDocument();
     expect(navigateElement).toHaveAttribute('data-to', ROUTES.LOGIN);
+  });
+
+  it('should redirect admin away from super_admin-only routes', () => {
+    (useAuth as Mock).mockReturnValue({
+      isAuth: true,
+      isAdmin: true,
+      isSuperAdmin: false,
+      role: 'admin',
+    });
+
+    render(
+      <ProtectedRoute
+        allowedRoles={['super_admin']}
+        redirectTo={ROUTES.ADMIN_PRODUCTS}
+      />,
+    );
+
+    expect(screen.queryByTestId('mock-outlet')).not.toBeInTheDocument();
+
+    const navigateElement = screen.getByTestId('mock-navigate');
+    expect(navigateElement).toHaveAttribute('data-to', ROUTES.ADMIN_PRODUCTS);
   });
 });

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
-import { ROUTES } from '@/constants';
+import { AUTH_ROLES, type AuthRole, ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 
-export const ProtectedRoute: React.FC = () => {
-  const { isAuth, isAdmin, isSuperAdmin } = useAuth();
+interface ProtectedRouteProps {
+  allowedRoles?: AuthRole[];
+  redirectTo?: string;
+}
+
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  allowedRoles = [AUTH_ROLES.ADMIN, AUTH_ROLES.SUPER_ADMIN],
+  redirectTo = ROUTES.SHOP,
+}) => {
+  const { isAuth, role } = useAuth();
 
   if (!isAuth) {
     return <Navigate to={ROUTES.LOGIN} replace />;
   }
 
-  // If the user is authenticated but not an admin or super admin,
-  // they should be redirected to the shop page.
-  // This ensures only authorized users can access routes protected by this component.
-  if (!isAdmin && !isSuperAdmin) {
-    return <Navigate to={ROUTES.SHOP} replace />;
+  if (!role || !allowedRoles.includes(role)) {
+    return <Navigate to={redirectTo} replace />;
   }
 
   return <Outlet />;

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -50,9 +50,9 @@ export const RegisterForm: React.FC = () => {
 
     localStorage.setItem(MOCK_AUTH.TOKEN_KEY, MOCK_AUTH.MOCK_TOKEN);
     localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, expirationTime);
-    localStorage.setItem(MOCK_AUTH.ROLE_KEY, AUTH_ROLES.ADMIN);
+    localStorage.setItem(MOCK_AUTH.ROLE_KEY, AUTH_ROLES.CUSTOMER);
 
-    navigate(ROUTES.ADMIN_PRODUCTS);
+    navigate(ROUTES.SHOP);
   };
 
   return (

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { AUTH_ROLES } from '@/constants';
+import { AUTH_ROLES, type AuthRole } from '@/constants';
 import { ConfirmModalProvider } from '@/contexts/ConfirmModalProvider';
 import { ThemeProvider } from '@/contexts/ThemeProvider';
 import { useAuth } from '@/hooks/useAuth';
@@ -31,7 +31,9 @@ const defaultAuthMock = {
   isAuth: true,
   isAdmin: true,
   isSuperAdmin: false,
-  role: AUTH_ROLES.ADMIN as string | null,
+  isCustomer: false,
+  canAccessAdminPanel: true,
+  role: AUTH_ROLES.ADMIN as AuthRole | null,
 };
 
 const renderWithProviders = (ui: React.ReactElement) =>
@@ -48,6 +50,22 @@ describe('UI Component: Sidebar', () => {
 
     expect(screen.getByText('Categories')).toBeInTheDocument();
     expect(screen.getByText('Products')).toBeInTheDocument();
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+  });
+
+  it('should render super admin links for super_admin role', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...defaultAuthMock,
+      isAdmin: false,
+      isSuperAdmin: true,
+      canAccessAdminPanel: true,
+      role: AUTH_ROLES.SUPER_ADMIN,
+    });
+
+    renderWithProviders(<Sidebar />);
+
+    expect(screen.getByText('Users')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });
 
@@ -56,6 +74,7 @@ describe('UI Component: Sidebar', () => {
     vi.mocked(useAuth).mockReturnValue({
       ...defaultAuthMock,
       isAdmin: false,
+      canAccessAdminPanel: true,
       logout: mockLogout,
     });
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useTheme } from '@/hooks/useTheme';
+import { canAccessAdminRoute } from '@/utils/permissions';
 
 const SIDEBAR_LINKS = [
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products', icon: <PackageIcon /> },
@@ -26,9 +27,12 @@ const SIDEBAR_LINKS = [
 
 export const Sidebar = () => {
   const { isDark } = useTheme();
-  const { logout } = useAuth();
+  const { logout, role } = useAuth();
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModal();
+  const visibleLinks = SIDEBAR_LINKS.filter(({ to }) =>
+    canAccessAdminRoute(role, to),
+  );
 
   const handleLogout = () => {
     openConfirmModal({
@@ -50,7 +54,7 @@ export const Sidebar = () => {
         </h1>
 
         <nav>
-          {SIDEBAR_LINKS.map(({ to, label, icon }) => (
+          {visibleLinks.map(({ to, label, icon }) => (
             <NavLink
               key={to}
               to={to}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -44,10 +44,12 @@ export const MOCK_AUTH = {
 };
 
 export const AUTH_ROLES = {
+  CUSTOMER: 'customer',
   SUPER_ADMIN: 'super_admin',
   ADMIN: 'admin',
-  USER: 'user',
-};
+} as const;
+
+export type AuthRole = (typeof AUTH_ROLES)[keyof typeof AUTH_ROLES];
 
 export const ADMIN_PAGE_LIMIT = 10;
 export const NEW_ARRIVALS_LIMIT = 10;

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -30,6 +30,7 @@ describe('Hook: useAuth', () => {
     expect(result.current.isAuth).toBe(false);
     expect(result.current.role).toBeNull();
     expect(result.current.isAdmin).toBe(false);
+    expect(result.current.canAccessAdminPanel).toBe(false);
   });
 
   it('should return unauthenticated state if token is expired', () => {
@@ -55,17 +56,33 @@ describe('Hook: useAuth', () => {
     expect(result.current.isAdmin).toBe(true);
   });
 
-  it('should return authenticated state as USER if valid token and user role exist', () => {
+  it('should return authenticated state as CUSTOMER if valid token and customer role exist', () => {
     const futureTime = (Date.now() + 10000).toString();
     localStorage.setItem(MOCK_AUTH.TOKEN_KEY, 'valid-token');
     localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, futureTime);
-    localStorage.setItem(MOCK_AUTH.ROLE_KEY, 'user'); // Standard role
+    localStorage.setItem(MOCK_AUTH.ROLE_KEY, AUTH_ROLES.CUSTOMER);
 
     const { result } = renderHook(() => useAuth());
 
     expect(result.current.isAuth).toBe(true);
-    expect(result.current.role).toBe('user');
-    expect(result.current.isAdmin).toBe(false); // Check the flag
+    expect(result.current.role).toBe(AUTH_ROLES.CUSTOMER);
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.isCustomer).toBe(true);
+    expect(result.current.canAccessAdminPanel).toBe(false);
+  });
+
+  it('should ignore unsupported role values from localStorage', () => {
+    const futureTime = (Date.now() + 10000).toString();
+    localStorage.setItem(MOCK_AUTH.TOKEN_KEY, 'valid-token');
+    localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, futureTime);
+    localStorage.setItem(MOCK_AUTH.ROLE_KEY, 'user');
+
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isAuth).toBe(true);
+    expect(result.current.role).toBeNull();
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.isSuperAdmin).toBe(false);
   });
 
   // --- Block 2: Asynchronous actions (Logout) ---

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 
-import { AUTH_ROLES, MOCK_AUTH } from '@/constants';
+import { MOCK_AUTH } from '@/constants';
 import { authService } from '@/services/authService';
+import {
+  canAccessAdminPanel,
+  isAdminRole,
+  isAuthRole,
+  isCustomerRole,
+  isSuperAdminRole,
+} from '@/utils/permissions';
 
 export const useAuth = () => {
   const [isAuth, setIsAuth] = useState(() => {
@@ -27,10 +34,20 @@ export const useAuth = () => {
     }
   };
 
-  const role = localStorage.getItem(MOCK_AUTH.ROLE_KEY);
+  const storedRole = localStorage.getItem(MOCK_AUTH.ROLE_KEY);
+  const role = isAuthRole(storedRole) ? storedRole : null;
 
-  const isAdmin = role === AUTH_ROLES.ADMIN;
-  const isSuperAdmin = role === AUTH_ROLES.SUPER_ADMIN;
+  const isAdmin = isAdminRole(role);
+  const isSuperAdmin = isSuperAdminRole(role);
+  const isCustomer = isCustomerRole(role);
 
-  return { isAuth, role, isAdmin, isSuperAdmin, logout };
+  return {
+    isAuth,
+    role,
+    isAdmin,
+    isSuperAdmin,
+    isCustomer,
+    canAccessAdminPanel: canAccessAdminPanel(role),
+    logout,
+  };
 };

--- a/src/types/admin-user.types.ts
+++ b/src/types/admin-user.types.ts
@@ -1,4 +1,6 @@
-export type UserRole = 'super_admin' | 'admin' | 'customer';
+import type { AuthRole } from '@/constants';
+
+export type UserRole = AuthRole;
 
 export interface AdminUser {
   id: string;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,32 @@
+import { AUTH_ROLES, type AuthRole, ROUTES } from '@/constants';
+
+const authRoles = new Set<AuthRole>(Object.values(AUTH_ROLES));
+
+export const isAuthRole = (value: string | null): value is AuthRole =>
+  value !== null && authRoles.has(value as AuthRole);
+
+export const isAdminRole = (role: AuthRole | null) => role === AUTH_ROLES.ADMIN;
+
+export const isSuperAdminRole = (role: AuthRole | null) =>
+  role === AUTH_ROLES.SUPER_ADMIN;
+
+export const isCustomerRole = (role: AuthRole | null) =>
+  role === AUTH_ROLES.CUSTOMER;
+
+export const canAccessAdminPanel = (role: AuthRole | null) =>
+  isAdminRole(role) || isSuperAdminRole(role);
+
+export const canAccessAdminRoute = (
+  role: AuthRole | null,
+  route: string,
+): boolean => {
+  if (!canAccessAdminPanel(role)) {
+    return false;
+  }
+
+  if (route === ROUTES.ADMIN_USERS || route === ROUTES.ADMIN_SETTING) {
+    return isSuperAdminRole(role);
+  }
+
+  return true;
+};


### PR DESCRIPTION
Implemented role-based UI visibility in the client admin panel.

### What was done:

- normalized frontend roles to customer, admin, super_admin
- added central permission helpers for role checks
- updated auth logic to use normalized roles
- restricted Users and Settings pages to super_admin only
- hid Users and Settings links from regular admin in desktop and mobile sidebar
- updated registration flow so new users are treated as customer and redirected to storefront
- added/updated tests for auth, protected routes, and sidebar visibility