### PR TITLE
feat(214): handle invalid page number in pagination

### DIFF
--- a/src/hooks/usePaginationPageParam.ts
+++ b/src/hooks/usePaginationPageParam.ts
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+type UsePaginationPageParamOptions = {
+  paramName?: string;
+  fallbackPage?: number;
+};
+
+export function usePaginationPageParam({
+  paramName = 'page',
+  fallbackPage = 1,
+}: UsePaginationPageParamOptions = {}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const pageParam = searchParams.get(paramName);
+  const parsedPage = Number(pageParam);
+
+  const currentPage =
+    Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : fallbackPage;
+
+  const updateSearchParams = useCallback(
+    (updater: (params: URLSearchParams) => void) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        updater(next);
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setPage = useCallback(
+    (nextPage: number) => {
+      updateSearchParams((params) => {
+        params.set(paramName, String(nextPage));
+      });
+    },
+    [paramName, updateSearchParams],
+  );
+
+  const resetPage = useCallback(() => {
+    setPage(fallbackPage);
+  }, [fallbackPage, setPage]);
+
+  const normalizeInvalidPageParam = useCallback(() => {
+    if (pageParam === null) return;
+
+    const isValidPage = Number.isInteger(parsedPage) && parsedPage > 0;
+
+    if (!isValidPage) {
+      updateSearchParams((params) => {
+        params.set(paramName, String(fallbackPage));
+      });
+    }
+  }, [fallbackPage, pageParam, paramName, parsedPage, updateSearchParams]);
+
+  const normalizeOutOfRangePage = useCallback(
+    (totalPages: number) => {
+      const safeTotalPages = Math.max(totalPages, fallbackPage);
+
+      if (currentPage > safeTotalPages) {
+        updateSearchParams((params) => {
+          params.set(paramName, String(fallbackPage));
+        });
+      }
+    },
+    [currentPage, fallbackPage, paramName, updateSearchParams],
+  );
+
+  return {
+    searchParams,
+    currentPage,
+    setPage,
+    resetPage,
+    updateSearchParams,
+    normalizeInvalidPageParam,
+    normalizeOutOfRangePage,
+  };
+}

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { AlertCircle } from 'lucide-react';
 
@@ -15,6 +15,7 @@ import { useDeleteAdminCategory } from '@/hooks';
 import { useAdminCategoriesPage } from '@/hooks/useAdminCategoriesPage';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useTheme } from '@/hooks/useTheme';
 import type { Category } from '@/types';
 
@@ -22,56 +23,46 @@ export function AdminCategories() {
   const { isDark } = useTheme();
   const { openConfirmModal } = useConfirmModal();
   const { deleteCategory } = useDeleteAdminCategory();
-  const [searchParams, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState('');
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const navigate = useNavigate();
 
-  const pageFromParams = Number(searchParams.get('page'));
-  const currentPage =
-    Number.isInteger(pageFromParams) && pageFromParams > 0 ? pageFromParams : 1;
+  const {
+    currentPage,
+    setPage,
+    resetPage,
+    normalizeInvalidPageParam,
+    normalizeOutOfRangePage,
+  } = usePaginationPageParam();
+
   const debouncedSearch = useDebouncedValue(search.trim(), 500);
 
-  const { categories, loading, error, totalPages, total } =
-    useAdminCategoriesPage({
-      page: currentPage,
-      limit: ADMIN_PAGE_LIMIT,
-      search: debouncedSearch,
-    });
-
-  const updateSearchParams = useCallback(
-    (updater: (params: URLSearchParams) => void) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        updater(next);
-        return next;
-      });
-    },
-    [setSearchParams],
-  );
+  const { categories, loading, error, totalPages } = useAdminCategoriesPage({
+    page: currentPage,
+    limit: ADMIN_PAGE_LIMIT,
+    search: debouncedSearch,
+  });
 
   const handlePageChange = (nextPage: number) => {
-    updateSearchParams((next) => {
-      next.set('page', String(nextPage));
-    });
+    setPage(nextPage);
   };
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
-    updateSearchParams((next) => {
-      next.set('page', '1');
-    });
+    resetPage();
   };
 
   useEffect(() => {
-    if (!loading && currentPage > 1 && total > 0 && categories.length === 0) {
-      updateSearchParams((next) => {
-        next.set('page', '1');
-      });
-    }
-  }, [categories.length, currentPage, loading, total, updateSearchParams]);
+    normalizeInvalidPageParam();
+  }, [normalizeInvalidPageParam]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    normalizeOutOfRangePage(totalPages);
+  }, [loading, normalizeOutOfRangePage, totalPages]);
 
   const handleDeleteCategory = (category: Category) => {
     setDeleteError(null);

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
   AdminPageHeader,
@@ -16,6 +16,7 @@ import { useConfirmModal } from '@/hooks/useConfirmModal';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useDeleteAdminProduct } from '@/hooks/useDeleteAdminProduct';
 import { useDuplicate } from '@/hooks/useDuplicate';
+import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useAdminProductsStore } from '@/store/useAdminProductsStore';
 import { type ProductsFilters } from '@/types/filters';
 import type { SortValue } from '@/types/productsSort';
@@ -24,19 +25,20 @@ import { buildSortValue, parseSortValue } from '@/utils/sorting';
 export function AdminProducts() {
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModal();
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const { filters, search, sort, order, setFilters, setSearch, setSort } =
     useAdminProductsStore();
 
-  const pageFromParams = Number(searchParams.get('page'));
-  const currentPage =
-    Number.isInteger(pageFromParams) && pageFromParams > 0 ? pageFromParams : 1;
+  const {
+    currentPage,
+    setPage,
+    resetPage,
+    normalizeInvalidPageParam,
+    normalizeOutOfRangePage,
+  } = usePaginationPageParam();
 
-  // filters
   const [showFilters, setShowFilters] = useState(false);
 
-  // debounce for product search
   const debouncedSearch = useDebouncedValue(search.trim(), 500);
   const { duplicateProduct } = useDuplicate();
   const { deleteProduct } = useDeleteAdminProduct();
@@ -52,34 +54,34 @@ export function AdminProducts() {
 
   const selectedSortValue = buildSortValue(sort, order);
 
-  const setPageParam = (nextPage: number) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.set('page', String(nextPage));
-      return next;
-    });
-  };
+  useEffect(() => {
+    normalizeInvalidPageParam();
+  }, [normalizeInvalidPageParam]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    normalizeOutOfRangePage(totalPages);
+  }, [loading, normalizeOutOfRangePage, totalPages]);
 
   const handleFiltersChange = (newFilters: ProductsFilters) => {
     setFilters(newFilters);
-    setPageParam(1);
+    resetPage();
   };
 
-  // reset page immediately when yser types
   const handleSearchChange = (value: string) => {
     setSearch(value);
-    setPageParam(1);
+    resetPage();
   };
 
   const handleSortChange = (value: SortValue) => {
     const nextSort = parseSortValue(value);
     setSort(nextSort.sort, nextSort.order);
-    setPageParam(1);
+    resetPage();
   };
 
-  //pagination
   const handlePageChange = (newPage: number) => {
-    setPageParam(newPage);
+    setPage(newPage);
   };
 
   const handleCreateProduct = () => {

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 import {
   Pagination,
@@ -15,6 +14,7 @@ import {
 } from '@/constants/adminUsers';
 import { useAdminUsers } from '@/hooks';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import type {
   UserRoleFilter,
   UserStatusFilter,
@@ -42,14 +42,17 @@ const isValidStatusFilter = (value: string | null): value is UserStatusFilter =>
 const isValidRoleFilter = (value: string | null): value is UserRoleFilter =>
   value !== null && VALID_ROLE_FILTERS.includes(value as UserRoleFilter);
 
-const getValidPage = (value: string | null) => {
-  const page = Number(value);
-
-  return Number.isInteger(page) && page > 0 ? page : 1;
-};
-
 export const AdminUsers = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    searchParams,
+    currentPage,
+    setPage,
+    updateSearchParams,
+    normalizeInvalidPageParam,
+    normalizeOutOfRangePage,
+  } = usePaginationPageParam({
+    paramName: USERS_QUERY_PARAMS.PAGE,
+  });
 
   const searchFromParams = searchParams.get(USERS_QUERY_PARAMS.SEARCH) ?? '';
 
@@ -65,8 +68,6 @@ export const AdminUsers = () => {
     ? (searchParams.get(USERS_QUERY_PARAMS.ROLE) as UserRoleFilter)
     : DEFAULT_USER_ROLE_FILTER;
 
-  const currentPage = getValidPage(searchParams.get(USERS_QUERY_PARAMS.PAGE));
-
   const [searchValue, setSearchValue] = useState(searchFromParams);
   const debouncedSearch = useDebouncedValue(searchValue.trim(), 500);
 
@@ -74,16 +75,9 @@ export const AdminUsers = () => {
     setSearchValue(searchFromParams);
   }, [searchFromParams]);
 
-  const updateSearchParams = useCallback(
-    (updater: (params: URLSearchParams) => void) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        updater(next);
-        return next;
-      });
-    },
-    [setSearchParams],
-  );
+  useEffect(() => {
+    normalizeInvalidPageParam();
+  }, [normalizeInvalidPageParam]);
 
   useEffect(() => {
     const currentSearchParam =
@@ -129,9 +123,7 @@ export const AdminUsers = () => {
   };
 
   const handlePageChange = (page: number) => {
-    updateSearchParams((next) => {
-      next.set(USERS_QUERY_PARAMS.PAGE, String(page));
-    });
+    setPage(page);
   };
 
   const usersState = useAdminUsers({
@@ -142,12 +134,8 @@ export const AdminUsers = () => {
   });
 
   useEffect(() => {
-    if (currentPage > usersState.totalPages) {
-      updateSearchParams((next) => {
-        next.set(USERS_QUERY_PARAMS.PAGE, '1');
-      });
-    }
-  }, [currentPage, usersState.totalPages, updateSearchParams]);
+    normalizeOutOfRangePage(usersState.totalPages);
+  }, [usersState.totalPages, normalizeOutOfRangePage]);
 
   return (
     <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">

--- a/src/pages/Products/Products.tsx
+++ b/src/pages/Products/Products.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 import { Dropdown, Pagination } from '@/components';
 import { ShopBanner } from '@/components/Banner';
 import type { DropdownOption } from '@/components/Dropdown';
 import { ShopFilters } from '@/components/ShopFilters';
+import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useProducts } from '@/hooks/useProducts';
 
 import { ProductsGrid } from '../../components/ProductsGrid/ProductsGrid';
@@ -18,8 +18,15 @@ export const Products = () => {
   const [viewType, setViewType] = useState<ViewType>('grid-5');
   const [isMobile, setIsMobile] = useState(false);
 
-  const [searchParams, setSearchParams] = useSearchParams();
-  const page = Number(searchParams.get('page')) || 1;
+  const {
+    searchParams,
+    currentPage,
+    setPage,
+    updateSearchParams,
+    normalizeInvalidPageParam,
+    normalizeOutOfRangePage,
+  } = usePaginationPageParam();
+
   const defaultLimit = viewType === 'grid-5' ? 15 : 12;
   const limit = Number(searchParams.get('limit')) || defaultLimit;
   const sort = (searchParams.get('sort') as 'title' | 'price') || 'title';
@@ -42,8 +49,12 @@ export const Products = () => {
     return () => clearTimeout(timer);
   }, [isMobile]);
 
+  useEffect(() => {
+    normalizeInvalidPageParam();
+  }, [normalizeInvalidPageParam]);
+
   const { data, isLoading, isError } = useProducts(
-    page,
+    currentPage,
     limit,
     sort,
     search,
@@ -52,30 +63,33 @@ export const Products = () => {
     maxPrice,
   );
 
+  useEffect(() => {
+    if (!data || isLoading) return;
+
+    normalizeOutOfRangePage(data.totalPages);
+  }, [data, isLoading, normalizeOutOfRangePage]);
+
   const handlePageChange = (newPage: number) => {
-    setSearchParams((prev) => {
-      prev.set('page', String(newPage));
-      return prev;
-    });
+    setPage(newPage);
   };
 
   const handleFilterChange = (newValue: DropdownOption[]) => {
-    setSearchParams((prev) => {
+    updateSearchParams((params) => {
       const selectedSort = newValue[0]?.value;
 
       if (selectedSort) {
-        prev.set('sort', selectedSort);
+        params.set('sort', selectedSort);
       } else {
-        prev.delete('sort');
+        params.delete('sort');
       }
 
-      prev.set('page', '1');
-      return prev;
+      params.set('page', '1');
     });
   };
 
   if (isLoading)
     return <div className="p-8 text-center text-gray-500">Loading...</div>;
+
   if (isError)
     return (
       <div className="p-8 text-center text-red-500">Something went wrong.</div>
@@ -108,13 +122,14 @@ export const Products = () => {
           />
         </div>
       </div>
+
       {!data?.items?.length ? (
         <div className="p-8 text-center text-gray-500">No products found.</div>
       ) : (
         <>
           <ProductsGrid products={data.items} viewType={viewType} />
           <Pagination
-            currentPage={page}
+            currentPage={currentPage}
             totalPages={data.totalPages || 1}
             onPageChange={handlePageChange}
           />


### PR DESCRIPTION
- added shared usePaginationPageParam hook for pagination query param handling
- updated Products, AdminProducts, AdminUsers, and AdminCategories to use the shared hook
- normalized invalid page values in URL
- reset out-of-range page numbers to page 1
- unified pagination behavior across client and admin pages
Resolves https://github.com/UA-5399-React/docs/issues/214