### PR TITLE
fix(269): restore admin categories flow and category images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,10 @@ import { AuthLayout } from './components/AuthLayout';
 import { RegisterForm } from './components/RegisterForm';
 import { AUTH_ROLES, ROUTES } from './constants';
 import { Cart, Home } from './pages';
+import { AddCategory } from './pages/Admin/AddCategory/AddCategory';
 import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
+import { EditCategory } from './pages/Admin/EditCategory/EditCategory';
 import { EditProduct } from './pages/Admin/EditProduct/EditProduct';
 import { AdminOrders } from './pages/Admin/Orders/AdminOrders';
 import { AdminProducts } from './pages/Admin/Products/AdminProducts';
@@ -28,6 +30,8 @@ function App() {
     CART,
     ADMIN,
     ADMIN_CATEGORIES,
+    ADMIN_CATEGORY_ADD,
+    ADMIN_CATEGORY_EDIT,
     ADMIN_PRODUCTS,
     ADMIN_USERS,
     ADMIN_SETTING,
@@ -69,6 +73,8 @@ function App() {
           <Route path={ADMIN} element={<AdminLayout />}>
             <Route index element={<Navigate to={ADMIN_PRODUCTS} replace />} />
             <Route path={ADMIN_CATEGORIES} element={<AdminCategories />} />
+            <Route path={ADMIN_CATEGORY_ADD} element={<AddCategory />} />
+            <Route path={ADMIN_CATEGORY_EDIT} element={<EditCategory />} />
             <Route path={ADMIN_PRODUCTS} element={<AdminProducts />} />
             <Route path={ADMIN_PRODUCT_CREATE} element={<CreateProduct />} />
             <Route path={ADMIN_PRODUCT_EDIT} element={<EditProduct />} />

--- a/src/components/CategoryForm/CategoryForm.test.tsx
+++ b/src/components/CategoryForm/CategoryForm.test.tsx
@@ -1,17 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  fireEvent,
-  render,
-  screen,
-  userEvent,
-  waitFor,
-} from '@/utils/test-utils';
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
 
 import { CategoryForm } from './CategoryForm';
 
 const mockCreateCategory = vi.fn();
 const mockUpdateCategory = vi.fn();
+const mockUploadImage = vi.fn();
 const mockNavigate = vi.fn();
 let mockIsDark = false;
 
@@ -21,6 +16,13 @@ vi.mock('@/hooks/useCreateAdminCategory', () => ({
 
 vi.mock('@/hooks/useUpdateAdminCategory', () => ({
   useUpdateAdminCategory: () => ({ updateCategory: mockUpdateCategory }),
+}));
+
+vi.mock('@/hooks/useUploadProductImage', () => ({
+  useUploadProductImage: () => ({
+    uploadImage: mockUploadImage,
+    loading: false,
+  }),
 }));
 
 vi.mock('@/hooks/useTheme', () => ({
@@ -165,6 +167,41 @@ describe('Component: CategoryForm', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/admin/categories');
   });
 
+  it('should upload image and save category with uploaded image URL', async () => {
+    mockUploadImage.mockResolvedValue({
+      imageUrl: 'https://cdn.example.com/category.png',
+      imagePublicId: 'products/category',
+    });
+    mockCreateCategory.mockResolvedValue({
+      data: { createCategory: { id: '1' } },
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<CategoryForm mode="add" />);
+    const file = new File(['img'], 'category.png', { type: 'image/png' });
+
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:preview');
+
+    await user.upload(
+      container.querySelector('input[type="file"]') as HTMLInputElement,
+      file,
+    );
+
+    await user.type(
+      screen.getByRole('textbox', { name: /Category Name/i }),
+      'Uploaded Category',
+    );
+    await user.type(screen.getByPlaceholderText(/Short description/i), 'Desc');
+    await user.click(screen.getByRole('button', { name: /Save Category/i }));
+
+    await waitFor(() => expect(mockUploadImage).toHaveBeenCalledWith(file));
+    expect(mockCreateCategory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageUrl: 'https://cdn.example.com/category.png',
+      }),
+    );
+  });
+
   it('should cover dropdown item selection and filtering', async () => {
     const user = userEvent.setup();
     const items = [
@@ -257,18 +294,24 @@ describe('Component: CategoryForm', () => {
   });
 
   it('should handle image upload and preview', async () => {
+    const user = userEvent.setup();
     const spy = vi
       .spyOn(URL, 'createObjectURL')
       .mockReturnValue('blob:preview');
     const { container } = render(<CategoryForm mode="add" />);
     const file = new File(['img'], 'c.png', { type: 'image/png' });
-    fireEvent.change(container.querySelector('input[type="file"]')!, {
-      target: { files: [file] },
-    });
-    expect(screen.getByAltText('Preview')).toHaveAttribute(
-      'src',
-      'blob:preview',
+    await user.upload(
+      container.querySelector('input[type="file"]') as HTMLInputElement,
+      file,
     );
+
+    await waitFor(() => {
+      expect(screen.getByAltText('Preview')).toHaveAttribute(
+        'src',
+        'blob:preview',
+      );
+    });
+
     spy.mockRestore();
   });
 

--- a/src/components/CategoryForm/CategoryForm.tsx
+++ b/src/components/CategoryForm/CategoryForm.tsx
@@ -11,13 +11,15 @@ import { ROUTES } from '@/constants';
 import { useCreateAdminCategory } from '@/hooks/useCreateAdminCategory';
 import { useTheme } from '@/hooks/useTheme';
 import { useUpdateAdminCategory } from '@/hooks/useUpdateAdminCategory';
+import { useUploadProductImage } from '@/hooks/useUploadProductImage';
 import type { Category, Product } from '@/types';
 
 const categorySchema = z.object({
   title: z.string().trim().min(1, 'Category name is required'),
   description: z.string().trim().min(1, 'Description is required'),
   parent: z.string().nullable().optional(),
-  imageUrl: z.string().optional().or(z.literal('')),
+  imagePreview: z.string().nullable().optional(),
+  imageFile: z.instanceof(File).optional(),
 });
 
 type CategoryFormData = z.infer<typeof categorySchema>;
@@ -38,6 +40,7 @@ export const CategoryForm = ({
   const isEdit = mode === 'edit';
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -55,15 +58,17 @@ export const CategoryForm = ({
       title: initialData?.title || '',
       description: initialData?.description || '',
       parent: initialData?.parent || null,
-      imageUrl: initialData?.imageUrl || undefined,
+      imagePreview: initialData?.imageUrl || null,
+      imageFile: undefined,
     },
   });
 
-  const preview = useWatch({ control, name: 'imageUrl' });
+  const preview = useWatch({ control, name: 'imagePreview' });
   const parentValue = useWatch({ control, name: 'parent' });
 
-  const { createCategory } = useCreateAdminCategory();
-  const { updateCategory } = useUpdateAdminCategory();
+  const { createCategory, loading: isCreating } = useCreateAdminCategory();
+  const { updateCategory, loading: isUpdating } = useUpdateAdminCategory();
+  const { uploadImage, loading: isUploading } = useUploadProductImage();
 
   const products = initialData?.products || [];
   const hasChildren =
@@ -82,22 +87,63 @@ export const CategoryForm = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
   const handleRemoveImage = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setValue('imageUrl', undefined);
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setValue('imagePreview', null);
+    setValue('imageFile', undefined);
     if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      setValue('imageFile', undefined);
+      return;
+    }
+
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    previewUrlRef.current = previewUrl;
+
+    setValue('imageFile', file, { shouldDirty: true, shouldValidate: true });
+    setValue('imagePreview', previewUrl, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
   };
 
   const onSubmit = async (data: CategoryFormData) => {
     setServerError(null);
 
     const depth: 1 | 2 = data.parent ? 2 : 1;
+    let uploadedImageUrl = data.imagePreview || undefined;
+
+    if (data.imageFile) {
+      const uploadedImage = await uploadImage(data.imageFile);
+      uploadedImageUrl = uploadedImage.imageUrl;
+    }
 
     const payload = {
       title: data.title,
       description: data.description,
       parent: data.parent || undefined,
-      imageUrl: data.imageUrl || undefined,
+      imageUrl: uploadedImageUrl,
       depth,
     };
 
@@ -124,6 +170,7 @@ export const CategoryForm = ({
 
   const labelStyles =
     'mb-1.5 block w-full text-[13px] font-semibold text-[#1A1C1E] font-sans';
+  const isSaving = isCreating || isUpdating || isUploading;
 
   return (
     <div
@@ -191,9 +238,9 @@ export const CategoryForm = ({
               )}
             </div>
 
-            {errors.imageUrl && (
+            {errors.imagePreview && (
               <p className="mt-2 text-xs text-red-500">
-                {errors.imageUrl.message}
+                {errors.imagePreview.message}
               </p>
             )}
 
@@ -202,10 +249,7 @@ export const CategoryForm = ({
               ref={fileInputRef}
               className="hidden"
               accept="image/*"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) setValue('imageUrl', URL.createObjectURL(file));
-              }}
+              onChange={handleImageChange}
             />
           </div>
 
@@ -407,15 +451,21 @@ export const CategoryForm = ({
           )}
           <button
             onClick={() => navigate(-1)}
+            disabled={isSaving}
             className="cursor-pointer border-none bg-transparent text-sm font-bold text-[#8A92A6] transition-colors hover:text-[#1A1C1E]"
           >
             Cancel
           </button>
           <button
             type="submit"
+            disabled={isSaving}
             className="cursor-pointer rounded-xl border-none bg-[#38CB89] px-8 py-3 text-sm font-bold text-white shadow-sm transition-all hover:bg-[#32b87a] active:scale-95"
           >
-            {isEdit ? 'Update Category' : 'Save Category'}
+            {isSaving
+              ? 'Saving...'
+              : isEdit
+                ? 'Update Category'
+                : 'Save Category'}
           </button>
         </div>
       </form>

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -7,8 +7,9 @@ import { useAuth } from '@/hooks/useAuth';
 import { canAccessAdminRoute } from '@/utils/permissions';
 
 const MOBILE_LINKS = [
-  { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products' },
+  { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
+  { to: ROUTES.ADMIN_USERS, label: 'Users' },
   { to: ROUTES.ADMIN_ORDERS, label: 'Orders' },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings' },
 ];

--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/hooks/useTheme', () => ({
 }));
 
 const mockDelete = vi.fn();
+const mockEdit = vi.fn();
 
 const mockCategories: Category[] = [
   {
@@ -57,7 +58,12 @@ const mockCategories: Category[] = [
 describe('UI Component: TableCategories', () => {
   it('should render the table and all column headers', () => {
     render(
-      <TableCategories items={[]} loading={false} onDelete={mockDelete} />,
+      <TableCategories
+        items={[]}
+        loading={false}
+        onDelete={mockDelete}
+        onEdit={mockEdit}
+      />,
     );
 
     expect(screen.getByRole('table')).toBeInTheDocument();
@@ -71,7 +77,14 @@ describe('UI Component: TableCategories', () => {
   });
 
   it('should show loading state', () => {
-    render(<TableCategories items={[]} loading={true} onDelete={mockDelete} />);
+    render(
+      <TableCategories
+        items={[]}
+        loading={true}
+        onDelete={mockDelete}
+        onEdit={mockEdit}
+      />,
+    );
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
@@ -83,6 +96,7 @@ describe('UI Component: TableCategories', () => {
         loading={false}
         error={new Error('Network failure')}
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 
@@ -93,7 +107,12 @@ describe('UI Component: TableCategories', () => {
 
   it('should show empty state when there are no categories', () => {
     render(
-      <TableCategories items={[]} loading={false} onDelete={mockDelete} />,
+      <TableCategories
+        items={[]}
+        loading={false}
+        onDelete={mockDelete}
+        onEdit={mockEdit}
+      />,
     );
 
     expect(screen.getByText('No categories found')).toBeInTheDocument();
@@ -105,6 +124,7 @@ describe('UI Component: TableCategories', () => {
         items={mockCategories}
         loading={false}
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 
@@ -121,6 +141,7 @@ describe('UI Component: TableCategories', () => {
         items={mockCategories}
         loading={false}
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 
@@ -143,6 +164,7 @@ describe('UI Component: TableCategories', () => {
         items={mockCategories}
         loading={false}
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 
@@ -163,6 +185,7 @@ describe('UI Component: TableCategories', () => {
     await user.click(editButton);
     await user.click(deleteButton);
 
+    expect(mockEdit).toHaveBeenCalledWith(mockCategories[2]);
     expect(mockDelete).toHaveBeenCalledWith(mockCategories[2]);
   });
 
@@ -173,6 +196,7 @@ describe('UI Component: TableCategories', () => {
         loading={false}
         deletingId="parent-2"
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 
@@ -187,6 +211,7 @@ describe('UI Component: TableCategories', () => {
         items={mockCategories}
         loading={false}
         onDelete={mockDelete}
+        onEdit={mockEdit}
       />,
     );
 

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -13,6 +13,7 @@ interface TableCategoriesProps {
   error?: Error | null;
   deletingId?: string | null;
   onDelete: (category: Category) => void;
+  onEdit: (category: Category) => void;
 }
 
 const formatCategoryDate = (value: string) =>
@@ -32,6 +33,7 @@ type CategoryRowProps = {
   isExpanded: boolean;
   deletingId?: string | null;
   onDelete: (category: Category) => void;
+  onEdit: (category: Category) => void;
   onToggle: (categoryId: string) => void;
 };
 
@@ -42,6 +44,7 @@ function CategoryRow({
   isExpanded,
   deletingId,
   onDelete,
+  onEdit,
   onToggle,
 }: CategoryRowProps) {
   const isDeleting = deletingId === category.id;
@@ -126,6 +129,7 @@ function CategoryRow({
           aria-label={`Edit ${category.title}`}
           className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
           type="button"
+          onClick={() => onEdit(category)}
         >
           <Pencil className="h-[20px] w-[20px]" />
         </Button>
@@ -141,6 +145,7 @@ function TableCategoriesContent({
   isDark,
   deletingId,
   onDelete,
+  onEdit,
 }: {
   items: Category[];
   loading: boolean;
@@ -148,6 +153,7 @@ function TableCategoriesContent({
   isDark: boolean;
   deletingId?: string | null;
   onDelete: (category: Category) => void;
+  onEdit: (category: Category) => void;
 }) {
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
 
@@ -236,6 +242,7 @@ function TableCategoriesContent({
         isExpanded={isExpanded}
         deletingId={deletingId}
         onDelete={onDelete}
+        onEdit={onEdit}
         onToggle={toggleCategory}
       />,
     ];
@@ -251,6 +258,7 @@ function TableCategoriesContent({
             isExpanded={false}
             deletingId={deletingId}
             onDelete={onDelete}
+            onEdit={onEdit}
             onToggle={toggleCategory}
           />
         )),
@@ -267,11 +275,12 @@ export function TableCategories({
   error,
   deletingId,
   onDelete,
+  onEdit,
 }: TableCategoriesProps) {
   const { isDark } = useTheme();
 
   return (
-    <div className="mx-5 mt-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
+    <div className="mx-5 mt-5 overflow-x-auto rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
       <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#e5e7eb] [&_td]:px-4 [&_thead_th]:border-b [&_thead_th]:border-[#e5e7eb] [&_thead_th]:px-4">
         <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
           <tr>
@@ -294,6 +303,7 @@ export function TableCategories({
             isDark={isDark}
             deletingId={deletingId}
             onDelete={onDelete}
+            onEdit={onEdit}
           />
         </tbody>
       </table>

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -132,7 +132,7 @@ export function TableProducts({
   const navigate = useNavigate();
 
   return (
-    <div className="mx-5 mt-5 rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
+    <div className="mx-5 mt-5 overflow-x-auto rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
       <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#e5e7eb] [&_thead_th]:border-b [&_thead_th]:border-[#e5e7eb] [&_thead_th]:px-4">
         <thead className="h-[50px] bg-[#F9FAFB] px-[12px] text-[#8A92A6]">
           <tr>

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -63,7 +63,7 @@ export function UsersTable({ items, onUpdateUser }: UsersTableProps) {
   }
 
   return (
-    <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white shadow-md">
+    <div className="mt-5 overflow-x-auto rounded-lg border border-[#E5E7EB] bg-white shadow-md">
       <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#E5E7EB] [&_thead_th]:border-b [&_thead_th]:border-[#E5E7EB] [&_thead_th]:px-4">
         <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
           <tr>

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -173,6 +173,51 @@ describe('Page: AdminCategories', () => {
     );
   });
 
+  it('should navigate to add category page when add button is clicked', async () => {
+    const user = userEvent.setup();
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 0,
+    });
+
+    render(<AdminCategories />);
+
+    await user.click(screen.getByRole('button', { name: '+ Add Category' }));
+
+    expect(window.location.pathname).toBe('/admin/categories/add');
+  });
+
+  it('should navigate to edit category page when edit button is clicked', async () => {
+    const user = userEvent.setup();
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-2',
+          title: 'Accessories',
+          imageUrl: null,
+          description: 'Category without children',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-14T12:00:00Z',
+          updatedAt: '2025-10-15T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 1,
+    });
+
+    render(<AdminCategories />);
+
+    await user.click(screen.getByRole('button', { name: 'Edit Accessories' }));
+
+    expect(window.location.pathname).toBe('/admin/categories/edit/parent-2');
+  });
+
   it('should execute delete mutation when modal confirm callback is called', async () => {
     useAdminCategoriesPageMock.mockReturnValue({
       categories: [

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { AlertCircle } from 'lucide-react';
 
@@ -10,7 +10,7 @@ import {
   SearchInput,
   TableCategories,
 } from '@/components';
-import { ADMIN_PAGE_LIMIT } from '@/constants';
+import { ADMIN_PAGE_LIMIT, ROUTES } from '@/constants';
 import { useDeleteAdminCategory } from '@/hooks';
 import { useAdminCategoriesPage } from '@/hooks/useAdminCategoriesPage';
 import { useConfirmModal } from '@/hooks/useConfirmModal';
@@ -89,6 +89,10 @@ export function AdminCategories() {
     });
   };
 
+  const handleEditCategory = (category: Category) => {
+    navigate(generatePath(ROUTES.ADMIN_CATEGORY_EDIT, { id: category.id }));
+  };
+
   return (
     <div>
       <AdminPageHeader />
@@ -97,7 +101,7 @@ export function AdminCategories() {
         <Button
           variant="primary"
           type="button"
-          onClick={() => navigate('/admin/categories/add')}
+          onClick={() => navigate(ROUTES.ADMIN_CATEGORY_ADD)}
         >
           + Add Category
         </Button>
@@ -141,6 +145,7 @@ export function AdminCategories() {
           error={error}
           deletingId={deletingId}
           onDelete={handleDeleteCategory}
+          onEdit={handleEditCategory}
         />
 
         <Pagination


### PR DESCRIPTION
Fixes the admin categories flow on the frontend.

### Included in this PR:
- restored navigation for the `+ Add Category` button
- restored navigation for the edit action in the categories table
- connected `AddCategory` and `EditCategory` pages to admin routing
- updated category image handling to use the upload service flow, similar to products
- removed saving temporary `blob:` preview URLs as `imageUrl`
- added and updated tests for category navigation and image upload behavior
- some minor style improvements

### Result:
- add/edit category actions work correctly again
- category images are now uploaded and persist after page refresh
