### PR TITLE
Feat/266 fetch data for order table

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -8,9 +8,14 @@ import styles from './ActionMenu.module.css';
 interface ActionMenuProps {
   editAction: () => void;
   deleteAction?: () => void;
+  className?: string;
 }
 
-export const ActionMenu = ({ editAction, deleteAction }: ActionMenuProps) => {
+export const ActionMenu = ({
+  editAction,
+  deleteAction,
+  className,
+}: ActionMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -39,7 +44,9 @@ export const ActionMenu = ({ editAction, deleteAction }: ActionMenuProps) => {
       </Button>
 
       {isOpen && (
-        <div className="align-center bg-background border-gray300 absolute top-0 left-10 z-20 flex w-[140px] flex-col rounded-xl border p-2 shadow-lg">
+        <div
+          className={`align-center bg-background border-gray300 absolute top-0 left-10 z-20 flex w-[140px] flex-col rounded-xl border p-2 shadow-lg ${className}`}
+        >
           <Button
             type="button"
             className={`${styles.button} text-text border-b-red700 border-b-2 bg-transparent`}

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -85,7 +85,7 @@ export function MainTable<T extends TableItem>({
   return (
     <div className="border-gray100 mx-5 mt-5 rounded-l-lg rounded-r-lg border shadow-md">
       <table className="[&_td]:border-gray100 [&_thead_th]:border-gray100 w-full border-collapse rounded-t-lg [&_td]:border-b [&_thead_th]:border-b">
-        <thead className="text-gray600 bg-backgroundSec h-[50px] px-[12px] text-center">
+        <thead className="text-gray600 bg-backgroundSec h-[50px] px-[12px] text-center [&_th]:px-2">
           <tr>
             {columns.map((column) => (
               <th key={column.key} className={column.className}>
@@ -95,7 +95,7 @@ export function MainTable<T extends TableItem>({
           </tr>
         </thead>
 
-        <tbody className={`bg-background [&_td]:px-4`}>
+        <tbody className={`bg-background [&_td]:px-2`}>
           {renderBodyContent({
             loading: !!loading,
             error: error ?? null,

--- a/src/components/TableOrders/TableOrders.test.tsx
+++ b/src/components/TableOrders/TableOrders.test.tsx
@@ -1,17 +1,42 @@
 import { describe, expect, it } from 'vitest';
 
+import { ORDER_STATUS, type OrderItem } from '@/types/tableOrders.types';
+import { formatDate } from '@/utils';
 import { render, screen } from '@/utils/test-utils';
 
 import { TableOrders } from './TableOrders';
 
+const orderItem: OrderItem = {
+  id: 'order-1',
+  orderId: 'ORD-20250324-0001',
+  items: [
+    {
+      title: 'Test product',
+      imageUrl: 'https://example.com/product.jpg',
+      unitPrice: 999.99,
+      amount: 2,
+    },
+  ],
+  user: {
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john@example.com',
+    phone: '+380501234567',
+  },
+  amount: 1999.98,
+  totalPrice: 1999.98,
+  status: ORDER_STATUS.PROCESSING,
+  createdAt: '2025-03-24T12:00:00.000Z',
+};
+
 describe('UI Component: TableOrders', () => {
   it('should render the table', () => {
-    render(<TableOrders />);
+    render(<TableOrders items={[]} loading={false} error={null} />);
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('should render all column headers', () => {
-    render(<TableOrders />);
+    render(<TableOrders items={[]} loading={false} error={null} />);
 
     expect(
       screen.getByRole('columnheader', { name: 'Product Name' }),
@@ -37,5 +62,33 @@ describe('UI Component: TableOrders', () => {
     expect(
       screen.getByRole('columnheader', { name: 'Actions' }),
     ).toBeInTheDocument();
+  });
+
+  it('should render empty state when there are no orders', () => {
+    render(<TableOrders items={[]} loading={false} error={null} />);
+
+    expect(screen.getByText('No orders found')).toBeInTheDocument();
+  });
+
+  it('should render order row values', () => {
+    render(<TableOrders items={[orderItem]} loading={false} error={null} />);
+
+    expect(screen.getByText('Test product')).toBeInTheDocument();
+    expect(screen.getByText('Items: 1')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('#ORD-20250324-0001')).toBeInTheDocument();
+    expect(screen.getByText('$1999.98')).toBeInTheDocument();
+    expect(screen.getByText('+380501234567')).toBeInTheDocument();
+    expect(
+      screen.getByText(formatDate(new Date(orderItem.createdAt))),
+    ).toBeInTheDocument();
+  });
+
+  it('should show selected order status in dropdown trigger', () => {
+    render(<TableOrders items={[orderItem]} loading={false} error={null} />);
+
+    expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
+      'Processing',
+    );
   });
 });

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -1,6 +1,9 @@
-import { ActionMenu, MainTable } from '@/components';
+import clsx from 'clsx';
+
+import { ActionMenu, Dropdown, MainTable } from '@/components';
 import type { Column } from '@/types';
-import type { OrderItem } from '@/types/tableOrders.types';
+import { ORDER_STATUS, type OrderItem } from '@/types/tableOrders.types';
+import { capitalizeFirst, formatDate } from '@/utils';
 
 interface TableOrdersProps {
   items: OrderItem[];
@@ -19,12 +22,21 @@ const columns: Column[] = [
   { key: 'actions', label: 'Actions', className: '' },
 ];
 
+const statusOptions = Object.values(ORDER_STATUS).map((status) => ({
+  label: capitalizeFirst(status),
+  value: status,
+}));
+
 const handleEdit = () => {};
 
 const renderProductRow = (item: OrderItem) => {
+  const handleStatusChange = () => {
+    // TODO: handle status change
+  };
+
   const firstProduct = item.items[0];
   const customerName = `${item.user.firstName} ${item.user.lastName}`.trim();
-  const createdAt = new Date(item.createdAt).toLocaleDateString('uk-UA');
+  const selectedStatus = item.status ? [String(item.status).toLowerCase()] : [];
 
   return (
     <>
@@ -48,12 +60,34 @@ const renderProductRow = (item: OrderItem) => {
       <td>#{item.orderId}</td>
       <td>${item.totalPrice.toFixed(2)}</td>
       <td>
-        <span>{item.status}</span>
+        <div className="flex justify-center">
+          <Dropdown
+            label="Status"
+            labelClassName="hidden"
+            options={statusOptions}
+            selectedValues={selectedStatus}
+            onChange={() => handleStatusChange()}
+            multiple={false}
+            hasBorder={true}
+            placeholder="Status"
+            selectClassName={
+              ' ' +
+              clsx(
+                '!flex !items-center !justify-between',
+                '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
+                '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+              )
+            }
+          />
+        </div>
       </td>
-      <td>{createdAt}</td>
+      <td>{formatDate(new Date(item.createdAt))}</td>
       <td>{item.user.phone}</td>
       <td>
-        <ActionMenu editAction={() => handleEdit()} />
+        <ActionMenu
+          className="top-0 left-[-135px]"
+          editAction={() => handleEdit()}
+        />
       </td>
     </>
   );

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -2,29 +2,11 @@ import { ActionMenu, MainTable } from '@/components';
 import type { Column } from '@/types';
 import type { OrderItem } from '@/types/tableOrders.types';
 
-// Mock data for testing
-const items: OrderItem[] = [
-  {
-    id: 'order-1',
-    productName: 'Product 1',
-    customerName: 'Customer 1',
-    orderId: '1234567890',
-    amount: 100,
-    status: 'Pending',
-    date: '2021-01-01',
-    phone: '1234567890',
-  },
-  {
-    id: 'order-2',
-    productName: 'Product 2',
-    customerName: 'Customer 2',
-    orderId: '1234567890',
-    amount: 200,
-    status: 'Shipped',
-    date: '2021-01-01',
-    phone: '1234567890',
-  },
-];
+interface TableOrdersProps {
+  items: OrderItem[];
+  loading: boolean;
+  error: Error | null | undefined;
+}
 
 const columns: Column[] = [
   { key: 'product', label: 'Product Name', className: '!min-w-[55%]' },
@@ -40,22 +22,36 @@ const columns: Column[] = [
 const handleEdit = () => {};
 
 const renderProductRow = (item: OrderItem) => {
+  const firstProduct = item.items[0];
+  const customerName = `${item.user.firstName} ${item.user.lastName}`.trim();
+  const createdAt = new Date(item.createdAt).toLocaleDateString('uk-UA');
+
   return (
     <>
       <td>
-        <div className="flex flex-col items-center gap-2">
-          {item.productName}
-          <span>Image</span>
+        <div className="flex flex-row gap-2">
+          {firstProduct?.imageUrl ? (
+            <img
+              src={firstProduct.imageUrl}
+              alt={firstProduct.title}
+              className="h-10 w-10 rounded object-cover"
+            />
+          ) : null}
+          <div className="flex flex-col gap-1 text-left">
+            <span>{firstProduct?.title ?? 'No items'}</span>
+
+            <span> Items: {item.items.length}</span>
+          </div>
         </div>
       </td>
-      <td>{item.customerName}</td>
+      <td>{customerName}</td>
       <td>#{item.orderId}</td>
-      <td>${item.amount}</td>
+      <td>${item.totalPrice.toFixed(2)}</td>
       <td>
         <span>{item.status}</span>
       </td>
-      <td>{item.date}</td>
-      <td>{item.phone}</td>
+      <td>{createdAt}</td>
+      <td>{item.user.phone}</td>
       <td>
         <ActionMenu editAction={() => handleEdit()} />
       </td>
@@ -63,11 +59,7 @@ const renderProductRow = (item: OrderItem) => {
   );
 };
 
-export function TableOrders() {
-  // TODO: add loading and error states
-  const loading = false;
-  const error = null;
-
+export function TableOrders({ items, loading, error }: TableOrdersProps) {
   return (
     <MainTable
       columns={columns}

--- a/src/hooks/useAdminOrders.ts
+++ b/src/hooks/useAdminOrders.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@apollo/client/react';
+
+import { GET_ORDERS } from '@/services/graphql/ordersAdminService';
+import type { GetOrdersData } from '@/types/tableOrders.types';
+
+export function useAdminOrders() {
+  const { data, loading, error } = useQuery<GetOrdersData>(GET_ORDERS, {
+    variables: {
+      page: 1,
+      limit: 10,
+      sort: 'createdAt',
+      order: 'desc',
+    },
+  });
+
+  return {
+    orders: data?.orders.items ?? [],
+    loading,
+    error,
+  };
+}

--- a/src/pages/Admin/Orders/AdminOrders.tsx
+++ b/src/pages/Admin/Orders/AdminOrders.tsx
@@ -1,5 +1,8 @@
 import { TableOrders } from '@/components';
+import { useAdminOrders } from '@/hooks/useAdminOrders';
 
 export function AdminOrders() {
-  return <TableOrders />;
+  const { orders, loading, error } = useAdminOrders();
+
+  return <TableOrders items={orders} loading={loading} error={error} />;
 }

--- a/src/services/graphql/ordersAdminService.ts
+++ b/src/services/graphql/ordersAdminService.ts
@@ -1,0 +1,38 @@
+import { gql } from '@apollo/client';
+
+export const GET_ORDERS = gql`
+  query Orders(
+    $page: Int!
+    $limit: Int!
+    $sort: OrdersSortField!
+    $order: SortOrder!
+  ) {
+    orders(page: $page, limit: $limit, sort: $sort, order: $order) {
+      total
+      totalPages
+      page
+      limit
+      items {
+        id
+        orderId
+        status
+        amount
+        totalPrice
+        createdAt
+        updatedAt
+        items {
+          title
+          imageUrl
+          unitPrice
+          amount
+        }
+        user {
+          email
+          firstName
+          lastName
+          phone
+        }
+      }
+    }
+  }
+`;

--- a/src/types/tableOrders.types.ts
+++ b/src/types/tableOrders.types.ts
@@ -1,9 +1,9 @@
 export const ORDER_STATUS = {
-  NEW: 'New',
-  PENDING: 'Pending',
-  PAID: 'Paid',
-  SHIPPED: 'Shipped',
-  CANCELLED: 'Cancelled',
+  NEW: 'new',
+  PENDING: 'pending',
+  PAID: 'paid',
+  SHIPPED: 'shipped',
+  CANCELLED: 'cancelled',
 } as const;
 
 export type OrderStatus =
@@ -15,11 +15,37 @@ export type OrderStatus =
 
 export interface OrderItem {
   id: string;
-  productName: string;
-  customerName: string;
   orderId: string;
+  items: OrderedProduct[];
+  user: OrderUser;
   amount: number;
+  totalPrice: number;
   status: OrderStatus;
-  date: string;
+  createdAt: string;
+}
+
+export interface OrderedProduct {
+  title: string;
+  imageUrl: string;
+  unitPrice: number;
+  amount: number;
+}
+
+export interface OrderUser {
+  firstName: string;
+  lastName: string;
+  email: string;
   phone: string;
+}
+
+export interface OrdersPage {
+  total: number;
+  totalPages: number;
+  page: number;
+  limit: number;
+  items: OrderItem[];
+}
+
+export interface GetOrdersData {
+  orders: OrdersPage;
 }

--- a/src/types/tableOrders.types.ts
+++ b/src/types/tableOrders.types.ts
@@ -1,16 +1,16 @@
 export const ORDER_STATUS = {
   NEW: 'new',
-  PENDING: 'pending',
-  PAID: 'paid',
-  SHIPPED: 'shipped',
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  SHIPPING: 'shipping',
   CANCELLED: 'cancelled',
 } as const;
 
 export type OrderStatus =
   | typeof ORDER_STATUS.NEW
-  | typeof ORDER_STATUS.PENDING
-  | typeof ORDER_STATUS.PAID
-  | typeof ORDER_STATUS.SHIPPED
+  | typeof ORDER_STATUS.PROCESSING
+  | typeof ORDER_STATUS.COMPLETED
+  | typeof ORDER_STATUS.SHIPPING
   | typeof ORDER_STATUS.CANCELLED;
 
 export interface OrderItem {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './date.utils';
+export * from './string.utils';

--- a/src/utils/string.utils.ts
+++ b/src/utils/string.utils.ts
@@ -1,0 +1,2 @@
+export const capitalizeFirst = (value: string) =>
+  value ? value.charAt(0).toUpperCase() + value.slice(1) : value;


### PR DESCRIPTION
- Added useAdminOrders hook for fetching orders data using GraphQL.
- Updated TableOrders component to accept items, loading, and error props.
- Created GET_ORDERS query in ordersAdminService for retrieving order details.
- Refactored order item structure in tableOrders.types to accommodate new data format.