### PR TITLE
feat(270): implement avatar upload on user profile

### DIFF
--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
@@ -73,15 +73,22 @@ describe('AccountSidebar', () => {
     expect(placeholder).toBeInTheDocument();
   });
 
-  it('calls onAvatarClick when avatar button is clicked', () => {
+  it('calls onAvatarClick when file is selected', () => {
     const onAvatarClick = vi.fn();
 
-    renderComponent({ onAvatarClick });
+    const { container } = renderComponent({ onAvatarClick });
 
-    const buttons = screen.getAllByRole('button');
-    fireEvent.click(buttons[0]);
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
+
+    fireEvent.change(input, {
+      target: { files: [file] },
+    });
 
     expect(onAvatarClick).toHaveBeenCalledTimes(1);
+    expect(onAvatarClick).toHaveBeenCalledWith(file);
   });
 
   it('calls onLogout when logout button is clicked', () => {

--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Camera, User as UserIcon } from 'lucide-react';
 
@@ -6,17 +7,35 @@ import type { User } from '@/types/user';
 
 type AccountSidebarProps = {
   user: User;
-  onAvatarClick?: () => void;
+  onAvatarClick?: (file: File) => void;
   onLogout: () => void;
+  isAvatarUploading?: boolean;
 };
 
 export function AccountSidebar({
   user,
   onAvatarClick,
   onLogout,
+  isAvatarUploading = false,
 }: AccountSidebarProps) {
   const fullName = `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim();
   const displayName = fullName || 'User';
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleOpenFilePicker = () => {
+    if (isAvatarUploading) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    onAvatarClick?.(file);
+    event.target.value = '';
+  };
 
   const navItemClass =
     'block w-full border-b pb-2 text-[16px] font-semibold transition';
@@ -42,11 +61,20 @@ export function AccountSidebar({
 
           <button
             type="button"
-            onClick={onAvatarClick}
-            className="absolute -right-1 -bottom-1 flex h-[30px] w-[30px] items-center justify-center rounded-full border-2 border-[rgb(var(--color-neutral-0))] bg-[rgb(var(--color-neutral-900))] text-[rgb(var(--color-neutral-0))] shadow-md transition hover:scale-110"
+            onClick={handleOpenFilePicker}
+            disabled={isAvatarUploading}
+            className="absolute -right-1 -bottom-1 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full border-2 border-[rgb(var(--color-neutral-0))] bg-[rgb(var(--color-neutral-900))] text-[rgb(var(--color-neutral-0))] shadow-md transition hover:scale-110 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Camera size={16} />
           </button>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            className="hidden"
+            onChange={handleFileChange}
+          />
         </div>
 
         <h3 className="mt-3 mb-0 text-[20px] leading-none font-semibold text-[rgb(var(--color-neutral-900))]">
@@ -63,7 +91,7 @@ export function AccountSidebar({
               className={({ isActive }) =>
                 `${navItemClass} ${
                   isActive
-                    ? 'border-[rgb(var(--neutral-800))] text-black'
+                    ? 'border-[rgb(var(--color-neutral-800))] text-black'
                     : 'border-transparent text-[rgb(var(--color-neutral-500))] hover:text-[rgb(var(--color-neutral-900))]'
                 }`
               }

--- a/src/pages/User/Profile.tsx
+++ b/src/pages/User/Profile.tsx
@@ -22,6 +22,7 @@ export function Profile() {
   const [isSaving, setIsSaving] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
 
   const {
     control,
@@ -159,6 +160,37 @@ export function Profile() {
     }
   };
 
+  const handleAvatarUpload = async (file: File) => {
+    if (!user) return;
+
+    try {
+      setIsAvatarUploading(true);
+      setSubmitError('');
+      setSuccessMessage('');
+
+      const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+      const maxSize = 5 * 1024 * 1024;
+
+      if (!allowedTypes.includes(file.type)) {
+        throw new Error('Only JPEG, PNG, and WEBP files are allowed');
+      }
+
+      if (file.size > maxSize) {
+        throw new Error('Maximum file size is 5 MB');
+      }
+
+      const updatedUser = await usersService.uploadAvatar(file);
+      setUser(updatedUser);
+      setSuccessMessage('Avatar updated successfully');
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : 'Failed to upload avatar',
+      );
+    } finally {
+      setIsAvatarUploading(false);
+    }
+  };
+
   if (isLoading) {
     return <div className="p-10">Loading...</div>;
   }
@@ -181,7 +213,12 @@ export function Profile() {
 
       <div className="mx-auto max-w-[1180px]">
         <div className="grid grid-cols-1 gap-10 md:grid-cols-[220px_minmax(0,1fr)] md:items-start">
-          <AccountSidebar user={user} onLogout={handleLogout} />
+          <AccountSidebar
+            user={user}
+            onAvatarClick={handleAvatarUpload}
+            onLogout={handleLogout}
+            isAvatarUploading={isAvatarUploading}
+          />
 
           <div className="max-w-[760px] px-[72px]">
             <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -54,4 +54,23 @@ export const usersService = {
       throw new Error('Failed to change password');
     }
   },
+
+  uploadAvatar: async (file: File): Promise<User> => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(`${API_BASE_URL}/users/me/avatar`, {
+      method: 'PATCH',
+      body: formData,
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      console.log('upload avatar error', errorData);
+      throw new Error(errorData.message || 'Failed to upload avatar');
+    }
+
+    return response.json();
+  },
 };


### PR DESCRIPTION
Implemented avatar upload functionality on the user profile page.

### What was done:
- Integrated backend endpoint PATCH /users/me/avatar
- Added file input and avatar upload handling
- Implemented avatar selection via hidden file input
- Added client-side validation (file type and size)
- Updated user state after successful upload
- Displayed updated avatar immediately in UI
- Added loading state during avatar upload

### Result:
- User can select and upload a new avatar
- Avatar is updated and displayed instantly
- Upload button is disabled during request