### PR TITLE
Implement checkout page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { AdminLayout } from './components/AdminLayout/AdminLayout';
 import { AuthLayout } from './components/AuthLayout';
 import { RegisterForm } from './components/RegisterForm';
 import { AUTH_ROLES, ROUTES } from './constants';
-import { Cart, Home } from './pages';
+import { Cart, Checkout, Home, OrderConfirmation } from './pages';
 import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
 import { EditProduct } from './pages/Admin/EditProduct/EditProduct';
@@ -26,6 +26,8 @@ function App() {
     PRODUCT,
     CONTACT_US,
     CART,
+    CHECKOUT,
+    ORDER_CONFIRMATION,
     ADMIN,
     ADMIN_CATEGORIES,
     ADMIN_PRODUCTS,
@@ -51,6 +53,8 @@ function App() {
           <Route path="*" element={<NotFound />} />
           <Route element={<ProtectedRoute />}>
             <Route path={PROFILE} element={<Profile />} />
+            <Route path={CHECKOUT} element={<Checkout />} />
+            <Route path={ORDER_CONFIRMATION} element={<OrderConfirmation />} />
           </Route>
         </Route>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { AuthLayout } from './components/AuthLayout';
 import { RegisterForm } from './components/RegisterForm';
 import { AUTH_ROLES, ROUTES } from './constants';
 import { useCartSync } from './hooks/useCartSync';
-import { Cart, Checkout, Home, OrderConfirmation, OrderDetail } from './pages';
+import { Cart, Checkout, Home, OrderConfirmation } from './pages';
 import { AddCategory } from './pages/Admin/AddCategory/AddCategory';
 import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
@@ -20,6 +20,7 @@ import { AdminProducts } from './pages/Admin/Products/AdminProducts';
 import { AdminSettings } from './pages/Admin/Settings/AdminSettings';
 import { AdminUsers } from './pages/Admin/Users/AdminUsers';
 import { ContactUs, NotFound, Shop } from './pages/Mocks';
+import { MyOrders } from './pages/User/MyOrders';
 import { Profile } from './pages/User/Profile';
 
 function App() {
@@ -32,7 +33,6 @@ function App() {
     CART,
     CHECKOUT,
     ORDER_CONFIRMATION,
-    ORDER_DETAIL,
     ADMIN,
     ADMIN_CATEGORIES,
     ADMIN_CATEGORY_ADD,
@@ -46,6 +46,7 @@ function App() {
     REGISTER,
     ADMIN_ORDERS,
     PROFILE,
+    MYORDERS,
   } = ROUTES;
 
   return (
@@ -60,9 +61,9 @@ function App() {
           <Route path="*" element={<NotFound />} />
           <Route element={<ProtectedRoute />}>
             <Route path={PROFILE} element={<Profile />} />
+            <Route path={MYORDERS} element={<MyOrders />} />
             <Route path={CHECKOUT} element={<Checkout />} />
             <Route path={ORDER_CONFIRMATION} element={<OrderConfirmation />} />
-            <Route path={ORDER_DETAIL} element={<OrderDetail />} />
           </Route>
         </Route>
 

--- a/src/components/LoginForm/LoginForm.test.tsx
+++ b/src/components/LoginForm/LoginForm.test.tsx
@@ -9,12 +9,16 @@ import { LoginForm } from './LoginForm';
 
 // Mock dependencies
 const mockNavigate = vi.fn();
+let mockLocationState: Record<string, unknown> | null = null;
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useLocation: () => ({
+      state: mockLocationState,
+    }),
   };
 });
 
@@ -34,6 +38,7 @@ describe('Feature: LoginForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockLocationState = null;
 
     // Default mock implementation
     (useLogin as Mock).mockReturnValue({
@@ -154,6 +159,30 @@ describe('Feature: LoginForm', () => {
         AUTH_ROLES.CUSTOMER,
       );
       expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SHOP);
+    });
+  });
+
+  it('should redirect back to the original page after successful login when a from state exists', async () => {
+    const user = userEvent.setup();
+    mockLocationState = { from: ROUTES.CHECKOUT };
+    mockMutateAsync.mockResolvedValueOnce(true);
+    (authService.getMe as Mock).mockResolvedValueOnce({
+      role: AUTH_ROLES.CUSTOMER,
+    });
+
+    render(<LoginForm />);
+
+    await user.type(
+      screen.getByPlaceholderText(/Your email address/i),
+      'customer@test.com',
+    );
+    await user.type(screen.getByPlaceholderText(/Password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.CHECKOUT, {
+        replace: true,
+      });
     });
   });
 

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -31,7 +31,10 @@ const getExpirationTime = (rememberMe?: boolean) => {
 
 export const LoginForm: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { mutateAsync: loginMutation, isPending } = useLogin();
+  const redirectTo =
+    typeof location.state?.from === 'string' ? location.state.from : null;
 
   const {
     register,
@@ -56,6 +59,11 @@ export const LoginForm: React.FC = () => {
     const role = isAuthRole(storedRole) ? storedRole : null;
 
     if (token && expires && Date.now() < Number(expires)) {
+      if (redirectTo) {
+        navigate(redirectTo, { replace: true });
+        return;
+      }
+
       if (canAccessAdminPanel(role)) {
         navigate(ROUTES.ADMIN);
       } else {
@@ -64,7 +72,7 @@ export const LoginForm: React.FC = () => {
     } else {
       clearAuthData();
     }
-  }, [navigate]);
+  }, [navigate, redirectTo]);
 
   const onSubmit = async (data: LoginFormValues) => {
     try {
@@ -75,6 +83,11 @@ export const LoginForm: React.FC = () => {
       localStorage.setItem(MOCK_AUTH.TOKEN_KEY, 'cookie-is-set');
       localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, expirationTime);
       localStorage.setItem(MOCK_AUTH.ROLE_KEY, user.role);
+
+      if (redirectTo) {
+        navigate(redirectTo, { replace: true });
+        return;
+      }
 
       if (canAccessAdminPanel(isAuthRole(user.role) ? user.role : null)) {
         navigate(ROUTES.ADMIN);

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -44,6 +44,32 @@ describe('ProtectedRoute', () => {
     );
 
     expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('preserves the original destination when redirecting to login', () => {
+    vi.mocked(useAuth).mockReturnValue(
+      createUseAuthMock({
+        isAuth: false,
+      }),
+    );
+
+    const LoginPage = () => {
+      const location = useLocation();
+      return <div>{(location.state as { from?: string } | null)?.from}</div>;
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/checkout?step=details']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/checkout" element={<div>Checkout Page</div>} />
+          </Route>
+          <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('/checkout?step=details')).toBeInTheDocument();
   });
 
   it('renders outlet if user is authenticated and no roles are required', () => {

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { type AuthRole, ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
@@ -13,9 +13,16 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   redirectTo = ROUTES.SHOP,
 }) => {
   const { isAuth, role } = useAuth();
+  const location = useLocation();
 
   if (!isAuth) {
-    return <Navigate to={ROUTES.LOGIN} replace />;
+    return (
+      <Navigate
+        to={ROUTES.LOGIN}
+        replace
+        state={{ from: location.pathname + location.search }}
+      />
+    );
   }
 
   if (allowedRoles && (!role || !allowedRoles.includes(role))) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,8 @@ export { MainTable } from './MainTable/MainTable';
 export { MobileSidebar } from './MobileSidebar/MobileSidebar';
 export { NewArrivals } from './NewArrivals/NewArrivals';
 export { Newsletter } from './Newsletter';
+export { OrderCard } from './OrderCard';
+export { MOCK_ORDERS } from './OrderCard/OrderCard.mock';
 export { Pagination } from './Pagination';
 export { ProductCard } from './ProductCard';
 export { ProductFiltersBar } from './ProductsFilters/ProductsFiltersBar';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,8 @@ export const ROUTES = {
   CONTACT_US: '/contact',
   LOGIN: '/login',
   CART: '/cart',
+  CHECKOUT: '/checkout',
+  ORDER_CONFIRMATION: '/order-confirmation',
   ADMIN: '/admin',
   ADMIN_CATEGORIES: '/admin/categories',
   ADMIN_PRODUCTS: '/admin/products',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -27,6 +27,7 @@ export const ROUTES = {
   ADMIN_CATEGORY_EDIT: '/admin/categories/edit/:id',
   ADMIN_ORDERS: '/admin/orders',
   PROFILE: '/profile',
+  MYORDERS: '/profile/myOrders',
 } as const;
 
 export const DEFAULT_FILTER: ProductsFilters = {

--- a/src/pages/Checkout/Checkout.test.tsx
+++ b/src/pages/Checkout/Checkout.test.tsx
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { ROUTES } from '@/constants';
+import { useTheme } from '@/hooks/useTheme';
+import { orderService, paymentService } from '@/services';
+import { useCartStore } from '@/store/useCartStore';
+import { redirectToExternalUrl } from '@/utils/navigation';
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
+
+import { Checkout } from './Checkout';
+
+const mockNavigate = vi.fn();
+const mockClearCart = vi.fn();
+const mockRemoveItem = vi.fn();
+const mockUpdateQuantity = vi.fn();
+
+const validCartItem = {
+  product: {
+    _id: '507f1f77bcf86cd799439011',
+    id: '507f1f77bcf86cd799439011',
+    title: 'Tray Table',
+    price: 38,
+    status: 'active' as const,
+    imageUrl: 'https://example.com/tray-table.jpg',
+    categories: ['Black'],
+  },
+  quantity: 2,
+};
+
+let mockCartState = {
+  items: [validCartItem],
+  clearCart: mockClearCart,
+  removeItem: mockRemoveItem,
+  updateQuantity: mockUpdateQuantity,
+  getCartTotal: () => 76,
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('@/services', () => ({
+  orderService: {
+    createOrder: vi.fn(),
+  },
+  paymentService: {
+    createCheckoutSession: vi.fn(),
+    getSessionStatus: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/useCartStore', () => ({
+  useCartStore: vi.fn((selector?: (state: typeof mockCartState) => unknown) =>
+    selector ? selector(mockCartState) : mockCartState,
+  ),
+}));
+
+vi.mock('@/utils/navigation', () => ({
+  redirectToExternalUrl: vi.fn(),
+}));
+
+const fillRequiredFields = async () => {
+  const user = userEvent.setup();
+
+  await user.type(screen.getByPlaceholderText('First name'), 'John');
+  await user.type(screen.getByPlaceholderText('Last name'), 'Doe');
+  await user.type(screen.getByPlaceholderText('Phone number'), '+380501234567');
+  await user.type(
+    screen.getByPlaceholderText('Email address'),
+    'john@example.com',
+  );
+  await user.type(screen.getByPlaceholderText('Town / City'), 'Kyiv');
+  await user.type(screen.getByPlaceholderText('Department code'), '42');
+
+  return user;
+};
+
+describe('Page: Checkout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+
+    mockCartState = {
+      items: [validCartItem],
+      clearCart: mockClearCart,
+      removeItem: mockRemoveItem,
+      updateQuantity: mockUpdateQuantity,
+      getCartTotal: () => 76,
+    };
+
+    (useTheme as unknown as Mock).mockReturnValue({ isDark: false });
+    (useCartStore as unknown as Mock).mockImplementation(
+      (selector?: (state: typeof mockCartState) => unknown) =>
+        selector ? selector(mockCartState) : mockCartState,
+    );
+    (orderService.createOrder as Mock).mockResolvedValue({
+      orderId: 'ORD-20260325-0001',
+      items: [
+        {
+          product: validCartItem.product._id,
+          title: validCartItem.product.title,
+          imageUrl: validCartItem.product.imageUrl,
+          unitPrice: validCartItem.product.price,
+          amount: validCartItem.quantity,
+        },
+      ],
+      totalPrice: 76,
+      amount: 76,
+    });
+    (paymentService.createCheckoutSession as Mock).mockResolvedValue({
+      sessionId: 'cs_test_123',
+      sessionUrl: 'https://checkout.stripe.com/c/pay/cs_test_123',
+    });
+  });
+
+  it('renders checkout sections, summary, total note, and autofill-friendly inputs', () => {
+    render(<Checkout />);
+
+    expect(screen.getByText('Contact Infomation')).toBeInTheDocument();
+    expect(screen.getByText('Shipping Address')).toBeInTheDocument();
+    expect(screen.getByText('Payment method')).toBeInTheDocument();
+    expect(screen.getAllByText('Order summary')).toHaveLength(2);
+    expect(
+      screen.getAllByText('Final price may change depending on delivery cost.'),
+    ).toHaveLength(2);
+
+    expect(screen.getByPlaceholderText('First name')).toHaveAttribute(
+      'autocomplete',
+      'given-name',
+    );
+    expect(screen.getByPlaceholderText('Last name')).toHaveAttribute(
+      'autocomplete',
+      'family-name',
+    );
+    expect(screen.getByPlaceholderText('Phone number')).toHaveAttribute(
+      'autocomplete',
+      'tel',
+    );
+    expect(screen.getByPlaceholderText('Email address')).toHaveAttribute(
+      'autocomplete',
+      'email',
+    );
+
+    const deliverySelect = screen.getByRole('combobox');
+    expect(deliverySelect).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Нова Пошта' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Укрпошта' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Meest' })).toBeInTheDocument();
+  });
+
+  it('shows Stripe info only for card payments and switches CTA copy', async () => {
+    const user = userEvent.setup();
+
+    render(<Checkout />);
+
+    expect(
+      screen.getByText('Card details are entered securely on Stripe.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('1234 1234 1234'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Continue to Stripe' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Cash on delivery'));
+    expect(
+      screen.queryByText('Card details are entered securely on Stripe.'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Place Order' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Pay with card securely'));
+    expect(
+      screen.getByText('Card details are entered securely on Stripe.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Continue to Stripe' }),
+    ).toBeInTheDocument();
+  });
+
+  it('blocks submit when a cart item has no valid backend product id', async () => {
+    mockCartState = {
+      ...mockCartState,
+      items: [
+        {
+          ...validCartItem,
+          product: {
+            ...validCartItem.product,
+            _id: '',
+            id: 'local-product-id',
+          },
+        },
+      ],
+      getCartTotal: () => 76,
+    };
+
+    (useCartStore as unknown as Mock).mockImplementation(
+      (selector?: (state: typeof mockCartState) => unknown) =>
+        selector ? selector(mockCartState) : mockCartState,
+    );
+
+    render(<Checkout />);
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole('button', { name: 'Continue to Stripe' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'Some cart items cannot be checked out because they are missing a valid product ID.',
+      ),
+    ).toBeInTheDocument();
+    expect(orderService.createOrder).not.toHaveBeenCalled();
+  });
+
+  it('creates a cash-on-delivery order, clears the cart, and navigates to confirmation', async () => {
+    render(<Checkout />);
+
+    const user = await fillRequiredFields();
+    await user.click(screen.getByLabelText('Cash on delivery'));
+    await user.click(screen.getByRole('button', { name: 'Place Order' }));
+
+    await waitFor(() => {
+      expect(orderService.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentMethod: 'cash_on_delivery',
+          user: expect.objectContaining({
+            email: 'john@example.com',
+          }),
+          shippingAddress: expect.objectContaining({
+            city: 'Kyiv',
+            branchNumber: '42',
+          }),
+        }),
+      );
+      expect(mockClearCart).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ORDER_CONFIRMATION, {
+        state: expect.objectContaining({
+          paymentStatus: 'pending',
+          orderSnapshot: expect.objectContaining({
+            orderId: 'ORD-20260325-0001',
+            paymentMethod: 'cash_on_delivery',
+          }),
+        }),
+      });
+    });
+  });
+
+  it('creates an online order, starts Stripe checkout, and keeps the cart intact until confirmation', async () => {
+    render(<Checkout />);
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole('button', { name: 'Continue to Stripe' }),
+    );
+
+    await waitFor(() => {
+      expect(orderService.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentMethod: 'stripe',
+        }),
+      );
+      expect(paymentService.createCheckoutSession).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            productId: validCartItem.product._id,
+            quantity: validCartItem.quantity,
+          }),
+        ],
+        'ORD-20260325-0001',
+      );
+      expect(
+        (orderService.createOrder as Mock).mock.calls[0][0],
+      ).not.toHaveProperty('cardNumber');
+      expect(
+        (orderService.createOrder as Mock).mock.calls[0][0],
+      ).not.toHaveProperty('expirationDate');
+      expect(
+        (orderService.createOrder as Mock).mock.calls[0][0],
+      ).not.toHaveProperty('cvc');
+      expect(mockClearCart).not.toHaveBeenCalled();
+      expect(redirectToExternalUrl).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/pay/cs_test_123',
+      );
+    });
+  });
+});

--- a/src/pages/Checkout/Checkout.test.tsx
+++ b/src/pages/Checkout/Checkout.test.tsx
@@ -228,6 +228,66 @@ describe('Page: Checkout', () => {
     expect(orderService.createOrder).not.toHaveBeenCalled();
   });
 
+  it('syncs restored browser values after returning to checkout and submits them correctly', async () => {
+    render(<Checkout />);
+
+    const firstNameInput = screen.getByPlaceholderText(
+      'First name',
+    ) as HTMLInputElement;
+    const lastNameInput = screen.getByPlaceholderText(
+      'Last name',
+    ) as HTMLInputElement;
+    const phoneInput = screen.getByPlaceholderText(
+      'Phone number',
+    ) as HTMLInputElement;
+    const emailInput = screen.getByPlaceholderText(
+      'Email address',
+    ) as HTMLInputElement;
+    const cityInput = screen.getByPlaceholderText(
+      'Town / City',
+    ) as HTMLInputElement;
+    const branchInput = screen.getByPlaceholderText(
+      'Department code',
+    ) as HTMLInputElement;
+
+    firstNameInput.value = 'Pavlo';
+    lastNameInput.value = 'Cat';
+    phoneInput.value = '+380501112233';
+    emailInput.value = 'customer@test.com';
+    cityInput.value = 'Kyiv';
+    branchInput.value = '12';
+
+    window.dispatchEvent(new Event('pageshow'));
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', { name: 'Continue to Stripe' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Phone number is required'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Email address is required'),
+      ).not.toBeInTheDocument();
+      expect(orderService.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({
+            firstName: 'Pavlo',
+            lastName: 'Cat',
+            phone: '+380501112233',
+            email: 'customer@test.com',
+          }),
+          shippingAddress: expect.objectContaining({
+            city: 'Kyiv',
+            branchNumber: '12',
+          }),
+        }),
+      );
+    });
+  });
+
   it('creates a cash-on-delivery order, clears the cart, and navigates to confirmation', async () => {
     render(<Checkout />);
 

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -1,0 +1,1007 @@
+import { useMemo, useState } from 'react';
+import { useForm, type UseFormRegisterReturn, useWatch } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { zodResolver } from '@hookform/resolvers/zod';
+import clsx from 'clsx';
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  CreditCard,
+  LockKeyhole,
+  Minus,
+  Plus,
+  TicketPercent,
+  X,
+} from 'lucide-react';
+import { z } from 'zod';
+
+import { Button, TextArea } from '@/components';
+import { ROUTES } from '@/constants';
+import { useTheme } from '@/hooks/useTheme';
+import { orderService, paymentService } from '@/services';
+import { useCartStore } from '@/store/useCartStore';
+import {
+  type CheckoutOrderSnapshot,
+  type CreateOrderPayload,
+  PAYMENT_METHODS,
+  SHIPPING_CARRIERS,
+} from '@/types';
+import { checkoutStorage } from '@/utils/checkoutStorage';
+import { redirectToExternalUrl } from '@/utils/navigation';
+
+const fieldLabelClassName =
+  'text-[12px] font-bold uppercase tracking-[0.02em] text-gray-600';
+
+const baseFieldClassName =
+  'box-border h-10 w-full max-w-full rounded-md border px-[15px] text-sm outline-none transition-colors placeholder:text-gray-600';
+
+const checkoutSchema = z.object({
+  firstName: z.string().trim().min(1, 'First name is required'),
+  lastName: z.string().trim().min(1, 'Last name is required'),
+  phone: z.string().trim().min(1, 'Phone number is required'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email address is required')
+    .email('Enter a valid email address'),
+  carrier: z.enum([
+    SHIPPING_CARRIERS.NOVA_POST,
+    SHIPPING_CARRIERS.UKRPOSHTA,
+    SHIPPING_CARRIERS.MEEST,
+  ]),
+  city: z.string().trim().min(1, 'Town / City is required'),
+  branchNumber: z.string().trim().min(1, 'Department code is required'),
+  paymentMethod: z.enum([
+    PAYMENT_METHODS.STRIPE,
+    PAYMENT_METHODS.CASH_ON_DELIVERY,
+  ]),
+  message: z.string().optional(),
+});
+
+type CheckoutFormValues = z.infer<typeof checkoutSchema>;
+
+const isMongoId = (value?: string) =>
+  Boolean(value && /^[a-f\d]{24}$/i.test(value));
+
+const getFieldClassName = (isDark: boolean, hasError = false) =>
+  clsx(
+    baseFieldClassName,
+    isDark
+      ? 'border-gray-700 bg-black text-white'
+      : 'border-[#CBCBCB] bg-white text-[#141718]',
+    hasError &&
+      (isDark ? 'border-red-500 text-red-200' : 'border-red-500 text-red-600'),
+  );
+
+const formatCurrency = (value: number) => `$${value.toFixed(2)}`;
+
+const carrierOptions = [
+  { value: SHIPPING_CARRIERS.NOVA_POST, label: 'Нова Пошта' },
+  { value: SHIPPING_CARRIERS.UKRPOSHTA, label: 'Укрпошта' },
+  { value: SHIPPING_CARRIERS.MEEST, label: 'Meest' },
+] as const;
+
+export const Checkout = () => {
+  const navigate = useNavigate();
+  const { isDark } = useTheme();
+  const { items, clearCart, removeItem, updateQuantity, getCartTotal } =
+    useCartStore();
+
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [promoCode, setPromoCode] = useState('');
+
+  const subtotal = getCartTotal();
+  const total = subtotal;
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<CheckoutFormValues>({
+    resolver: zodResolver(checkoutSchema),
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      phone: '',
+      email: '',
+      carrier: SHIPPING_CARRIERS.NOVA_POST,
+      city: '',
+      branchNumber: '',
+      paymentMethod: PAYMENT_METHODS.STRIPE,
+      message: '',
+    },
+  });
+
+  const paymentMethod = useWatch({
+    control,
+    name: 'paymentMethod',
+  });
+
+  const checkoutItems = useMemo(
+    () =>
+      items.map((item) => ({
+        productId: item.product._id ?? item.product.id,
+        title: item.product.title,
+        price: item.product.price,
+        quantity: item.quantity,
+        imageUrl: item.product.imageUrl,
+      })),
+    [items],
+  );
+
+  const buildOrderSnapshot = (
+    values: CheckoutFormValues,
+    payload: Awaited<ReturnType<typeof orderService.createOrder>>,
+  ): CheckoutOrderSnapshot => ({
+    orderId: payload.orderId,
+    amount: payload.amount,
+    totalPrice: payload.totalPrice,
+    paymentMethod: values.paymentMethod,
+    items: payload.items,
+    customerName: `${values.firstName} ${values.lastName}`.trim(),
+  });
+
+  const onSubmit = async (values: CheckoutFormValues) => {
+    setSubmitError(null);
+
+    if (items.length === 0) {
+      setSubmitError(
+        'Your cart is empty. Add products before placing an order.',
+      );
+      return;
+    }
+
+    const invalidItem = items.find((item) => !isMongoId(item.product._id));
+
+    if (invalidItem) {
+      setSubmitError(
+        'Some cart items cannot be checked out because they are missing a valid product ID.',
+      );
+      return;
+    }
+
+    const payload: CreateOrderPayload = {
+      items: items.map((item) => ({
+        product: item.product._id!,
+        amount: item.quantity,
+      })),
+      shippingAddress: {
+        carrier: values.carrier,
+        city: values.city,
+        branchNumber: values.branchNumber,
+      },
+      user: {
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        phone: values.phone,
+      },
+      paymentMethod: values.paymentMethod,
+      message: values.message?.trim() || undefined,
+    };
+
+    try {
+      const createdOrder = await orderService.createOrder(payload);
+      const snapshot = buildOrderSnapshot(values, createdOrder);
+      checkoutStorage.save(snapshot);
+
+      if (values.paymentMethod === PAYMENT_METHODS.CASH_ON_DELIVERY) {
+        clearCart();
+        navigate(ROUTES.ORDER_CONFIRMATION, {
+          state: {
+            orderSnapshot: snapshot,
+            paymentStatus: 'pending',
+          },
+        });
+        return;
+      }
+
+      const { sessionUrl } = await paymentService.createCheckoutSession(
+        checkoutItems,
+        createdOrder.orderId,
+      );
+
+      redirectToExternalUrl(sessionUrl);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Something went wrong while placing your order.';
+      setSubmitError(message);
+    }
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center px-6 text-center">
+        <h1
+          className={clsx(
+            'text-[40px] leading-[44px] font-medium tracking-[-0.4px]',
+            isDark ? 'text-white' : 'text-[#141718]',
+          )}
+        >
+          Check Out
+        </h1>
+        <p
+          className={clsx(
+            'mt-4 text-base',
+            isDark ? 'text-gray-400' : 'text-gray-600',
+          )}
+        >
+          Your cart is empty. Add products before continuing to checkout.
+        </p>
+        <Button onClick={() => navigate(ROUTES.SHOP)} className="mt-8 px-8">
+          Continue Shopping
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx('pt-4 pb-16 md:pt-10', isDark ? 'bg-black' : 'bg-white')}
+    >
+      <div className="mx-auto max-w-[1120px] px-4 md:px-8 lg:px-0">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className={clsx(
+            'mb-7 flex items-center gap-1 text-sm font-medium md:hidden',
+            isDark ? 'text-gray-400' : 'text-[#605F5F]',
+          )}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          back
+        </button>
+
+        <h1
+          className={clsx(
+            'text-center text-[40px] leading-[44px] font-medium tracking-[-0.4px] md:text-[54px] md:leading-[58px] md:tracking-[-1px]',
+            isDark ? 'text-white' : 'text-[#141718]',
+          )}
+        >
+          Check Out
+        </h1>
+
+        <DesktopProcess isDark={isDark} />
+        <MobileProcess isDark={isDark} />
+
+        <div className="mt-10 lg:grid lg:grid-cols-[minmax(0,643px)_376px] lg:items-start lg:justify-between lg:gap-[101px]">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <CheckoutSection
+              title="Contact Infomation"
+              isDark={isDark}
+              className="md:px-[23px] md:pt-[39px] md:pb-10"
+            >
+              <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:gap-x-6 md:gap-y-0">
+                <Field
+                  label="First Name *"
+                  error={errors.firstName?.message}
+                  isDark={isDark}
+                >
+                  <input
+                    {...register('firstName')}
+                    type="text"
+                    name="firstName"
+                    autoComplete="given-name"
+                    placeholder="First name"
+                    className={getFieldClassName(
+                      isDark,
+                      Boolean(errors.firstName),
+                    )}
+                  />
+                </Field>
+                <Field
+                  label="Last Name *"
+                  error={errors.lastName?.message}
+                  isDark={isDark}
+                >
+                  <input
+                    {...register('lastName')}
+                    type="text"
+                    name="lastName"
+                    autoComplete="family-name"
+                    placeholder="Last name"
+                    className={getFieldClassName(
+                      isDark,
+                      Boolean(errors.lastName),
+                    )}
+                  />
+                </Field>
+              </div>
+
+              <Field
+                label="Phone Number *"
+                error={errors.phone?.message}
+                isDark={isDark}
+              >
+                <input
+                  {...register('phone')}
+                  type="tel"
+                  name="phone"
+                  autoComplete="tel"
+                  placeholder="Phone number"
+                  className={getFieldClassName(isDark, Boolean(errors.phone))}
+                />
+              </Field>
+
+              <Field
+                label="Email Address *"
+                error={errors.email?.message}
+                isDark={isDark}
+              >
+                <input
+                  {...register('email')}
+                  type="email"
+                  name="email"
+                  autoComplete="email"
+                  placeholder="Email address"
+                  className={getFieldClassName(isDark, Boolean(errors.email))}
+                />
+              </Field>
+            </CheckoutSection>
+
+            <CheckoutSection
+              title="Shipping Address"
+              isDark={isDark}
+              className="md:px-[23px] md:pt-[39px] md:pb-10"
+            >
+              <Field
+                label="Delivery *"
+                error={errors.carrier?.message}
+                isDark={isDark}
+              >
+                <div className="relative">
+                  <select
+                    {...register('carrier')}
+                    name="carrier"
+                    autoComplete="shipping country"
+                    className={clsx(
+                      getFieldClassName(isDark, Boolean(errors.carrier)),
+                      'appearance-none pr-10',
+                    )}
+                  >
+                    {carrierOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown
+                    className={clsx(
+                      'pointer-events-none absolute top-1/2 right-4 h-4 w-4 -translate-y-1/2',
+                      isDark ? 'text-gray-500' : 'text-[#6C7275]',
+                    )}
+                  />
+                </div>
+              </Field>
+
+              <Field
+                label="Town / City *"
+                error={errors.city?.message}
+                isDark={isDark}
+              >
+                <input
+                  {...register('city')}
+                  type="text"
+                  name="city"
+                  autoComplete="address-level2"
+                  placeholder="Town / City"
+                  className={getFieldClassName(isDark, Boolean(errors.city))}
+                />
+              </Field>
+
+              <Field
+                label="Department Code*"
+                error={errors.branchNumber?.message}
+                isDark={isDark}
+              >
+                <input
+                  {...register('branchNumber')}
+                  type="text"
+                  name="branchNumber"
+                  autoComplete="address-line2"
+                  placeholder="Department code"
+                  className={getFieldClassName(
+                    isDark,
+                    Boolean(errors.branchNumber),
+                  )}
+                />
+              </Field>
+            </CheckoutSection>
+
+            <CheckoutSection
+              title="Payment method"
+              isDark={isDark}
+              className="md:px-[23px] md:pt-[39px] md:pb-10"
+            >
+              <div
+                className={clsx(
+                  'space-y-6',
+                  isDark ? 'border-gray-700' : 'border-[#6C7275]',
+                )}
+              >
+                <div className="space-y-6 border-b pb-6">
+                  <PaymentOption
+                    label="Pay with card securely"
+                    value={PAYMENT_METHODS.STRIPE}
+                    selectedValue={paymentMethod}
+                    isDark={isDark}
+                    icon={<CreditCard className="h-4 w-4" />}
+                    inputProps={register('paymentMethod')}
+                  />
+
+                  <PaymentOption
+                    label="Cash on delivery"
+                    value={PAYMENT_METHODS.CASH_ON_DELIVERY}
+                    selectedValue={paymentMethod}
+                    isDark={isDark}
+                    inputProps={register('paymentMethod')}
+                  />
+                </div>
+
+                {paymentMethod === PAYMENT_METHODS.STRIPE && (
+                  <StripeInfoPanel isDark={isDark} />
+                )}
+              </div>
+            </CheckoutSection>
+
+            <CheckoutSection
+              title="Additional information"
+              isDark={isDark}
+              className="hidden md:block md:px-[23px] md:pt-[23px] md:pb-10"
+            >
+              <Field label="Message" isDark={isDark}>
+                <TextArea
+                  {...register('message')}
+                  name="message"
+                  autoComplete="off"
+                  placeholder="Your message"
+                  textAreaClassName={clsx(
+                    'box-border min-h-[140px] w-full max-w-full rounded-md px-[15px] py-3 text-sm',
+                    isDark
+                      ? 'border-gray-700 bg-black text-white'
+                      : 'border-[#CBCBCB] bg-white text-[#141718]',
+                  )}
+                />
+              </Field>
+            </CheckoutSection>
+
+            <div className="lg:hidden">
+              <OrderSummary
+                isDark={isDark}
+                promoCode={promoCode}
+                setPromoCode={setPromoCode}
+                subtotal={subtotal}
+                total={total}
+                items={items}
+                removeItem={removeItem}
+                updateQuantity={updateQuantity}
+              />
+            </div>
+
+            {submitError && (
+              <p className="text-sm font-medium text-red-500">{submitError}</p>
+            )}
+
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className={clsx(
+                'h-[52px] w-full rounded-[8px] border-none text-base font-medium shadow-none transition-colors hover:border-none md:max-w-[643px]',
+                isDark
+                  ? 'bg-white text-[#141718] hover:bg-gray-200'
+                  : 'bg-[#141718] text-white hover:bg-black',
+              )}
+            >
+              {isSubmitting
+                ? paymentMethod === PAYMENT_METHODS.STRIPE
+                  ? 'Continuing to Stripe...'
+                  : 'Placing order...'
+                : paymentMethod === PAYMENT_METHODS.STRIPE
+                  ? 'Continue to Stripe'
+                  : 'Place Order'}
+            </Button>
+          </form>
+
+          <div className="hidden lg:block">
+            <OrderSummary
+              isDark={isDark}
+              promoCode={promoCode}
+              setPromoCode={setPromoCode}
+              subtotal={subtotal}
+              total={total}
+              items={items}
+              removeItem={removeItem}
+              updateQuantity={updateQuantity}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DesktopProcess = ({ isDark }: { isDark: boolean }) => (
+  <div className="mx-auto mt-10 hidden max-w-[832px] items-start justify-between md:flex">
+    <ProcessStep
+      isDark={isDark}
+      title="Shopping cart"
+      number="1"
+      state="completed"
+    />
+    <ProcessStep
+      isDark={isDark}
+      title="Checkout details"
+      number="2"
+      state="current"
+    />
+    <ProcessStep
+      isDark={isDark}
+      title="Order complete"
+      number="3"
+      state="upcoming"
+    />
+  </div>
+);
+
+const MobileProcess = ({ isDark }: { isDark: boolean }) => (
+  <div className="mt-6 flex overflow-hidden md:hidden">
+    <div className="min-w-[256px]">
+      <ProcessStep
+        isDark={isDark}
+        title="Checkout details"
+        number="2"
+        state="current"
+      />
+    </div>
+    <div className="ml-8 min-w-[256px]">
+      <ProcessStep
+        isDark={isDark}
+        title="Order complete"
+        number="3"
+        state="upcoming"
+      />
+    </div>
+  </div>
+);
+
+const ProcessStep = ({
+  title,
+  number,
+  state,
+  isDark,
+}: {
+  title: string;
+  number: string;
+  state: 'completed' | 'current' | 'upcoming';
+  isDark: boolean;
+}) => {
+  const containerClassName =
+    state === 'completed'
+      ? 'border-primary text-primary'
+      : state === 'current'
+        ? isDark
+          ? 'border-white text-white'
+          : 'border-[#141718] text-[#23262F]'
+        : isDark
+          ? 'border-gray-700 text-gray-500'
+          : 'border-[#E8ECEF] text-[#B1B5C3]';
+
+  const badgeClassName =
+    state === 'completed'
+      ? 'bg-primary text-white'
+      : state === 'current'
+        ? isDark
+          ? 'bg-white text-[#141718]'
+          : 'bg-[#23262F] text-white'
+        : isDark
+          ? 'bg-gray-700 text-white'
+          : 'bg-[#B1B5C3] text-white';
+
+  return (
+    <div className={clsx('border-b-2 pb-6', containerClassName)}>
+      <div className="flex items-center gap-4">
+        <div
+          className={clsx(
+            'flex h-10 w-10 items-center justify-center rounded-full text-base font-semibold',
+            badgeClassName,
+          )}
+        >
+          {state === 'completed' ? <Check className="h-5 w-5" /> : number}
+        </div>
+        <span className="text-base font-semibold">{title}</span>
+      </div>
+    </div>
+  );
+};
+
+const CheckoutSection = ({
+  title,
+  isDark,
+  className,
+  children,
+}: {
+  title: string;
+  isDark: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) => (
+  <section
+    className={clsx(
+      'rounded-[4px] border px-[15px] pt-[23px] pb-6',
+      isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
+      className,
+    )}
+  >
+    <h2
+      className={clsx(
+        'mb-6 text-base leading-[26px] font-semibold md:text-[20px] md:leading-[28px] md:font-medium',
+        isDark ? 'text-white' : 'text-[#141718]',
+      )}
+    >
+      {title}
+    </h2>
+    <div className="space-y-6">{children}</div>
+  </section>
+);
+
+const Field = ({
+  label,
+  error,
+  isDark,
+  children,
+}: {
+  label: string;
+  error?: string;
+  isDark: boolean;
+  children: React.ReactNode;
+}) => (
+  <div className="min-w-0 space-y-3">
+    <label className={fieldLabelClassName}>{label}</label>
+    {children}
+    {error && (
+      <p className={clsx('text-xs', isDark ? 'text-red-400' : 'text-red-500')}>
+        {error}
+      </p>
+    )}
+  </div>
+);
+
+const PaymentOption = ({
+  label,
+  value,
+  selectedValue,
+  isDark,
+  icon,
+  inputProps,
+}: {
+  label: string;
+  value: CheckoutFormValues['paymentMethod'];
+  selectedValue: CheckoutFormValues['paymentMethod'];
+  isDark: boolean;
+  icon?: React.ReactNode;
+  inputProps: UseFormRegisterReturn<'paymentMethod'>;
+}) => (
+  <label
+    className={clsx(
+      'flex cursor-pointer items-center justify-between rounded-[4px] border px-[15px] py-[13px]',
+      selectedValue === value
+        ? isDark
+          ? 'border-white bg-[#111111]'
+          : 'border-[#141718] bg-[#F3F5F7]'
+        : isDark
+          ? 'border-gray-700 bg-black'
+          : 'border-[#6C7275] bg-white',
+    )}
+  >
+    <div className="flex items-center gap-3">
+      <input
+        {...inputProps}
+        value={value}
+        type="radio"
+        className="h-[18px] w-[18px] accent-[#141718]"
+      />
+      <span
+        className={clsx('text-base', isDark ? 'text-white' : 'text-[#141718]')}
+      >
+        {label}
+      </span>
+    </div>
+    {icon && (
+      <span className={clsx(isDark ? 'text-gray-400' : 'text-[#141718]')}>
+        {icon}
+      </span>
+    )}
+  </label>
+);
+
+const StripeInfoPanel = ({ isDark }: { isDark: boolean }) => (
+  <div
+    className={clsx(
+      'rounded-[6px] border px-4 py-4 md:px-[15px]',
+      isDark
+        ? 'border-gray-700 bg-[#111111] text-white'
+        : 'border-[#6C7275] bg-[#FEFEFE] text-[#141718]',
+    )}
+  >
+    <div className="flex items-start gap-3">
+      <span
+        className={clsx(
+          'mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          isDark ? 'bg-black text-gray-300' : 'bg-[#F3F5F7] text-[#141718]',
+        )}
+      >
+        <LockKeyhole className="h-4 w-4" />
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm font-medium md:text-base">
+          Card details are entered securely on Stripe.
+        </p>
+        <p
+          className={clsx(
+            'mt-1 text-sm leading-6',
+            isDark ? 'text-gray-400' : 'text-[#6C7275]',
+          )}
+        >
+          After you continue, Stripe will open in a secure checkout page where
+          you can enter your card information once and complete the payment.
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+function OrderSummary({
+  isDark,
+  promoCode,
+  setPromoCode,
+  subtotal,
+  total,
+  items,
+  removeItem,
+  updateQuantity,
+}: {
+  isDark: boolean;
+  promoCode: string;
+  setPromoCode: (value: string) => void;
+  subtotal: number;
+  total: number;
+  items: ReturnType<typeof useCartStore.getState>['items'];
+  removeItem: ReturnType<typeof useCartStore.getState>['removeItem'];
+  updateQuantity: ReturnType<typeof useCartStore.getState>['updateQuantity'];
+}) {
+  return (
+    <aside
+      className={clsx(
+        'rounded-[6px] border px-[15px] py-[15px] md:px-[23px] md:py-[31px]',
+        isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
+      )}
+    >
+      <h2
+        className={clsx(
+          'text-[20px] leading-[28px] font-medium',
+          isDark ? 'text-white' : 'text-[#121212]',
+        )}
+      >
+        Order summary
+      </h2>
+
+      <div className="mt-6 space-y-6">
+        {items.map((item) => {
+          const productId = item.product.id || item.product._id!;
+          const lineTotal = item.product.price * item.quantity;
+
+          return (
+            <div
+              key={productId}
+              className={clsx(
+                'border-b pb-6',
+                isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+              )}
+            >
+              <div className="flex gap-4">
+                {item.product.imageUrl ? (
+                  <img
+                    src={item.product.imageUrl}
+                    alt={item.product.title}
+                    className="h-24 w-20 object-cover"
+                  />
+                ) : (
+                  <div
+                    className={clsx(
+                      'flex h-24 w-20 items-center justify-center',
+                      isDark ? 'bg-[#111111]' : 'bg-[#F3F5F7]',
+                    )}
+                  >
+                    <span className="text-xs text-gray-400">No image</span>
+                  </div>
+                )}
+
+                <div className="flex min-w-0 flex-1 justify-between gap-4">
+                  <div className="min-w-0">
+                    <p
+                      className={clsx(
+                        'text-sm leading-[22px] font-semibold',
+                        isDark ? 'text-white' : 'text-[#141718]',
+                      )}
+                    >
+                      {item.product.title}
+                    </p>
+                    {item.product.categories?.[0] && (
+                      <p
+                        className={clsx(
+                          'mt-2 text-xs leading-5',
+                          isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                        )}
+                      >
+                        {item.product.categories[0]}
+                      </p>
+                    )}
+
+                    <div
+                      className={clsx(
+                        'mt-3 flex h-8 w-20 items-center rounded-[4px] border px-[7px]',
+                        isDark ? 'border-gray-700' : 'border-[#6C7275]',
+                      )}
+                    >
+                      <button
+                        type="button"
+                        onClick={() =>
+                          updateQuantity(productId, item.quantity - 1)
+                        }
+                        disabled={item.quantity <= 1}
+                        className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current disabled:opacity-40"
+                        aria-label={`Decrease quantity for ${item.product.title}`}
+                      >
+                        <Minus className="h-3 w-3" />
+                      </button>
+                      <span
+                        className={clsx(
+                          'flex-1 text-center text-xs font-semibold',
+                          isDark ? 'text-white' : 'text-[#121212]',
+                        )}
+                      >
+                        {item.quantity}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          updateQuantity(productId, item.quantity + 1)
+                        }
+                        className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current"
+                        aria-label={`Increase quantity for ${item.product.title}`}
+                      >
+                        <Plus className="h-3 w-3" />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col items-end">
+                    <p
+                      className={clsx(
+                        'text-sm leading-[22px] font-semibold',
+                        isDark ? 'text-white' : 'text-[#121212]',
+                      )}
+                    >
+                      {formatCurrency(lineTotal)}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => removeItem(productId)}
+                      className={clsx(
+                        'mt-2 border-none bg-transparent p-0',
+                        isDark ? 'text-gray-400' : 'text-[#141718]',
+                      )}
+                      aria-label={`Remove ${item.product.title}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+
+        <div className="flex gap-3">
+          <input
+            value={promoCode}
+            onChange={(event) => setPromoCode(event.target.value)}
+            type="text"
+            name="promoCode"
+            autoComplete="off"
+            placeholder="Promo code"
+            className={clsx(
+              'box-border h-[52px] max-w-full flex-1 rounded-[6px] border px-[15px] text-base outline-none placeholder:text-[#605F5F]',
+              isDark
+                ? 'border-gray-700 bg-black text-white'
+                : 'border-[#CBCBCB] bg-white text-[#141718]',
+            )}
+          />
+          <Button
+            type="button"
+            onClick={() => setPromoCode('')}
+            className={clsx(
+              'h-[52px] rounded-[8px] border-none px-6 text-base font-medium shadow-none',
+              isDark
+                ? 'bg-white text-[#141718] hover:bg-gray-200'
+                : 'bg-[#141718] text-white hover:bg-black',
+            )}
+          >
+            Apply
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div
+            className={clsx(
+              'flex items-center justify-between border-b pb-4',
+              isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <TicketPercent className="h-4 w-4" />
+              <span className={clsx(isDark ? 'text-white' : 'text-[#141718]')}>
+                Promo
+              </span>
+            </div>
+            <span className="text-[#38CB89]">Not applied</span>
+          </div>
+
+          <div
+            className={clsx(
+              'flex items-center justify-between border-b pb-4',
+              isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+            )}
+          >
+            <span className={clsx(isDark ? 'text-white' : 'text-[#141718]')}>
+              Shipping
+            </span>
+            <span
+              className={clsx(
+                'text-right',
+                isDark ? 'text-gray-400' : 'text-[#6C7275]',
+              )}
+            >
+              Carrier tariffs | Free
+            </span>
+          </div>
+
+          <div>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p
+                  className={clsx(
+                    'text-[20px] leading-[28px] font-medium',
+                    isDark ? 'text-white' : 'text-[#141718]',
+                  )}
+                >
+                  Total <span className="align-top text-sm">*</span>
+                </p>
+                <p
+                  className={clsx(
+                    'mt-1 text-xs',
+                    isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                  )}
+                >
+                  Final price may change depending on delivery cost.
+                </p>
+              </div>
+              <p
+                className={clsx(
+                  'text-[20px] leading-[28px] font-medium',
+                  isDark ? 'text-white' : 'text-[#141718]',
+                )}
+              >
+                {formatCurrency(total || subtotal)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -1,22 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useForm, type UseFormRegisterReturn, useWatch } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import clsx from 'clsx';
-import {
-  ArrowLeft,
-  Check,
-  ChevronDown,
-  CreditCard,
-  LockKeyhole,
-  Minus,
-  Plus,
-  TicketPercent,
-  X,
-} from 'lucide-react';
-import { z } from 'zod';
+import { ArrowLeft } from 'lucide-react';
 
-import { Button, TextArea } from '@/components';
+import { Button } from '@/components';
 import { ROUTES } from '@/constants';
 import { useTheme } from '@/hooks/useTheme';
 import { orderService, paymentService } from '@/services';
@@ -30,100 +19,35 @@ import {
 import { checkoutStorage } from '@/utils/checkoutStorage';
 import { redirectToExternalUrl } from '@/utils/navigation';
 
-const fieldLabelClassName =
-  'text-[12px] font-bold uppercase tracking-[0.02em] text-gray-600';
+import {
+  checkoutFieldNames,
+  type CheckoutFormValues,
+  checkoutSchema,
+  isMongoId,
+  readControlValue,
+} from './checkout.helpers';
+import { DesktopProcess, MobileProcess } from './CheckoutProcess';
+import {
+  AdditionalInformationSection,
+  ContactInformationSection,
+  PaymentMethodSection,
+  ShippingAddressSection,
+} from './CheckoutSections';
+import { OrderSummary } from './OrderSummary';
 
-const baseFieldClassName =
-  'box-border h-10 w-full max-w-full rounded-md border px-[15px] text-sm outline-none transition-colors placeholder:text-gray-600';
-
-const checkoutSchema = z.object({
-  firstName: z.string().trim().min(1, 'First name is required'),
-  lastName: z.string().trim().min(1, 'Last name is required'),
-  phone: z.string().trim().min(1, 'Phone number is required'),
-  email: z
-    .string()
-    .trim()
-    .min(1, 'Email address is required')
-    .email('Enter a valid email address'),
-  carrier: z.enum([
-    SHIPPING_CARRIERS.NOVA_POST,
-    SHIPPING_CARRIERS.UKRPOSHTA,
-    SHIPPING_CARRIERS.MEEST,
-  ]),
-  city: z.string().trim().min(1, 'Town / City is required'),
-  branchNumber: z.string().trim().min(1, 'Department code is required'),
-  paymentMethod: z.enum([
-    PAYMENT_METHODS.STRIPE,
-    PAYMENT_METHODS.CASH_ON_DELIVERY,
-  ]),
-  message: z.string().optional(),
-});
-
-type CheckoutFormValues = z.infer<typeof checkoutSchema>;
-type CheckoutFieldName = keyof CheckoutFormValues;
-
-const isMongoId = (value?: string) =>
-  Boolean(value && /^[a-f\d]{24}$/i.test(value));
-
-const checkoutFieldNames: CheckoutFieldName[] = [
-  'firstName',
-  'lastName',
-  'phone',
-  'email',
-  'carrier',
-  'city',
-  'branchNumber',
-  'paymentMethod',
-  'message',
-];
-
-const readControlValue = (
-  control: Element | RadioNodeList | null,
-): string | null => {
-  if (!control) {
-    return null;
-  }
-
-  if (
-    typeof RadioNodeList !== 'undefined' &&
-    control instanceof RadioNodeList
-  ) {
-    const checkedInput = Array.from(control).find(
-      (item): item is HTMLInputElement =>
-        item instanceof HTMLInputElement && item.checked,
-    );
-
-    return checkedInput?.value ?? null;
-  }
-
-  if (
-    control instanceof HTMLInputElement ||
-    control instanceof HTMLTextAreaElement ||
-    control instanceof HTMLSelectElement
-  ) {
-    return control.value;
-  }
-
-  return null;
+const submitButtonLabels: Record<
+  CheckoutFormValues['paymentMethod'],
+  { idle: string; loading: string }
+> = {
+  [PAYMENT_METHODS.STRIPE]: {
+    idle: 'Continue to Stripe',
+    loading: 'Continuing to Stripe...',
+  },
+  [PAYMENT_METHODS.CASH_ON_DELIVERY]: {
+    idle: 'Place Order',
+    loading: 'Placing order...',
+  },
 };
-
-const getFieldClassName = (isDark: boolean, hasError = false) =>
-  clsx(
-    baseFieldClassName,
-    isDark
-      ? 'border-gray-700 bg-black text-white'
-      : 'border-[#CBCBCB] bg-white text-[#141718]',
-    hasError &&
-      (isDark ? 'border-red-500 text-red-200' : 'border-red-500 text-red-600'),
-  );
-
-const formatCurrency = (value: number) => `$${value.toFixed(2)}`;
-
-const carrierOptions = [
-  { value: SHIPPING_CARRIERS.NOVA_POST, label: 'Нова Пошта' },
-  { value: SHIPPING_CARRIERS.UKRPOSHTA, label: 'Укрпошта' },
-  { value: SHIPPING_CARRIERS.MEEST, label: 'Meest' },
-] as const;
 
 export const Checkout = () => {
   const navigate = useNavigate();
@@ -222,6 +146,10 @@ export const Checkout = () => {
       })),
     [items],
   );
+
+  const submitButtonText = isSubmitting
+    ? submitButtonLabels[paymentMethod].loading
+    : submitButtonLabels[paymentMethod].idle;
 
   const buildOrderSnapshot = (
     values: CheckoutFormValues,
@@ -366,204 +294,26 @@ export const Checkout = () => {
             onSubmit={handleSubmit(onSubmit)}
             className="space-y-6"
           >
-            <CheckoutSection
-              title="Contact Infomation"
+            <ContactInformationSection
               isDark={isDark}
-              className="md:px-[23px] md:pt-[39px] md:pb-10"
-            >
-              <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:gap-x-6 md:gap-y-0">
-                <Field
-                  label="First Name *"
-                  error={errors.firstName?.message}
-                  isDark={isDark}
-                >
-                  <input
-                    {...register('firstName')}
-                    type="text"
-                    name="firstName"
-                    autoComplete="given-name"
-                    placeholder="First name"
-                    className={getFieldClassName(
-                      isDark,
-                      Boolean(errors.firstName),
-                    )}
-                  />
-                </Field>
-                <Field
-                  label="Last Name *"
-                  error={errors.lastName?.message}
-                  isDark={isDark}
-                >
-                  <input
-                    {...register('lastName')}
-                    type="text"
-                    name="lastName"
-                    autoComplete="family-name"
-                    placeholder="Last name"
-                    className={getFieldClassName(
-                      isDark,
-                      Boolean(errors.lastName),
-                    )}
-                  />
-                </Field>
-              </div>
+              errors={errors}
+              register={register}
+            />
 
-              <Field
-                label="Phone Number *"
-                error={errors.phone?.message}
-                isDark={isDark}
-              >
-                <input
-                  {...register('phone')}
-                  type="tel"
-                  name="phone"
-                  autoComplete="tel"
-                  placeholder="Phone number"
-                  className={getFieldClassName(isDark, Boolean(errors.phone))}
-                />
-              </Field>
-
-              <Field
-                label="Email Address *"
-                error={errors.email?.message}
-                isDark={isDark}
-              >
-                <input
-                  {...register('email')}
-                  type="email"
-                  name="email"
-                  autoComplete="email"
-                  placeholder="Email address"
-                  className={getFieldClassName(isDark, Boolean(errors.email))}
-                />
-              </Field>
-            </CheckoutSection>
-
-            <CheckoutSection
-              title="Shipping Address"
+            <ShippingAddressSection
               isDark={isDark}
-              className="md:px-[23px] md:pt-[39px] md:pb-10"
-            >
-              <Field
-                label="Delivery *"
-                error={errors.carrier?.message}
-                isDark={isDark}
-              >
-                <div className="relative">
-                  <select
-                    {...register('carrier')}
-                    name="carrier"
-                    autoComplete="shipping country"
-                    className={clsx(
-                      getFieldClassName(isDark, Boolean(errors.carrier)),
-                      'appearance-none pr-10',
-                    )}
-                  >
-                    {carrierOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown
-                    className={clsx(
-                      'pointer-events-none absolute top-1/2 right-4 h-4 w-4 -translate-y-1/2',
-                      isDark ? 'text-gray-500' : 'text-[#6C7275]',
-                    )}
-                  />
-                </div>
-              </Field>
+              errors={errors}
+              register={register}
+            />
 
-              <Field
-                label="Town / City *"
-                error={errors.city?.message}
-                isDark={isDark}
-              >
-                <input
-                  {...register('city')}
-                  type="text"
-                  name="city"
-                  autoComplete="address-level2"
-                  placeholder="Town / City"
-                  className={getFieldClassName(isDark, Boolean(errors.city))}
-                />
-              </Field>
-
-              <Field
-                label="Department Code*"
-                error={errors.branchNumber?.message}
-                isDark={isDark}
-              >
-                <input
-                  {...register('branchNumber')}
-                  type="text"
-                  name="branchNumber"
-                  autoComplete="address-line2"
-                  placeholder="Department code"
-                  className={getFieldClassName(
-                    isDark,
-                    Boolean(errors.branchNumber),
-                  )}
-                />
-              </Field>
-            </CheckoutSection>
-
-            <CheckoutSection
-              title="Payment method"
+            <PaymentMethodSection
               isDark={isDark}
-              className="md:px-[23px] md:pt-[39px] md:pb-10"
-            >
-              <div
-                className={clsx(
-                  'space-y-6',
-                  isDark ? 'border-gray-700' : 'border-[#6C7275]',
-                )}
-              >
-                <div className="space-y-6 border-b pb-6">
-                  <PaymentOption
-                    label="Pay with card securely"
-                    value={PAYMENT_METHODS.STRIPE}
-                    selectedValue={paymentMethod}
-                    isDark={isDark}
-                    icon={<CreditCard className="h-4 w-4" />}
-                    inputProps={register('paymentMethod')}
-                  />
+              errors={errors}
+              register={register}
+              paymentMethod={paymentMethod}
+            />
 
-                  <PaymentOption
-                    label="Cash on delivery"
-                    value={PAYMENT_METHODS.CASH_ON_DELIVERY}
-                    selectedValue={paymentMethod}
-                    isDark={isDark}
-                    inputProps={register('paymentMethod')}
-                  />
-                </div>
-
-                {paymentMethod === PAYMENT_METHODS.STRIPE && (
-                  <StripeInfoPanel isDark={isDark} />
-                )}
-              </div>
-            </CheckoutSection>
-
-            <CheckoutSection
-              title="Additional information"
-              isDark={isDark}
-              className="hidden md:block md:px-[23px] md:pt-[23px] md:pb-10"
-            >
-              <Field label="Message" isDark={isDark}>
-                <TextArea
-                  {...register('message')}
-                  name="message"
-                  autoComplete="off"
-                  placeholder="Your message"
-                  textAreaClassName={clsx(
-                    'box-border min-h-[140px] w-full max-w-full rounded-md px-[15px] py-3 text-sm',
-                    isDark
-                      ? 'border-gray-700 bg-black text-white'
-                      : 'border-[#CBCBCB] bg-white text-[#141718]',
-                  )}
-                />
-              </Field>
-            </CheckoutSection>
+            <AdditionalInformationSection isDark={isDark} register={register} />
 
             <div className="lg:hidden">
               <OrderSummary
@@ -592,13 +342,7 @@ export const Checkout = () => {
                   : 'bg-[#141718] text-white hover:bg-black',
               )}
             >
-              {isSubmitting
-                ? paymentMethod === PAYMENT_METHODS.STRIPE
-                  ? 'Continuing to Stripe...'
-                  : 'Placing order...'
-                : paymentMethod === PAYMENT_METHODS.STRIPE
-                  ? 'Continue to Stripe'
-                  : 'Place Order'}
+              {submitButtonText}
             </Button>
           </form>
 
@@ -619,485 +363,3 @@ export const Checkout = () => {
     </div>
   );
 };
-
-const DesktopProcess = ({ isDark }: { isDark: boolean }) => (
-  <div className="mx-auto mt-10 hidden max-w-[832px] items-start justify-between md:flex">
-    <ProcessStep
-      isDark={isDark}
-      title="Shopping cart"
-      number="1"
-      state="completed"
-    />
-    <ProcessStep
-      isDark={isDark}
-      title="Checkout details"
-      number="2"
-      state="current"
-    />
-    <ProcessStep
-      isDark={isDark}
-      title="Order complete"
-      number="3"
-      state="upcoming"
-    />
-  </div>
-);
-
-const MobileProcess = ({ isDark }: { isDark: boolean }) => (
-  <div className="mt-6 flex overflow-hidden md:hidden">
-    <div className="min-w-[256px]">
-      <ProcessStep
-        isDark={isDark}
-        title="Checkout details"
-        number="2"
-        state="current"
-      />
-    </div>
-    <div className="ml-8 min-w-[256px]">
-      <ProcessStep
-        isDark={isDark}
-        title="Order complete"
-        number="3"
-        state="upcoming"
-      />
-    </div>
-  </div>
-);
-
-const ProcessStep = ({
-  title,
-  number,
-  state,
-  isDark,
-}: {
-  title: string;
-  number: string;
-  state: 'completed' | 'current' | 'upcoming';
-  isDark: boolean;
-}) => {
-  const containerClassName =
-    state === 'completed'
-      ? 'border-primary text-primary'
-      : state === 'current'
-        ? isDark
-          ? 'border-white text-white'
-          : 'border-[#141718] text-[#23262F]'
-        : isDark
-          ? 'border-gray-700 text-gray-500'
-          : 'border-[#E8ECEF] text-[#B1B5C3]';
-
-  const badgeClassName =
-    state === 'completed'
-      ? 'bg-primary text-white'
-      : state === 'current'
-        ? isDark
-          ? 'bg-white text-[#141718]'
-          : 'bg-[#23262F] text-white'
-        : isDark
-          ? 'bg-gray-700 text-white'
-          : 'bg-[#B1B5C3] text-white';
-
-  return (
-    <div className={clsx('border-b-2 pb-6', containerClassName)}>
-      <div className="flex items-center gap-4">
-        <div
-          className={clsx(
-            'flex h-10 w-10 items-center justify-center rounded-full text-base font-semibold',
-            badgeClassName,
-          )}
-        >
-          {state === 'completed' ? <Check className="h-5 w-5" /> : number}
-        </div>
-        <span className="text-base font-semibold">{title}</span>
-      </div>
-    </div>
-  );
-};
-
-const CheckoutSection = ({
-  title,
-  isDark,
-  className,
-  children,
-}: {
-  title: string;
-  isDark: boolean;
-  className?: string;
-  children: React.ReactNode;
-}) => (
-  <section
-    className={clsx(
-      'rounded-[4px] border px-[15px] pt-[23px] pb-6',
-      isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
-      className,
-    )}
-  >
-    <h2
-      className={clsx(
-        'mb-6 text-base leading-[26px] font-semibold md:text-[20px] md:leading-[28px] md:font-medium',
-        isDark ? 'text-white' : 'text-[#141718]',
-      )}
-    >
-      {title}
-    </h2>
-    <div className="space-y-6">{children}</div>
-  </section>
-);
-
-const Field = ({
-  label,
-  error,
-  isDark,
-  children,
-}: {
-  label: string;
-  error?: string;
-  isDark: boolean;
-  children: React.ReactNode;
-}) => (
-  <div className="min-w-0 space-y-3">
-    <label className={fieldLabelClassName}>{label}</label>
-    {children}
-    {error && (
-      <p className={clsx('text-xs', isDark ? 'text-red-400' : 'text-red-500')}>
-        {error}
-      </p>
-    )}
-  </div>
-);
-
-const PaymentOption = ({
-  label,
-  value,
-  selectedValue,
-  isDark,
-  icon,
-  inputProps,
-}: {
-  label: string;
-  value: CheckoutFormValues['paymentMethod'];
-  selectedValue: CheckoutFormValues['paymentMethod'];
-  isDark: boolean;
-  icon?: React.ReactNode;
-  inputProps: UseFormRegisterReturn<'paymentMethod'>;
-}) => (
-  <label
-    className={clsx(
-      'flex cursor-pointer items-center justify-between rounded-[4px] border px-[15px] py-[13px]',
-      selectedValue === value
-        ? isDark
-          ? 'border-white bg-[#111111]'
-          : 'border-[#141718] bg-[#F3F5F7]'
-        : isDark
-          ? 'border-gray-700 bg-black'
-          : 'border-[#6C7275] bg-white',
-    )}
-  >
-    <div className="flex items-center gap-3">
-      <input
-        {...inputProps}
-        value={value}
-        type="radio"
-        className="h-[18px] w-[18px] accent-[#141718]"
-      />
-      <span
-        className={clsx('text-base', isDark ? 'text-white' : 'text-[#141718]')}
-      >
-        {label}
-      </span>
-    </div>
-    {icon && (
-      <span className={clsx(isDark ? 'text-gray-400' : 'text-[#141718]')}>
-        {icon}
-      </span>
-    )}
-  </label>
-);
-
-const StripeInfoPanel = ({ isDark }: { isDark: boolean }) => (
-  <div
-    className={clsx(
-      'rounded-[6px] border px-4 py-4 md:px-[15px]',
-      isDark
-        ? 'border-gray-700 bg-[#111111] text-white'
-        : 'border-[#6C7275] bg-[#FEFEFE] text-[#141718]',
-    )}
-  >
-    <div className="flex items-start gap-3">
-      <span
-        className={clsx(
-          'mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
-          isDark ? 'bg-black text-gray-300' : 'bg-[#F3F5F7] text-[#141718]',
-        )}
-      >
-        <LockKeyhole className="h-4 w-4" />
-      </span>
-      <div className="min-w-0">
-        <p className="text-sm font-medium md:text-base">
-          Card details are entered securely on Stripe.
-        </p>
-        <p
-          className={clsx(
-            'mt-1 text-sm leading-6',
-            isDark ? 'text-gray-400' : 'text-[#6C7275]',
-          )}
-        >
-          After you continue, Stripe will open in a secure checkout page where
-          you can enter your card information once and complete the payment.
-        </p>
-      </div>
-    </div>
-  </div>
-);
-
-function OrderSummary({
-  isDark,
-  promoCode,
-  setPromoCode,
-  subtotal,
-  total,
-  items,
-  removeItem,
-  updateQuantity,
-}: {
-  isDark: boolean;
-  promoCode: string;
-  setPromoCode: (value: string) => void;
-  subtotal: number;
-  total: number;
-  items: ReturnType<typeof useCartStore.getState>['items'];
-  removeItem: ReturnType<typeof useCartStore.getState>['removeItem'];
-  updateQuantity: ReturnType<typeof useCartStore.getState>['updateQuantity'];
-}) {
-  return (
-    <aside
-      className={clsx(
-        'rounded-[6px] border px-[15px] py-[15px] md:px-[23px] md:py-[31px]',
-        isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
-      )}
-    >
-      <h2
-        className={clsx(
-          'text-[20px] leading-[28px] font-medium',
-          isDark ? 'text-white' : 'text-[#121212]',
-        )}
-      >
-        Order summary
-      </h2>
-
-      <div className="mt-6 space-y-6">
-        {items.map((item) => {
-          const productId = item.product.id || item.product._id!;
-          const lineTotal = item.product.price * item.quantity;
-
-          return (
-            <div
-              key={productId}
-              className={clsx(
-                'border-b pb-6',
-                isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
-              )}
-            >
-              <div className="flex gap-4">
-                {item.product.imageUrl ? (
-                  <img
-                    src={item.product.imageUrl}
-                    alt={item.product.title}
-                    className="h-24 w-20 object-cover"
-                  />
-                ) : (
-                  <div
-                    className={clsx(
-                      'flex h-24 w-20 items-center justify-center',
-                      isDark ? 'bg-[#111111]' : 'bg-[#F3F5F7]',
-                    )}
-                  >
-                    <span className="text-xs text-gray-400">No image</span>
-                  </div>
-                )}
-
-                <div className="flex min-w-0 flex-1 justify-between gap-4">
-                  <div className="min-w-0">
-                    <p
-                      className={clsx(
-                        'text-sm leading-[22px] font-semibold',
-                        isDark ? 'text-white' : 'text-[#141718]',
-                      )}
-                    >
-                      {item.product.title}
-                    </p>
-                    {item.product.categories?.[0] && (
-                      <p
-                        className={clsx(
-                          'mt-2 text-xs leading-5',
-                          isDark ? 'text-gray-400' : 'text-[#6C7275]',
-                        )}
-                      >
-                        {item.product.categories[0]}
-                      </p>
-                    )}
-
-                    <div
-                      className={clsx(
-                        'mt-3 flex h-8 w-20 items-center rounded-[4px] border px-[7px]',
-                        isDark ? 'border-gray-700' : 'border-[#6C7275]',
-                      )}
-                    >
-                      <button
-                        type="button"
-                        onClick={() =>
-                          updateQuantity(productId, item.quantity - 1)
-                        }
-                        disabled={item.quantity <= 1}
-                        className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current disabled:opacity-40"
-                        aria-label={`Decrease quantity for ${item.product.title}`}
-                      >
-                        <Minus className="h-3 w-3" />
-                      </button>
-                      <span
-                        className={clsx(
-                          'flex-1 text-center text-xs font-semibold',
-                          isDark ? 'text-white' : 'text-[#121212]',
-                        )}
-                      >
-                        {item.quantity}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          updateQuantity(productId, item.quantity + 1)
-                        }
-                        className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current"
-                        aria-label={`Increase quantity for ${item.product.title}`}
-                      >
-                        <Plus className="h-3 w-3" />
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col items-end">
-                    <p
-                      className={clsx(
-                        'text-sm leading-[22px] font-semibold',
-                        isDark ? 'text-white' : 'text-[#121212]',
-                      )}
-                    >
-                      {formatCurrency(lineTotal)}
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => removeItem(productId)}
-                      className={clsx(
-                        'mt-2 border-none bg-transparent p-0',
-                        isDark ? 'text-gray-400' : 'text-[#141718]',
-                      )}
-                      aria-label={`Remove ${item.product.title}`}
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <div className="flex gap-3">
-          <input
-            value={promoCode}
-            onChange={(event) => setPromoCode(event.target.value)}
-            type="text"
-            name="promoCode"
-            autoComplete="off"
-            placeholder="Promo code"
-            className={clsx(
-              'box-border h-[52px] max-w-full flex-1 rounded-[6px] border px-[15px] text-base outline-none placeholder:text-[#605F5F]',
-              isDark
-                ? 'border-gray-700 bg-black text-white'
-                : 'border-[#CBCBCB] bg-white text-[#141718]',
-            )}
-          />
-          <Button
-            type="button"
-            onClick={() => setPromoCode('')}
-            className={clsx(
-              'h-[52px] rounded-[8px] border-none px-6 text-base font-medium shadow-none',
-              isDark
-                ? 'bg-white text-[#141718] hover:bg-gray-200'
-                : 'bg-[#141718] text-white hover:bg-black',
-            )}
-          >
-            Apply
-          </Button>
-        </div>
-
-        <div className="space-y-4">
-          <div
-            className={clsx(
-              'flex items-center justify-between border-b pb-4',
-              isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
-            )}
-          >
-            <div className="flex items-center gap-2">
-              <TicketPercent className="h-4 w-4" />
-              <span className={clsx(isDark ? 'text-white' : 'text-[#141718]')}>
-                Promo
-              </span>
-            </div>
-            <span className="text-[#38CB89]">Not applied</span>
-          </div>
-
-          <div
-            className={clsx(
-              'flex items-center justify-between border-b pb-4',
-              isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
-            )}
-          >
-            <span className={clsx(isDark ? 'text-white' : 'text-[#141718]')}>
-              Shipping
-            </span>
-            <span
-              className={clsx(
-                'text-right',
-                isDark ? 'text-gray-400' : 'text-[#6C7275]',
-              )}
-            >
-              Carrier tariffs | Free
-            </span>
-          </div>
-
-          <div>
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p
-                  className={clsx(
-                    'text-[20px] leading-[28px] font-medium',
-                    isDark ? 'text-white' : 'text-[#141718]',
-                  )}
-                >
-                  Total <span className="align-top text-sm">*</span>
-                </p>
-                <p
-                  className={clsx(
-                    'mt-1 text-xs',
-                    isDark ? 'text-gray-400' : 'text-[#6C7275]',
-                  )}
-                >
-                  Final price may change depending on delivery cost.
-                </p>
-              </div>
-              <p
-                className={clsx(
-                  'text-[20px] leading-[28px] font-medium',
-                  isDark ? 'text-white' : 'text-[#141718]',
-                )}
-              >
-                {formatCurrency(total || subtotal)}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </aside>
-  );
-}

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, type UseFormRegisterReturn, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -60,9 +60,52 @@ const checkoutSchema = z.object({
 });
 
 type CheckoutFormValues = z.infer<typeof checkoutSchema>;
+type CheckoutFieldName = keyof CheckoutFormValues;
 
 const isMongoId = (value?: string) =>
   Boolean(value && /^[a-f\d]{24}$/i.test(value));
+
+const checkoutFieldNames: CheckoutFieldName[] = [
+  'firstName',
+  'lastName',
+  'phone',
+  'email',
+  'carrier',
+  'city',
+  'branchNumber',
+  'paymentMethod',
+  'message',
+];
+
+const readControlValue = (
+  control: Element | RadioNodeList | null,
+): string | null => {
+  if (!control) {
+    return null;
+  }
+
+  if (
+    typeof RadioNodeList !== 'undefined' &&
+    control instanceof RadioNodeList
+  ) {
+    const checkedInput = Array.from(control).find(
+      (item): item is HTMLInputElement =>
+        item instanceof HTMLInputElement && item.checked,
+    );
+
+    return checkedInput?.value ?? null;
+  }
+
+  if (
+    control instanceof HTMLInputElement ||
+    control instanceof HTMLTextAreaElement ||
+    control instanceof HTMLSelectElement
+  ) {
+    return control.value;
+  }
+
+  return null;
+};
 
 const getFieldClassName = (isDark: boolean, hasError = false) =>
   clsx(
@@ -87,6 +130,7 @@ export const Checkout = () => {
   const { isDark } = useTheme();
   const { items, clearCart, removeItem, updateQuantity, getCartTotal } =
     useCartStore();
+  const formRef = useRef<HTMLFormElement | null>(null);
 
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [promoCode, setPromoCode] = useState('');
@@ -98,6 +142,9 @@ export const Checkout = () => {
     control,
     register,
     handleSubmit,
+    clearErrors,
+    getValues,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<CheckoutFormValues>({
     resolver: zodResolver(checkoutSchema),
@@ -118,6 +165,51 @@ export const Checkout = () => {
     control,
     name: 'paymentMethod',
   });
+
+  useEffect(() => {
+    const syncRestoredValues = () => {
+      const form = formRef.current;
+
+      if (!form) {
+        return;
+      }
+
+      checkoutFieldNames.forEach((fieldName) => {
+        const restoredValue = readControlValue(
+          form.elements.namedItem(fieldName),
+        );
+
+        if (restoredValue === null || restoredValue === getValues(fieldName)) {
+          return;
+        }
+
+        setValue(
+          fieldName,
+          restoredValue as CheckoutFormValues[typeof fieldName],
+          {
+            shouldDirty: restoredValue !== '',
+            shouldTouch: false,
+            shouldValidate: false,
+          },
+        );
+
+        if (restoredValue.trim() !== '') {
+          clearErrors(fieldName);
+        }
+      });
+    };
+
+    const syncOnPageShow = () => {
+      window.requestAnimationFrame(syncRestoredValues);
+    };
+
+    syncOnPageShow();
+    window.addEventListener('pageshow', syncOnPageShow);
+
+    return () => {
+      window.removeEventListener('pageshow', syncOnPageShow);
+    };
+  }, [clearErrors, getValues, setValue]);
 
   const checkoutItems = useMemo(
     () =>
@@ -269,7 +361,11 @@ export const Checkout = () => {
         <MobileProcess isDark={isDark} />
 
         <div className="mt-10 lg:grid lg:grid-cols-[minmax(0,643px)_376px] lg:items-start lg:justify-between lg:gap-[101px]">
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <form
+            ref={formRef}
+            onSubmit={handleSubmit(onSubmit)}
+            className="space-y-6"
+          >
             <CheckoutSection
               title="Contact Infomation"
               isDark={isDark}

--- a/src/pages/Checkout/CheckoutProcess.tsx
+++ b/src/pages/Checkout/CheckoutProcess.tsx
@@ -1,0 +1,127 @@
+import clsx from 'clsx';
+import { Check } from 'lucide-react';
+
+type ProcessStepState = 'completed' | 'current' | 'upcoming';
+
+interface ProcessStepConfig {
+  title: string;
+  number: string;
+  state: ProcessStepState;
+}
+
+const desktopSteps: ProcessStepConfig[] = [
+  {
+    title: 'Shopping cart',
+    number: '1',
+    state: 'completed',
+  },
+  {
+    title: 'Checkout details',
+    number: '2',
+    state: 'current',
+  },
+  {
+    title: 'Order complete',
+    number: '3',
+    state: 'upcoming',
+  },
+];
+
+const mobileSteps: ProcessStepConfig[] = [
+  {
+    title: 'Checkout details',
+    number: '2',
+    state: 'current',
+  },
+  {
+    title: 'Order complete',
+    number: '3',
+    state: 'upcoming',
+  },
+];
+
+const processContainerStyles: Record<
+  ProcessStepState,
+  { light: string; dark: string }
+> = {
+  completed: {
+    light: 'border-primary text-primary',
+    dark: 'border-primary text-primary',
+  },
+  current: {
+    light: 'border-[#141718] text-[#23262F]',
+    dark: 'border-white text-white',
+  },
+  upcoming: {
+    light: 'border-[#E8ECEF] text-[#B1B5C3]',
+    dark: 'border-gray-700 text-gray-500',
+  },
+};
+
+const processBadgeStyles: Record<
+  ProcessStepState,
+  { light: string; dark: string }
+> = {
+  completed: {
+    light: 'bg-primary text-white',
+    dark: 'bg-primary text-white',
+  },
+  current: {
+    light: 'bg-[#23262F] text-white',
+    dark: 'bg-white text-[#141718]',
+  },
+  upcoming: {
+    light: 'bg-[#B1B5C3] text-white',
+    dark: 'bg-gray-700 text-white',
+  },
+};
+
+const getProcessTone = (isDark: boolean) => (isDark ? 'dark' : 'light');
+
+const ProcessStep = ({
+  title,
+  number,
+  state,
+  isDark,
+}: ProcessStepConfig & { isDark: boolean }) => {
+  const tone = getProcessTone(isDark);
+
+  return (
+    <div
+      className={clsx('border-b-2 pb-6', processContainerStyles[state][tone])}
+    >
+      <div className="flex items-center gap-4">
+        <div
+          className={clsx(
+            'flex h-10 w-10 items-center justify-center rounded-full text-base font-semibold',
+            processBadgeStyles[state][tone],
+          )}
+        >
+          {state === 'completed' ? <Check className="h-5 w-5" /> : number}
+        </div>
+        <span className="text-base font-semibold">{title}</span>
+      </div>
+    </div>
+  );
+};
+
+export const DesktopProcess = ({ isDark }: { isDark: boolean }) => (
+  <div className="mx-auto mt-10 hidden max-w-[832px] items-start justify-between md:flex">
+    {desktopSteps.map((step) => (
+      <ProcessStep key={step.number} {...step} isDark={isDark} />
+    ))}
+  </div>
+);
+
+export const MobileProcess = ({ isDark }: { isDark: boolean }) => (
+  <div className="mt-6 flex overflow-hidden md:hidden">
+    {mobileSteps.map((step, index) => (
+      <div
+        key={step.number}
+        className={clsx('min-w-[256px]', index > 0 && 'ml-8')}
+      >
+        <ProcessStep {...step} isDark={isDark} />
+      </div>
+    ))}
+  </div>
+);

--- a/src/pages/Checkout/CheckoutSections.tsx
+++ b/src/pages/Checkout/CheckoutSections.tsx
@@ -1,0 +1,229 @@
+import { type FieldErrors, type UseFormRegister } from 'react-hook-form';
+import clsx from 'clsx';
+import { ChevronDown, CreditCard } from 'lucide-react';
+
+import { TextArea } from '@/components';
+import { PAYMENT_METHODS } from '@/types';
+
+import {
+  carrierOptions,
+  type CheckoutFormValues,
+  getFieldClassName,
+} from './checkout.helpers';
+import {
+  CheckoutSection,
+  Field,
+  PaymentOption,
+  StripeInfoPanel,
+} from './CheckoutUI';
+
+interface CheckoutSectionProps {
+  isDark: boolean;
+  errors: FieldErrors<CheckoutFormValues>;
+  register: UseFormRegister<CheckoutFormValues>;
+}
+
+export const ContactInformationSection = ({
+  isDark,
+  errors,
+  register,
+}: CheckoutSectionProps) => (
+  <CheckoutSection
+    title="Contact Infomation"
+    isDark={isDark}
+    className="md:px-[23px] md:pt-[39px] md:pb-10"
+  >
+    <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:gap-x-6 md:gap-y-0">
+      <Field
+        label="First Name *"
+        error={errors.firstName?.message}
+        isDark={isDark}
+      >
+        <input
+          {...register('firstName')}
+          type="text"
+          name="firstName"
+          autoComplete="given-name"
+          placeholder="First name"
+          className={getFieldClassName(isDark, Boolean(errors.firstName))}
+        />
+      </Field>
+      <Field
+        label="Last Name *"
+        error={errors.lastName?.message}
+        isDark={isDark}
+      >
+        <input
+          {...register('lastName')}
+          type="text"
+          name="lastName"
+          autoComplete="family-name"
+          placeholder="Last name"
+          className={getFieldClassName(isDark, Boolean(errors.lastName))}
+        />
+      </Field>
+    </div>
+
+    <Field label="Phone Number *" error={errors.phone?.message} isDark={isDark}>
+      <input
+        {...register('phone')}
+        type="tel"
+        name="phone"
+        autoComplete="tel"
+        placeholder="Phone number"
+        className={getFieldClassName(isDark, Boolean(errors.phone))}
+      />
+    </Field>
+
+    <Field
+      label="Email Address *"
+      error={errors.email?.message}
+      isDark={isDark}
+    >
+      <input
+        {...register('email')}
+        type="email"
+        name="email"
+        autoComplete="email"
+        placeholder="Email address"
+        className={getFieldClassName(isDark, Boolean(errors.email))}
+      />
+    </Field>
+  </CheckoutSection>
+);
+
+export const ShippingAddressSection = ({
+  isDark,
+  errors,
+  register,
+}: CheckoutSectionProps) => (
+  <CheckoutSection
+    title="Shipping Address"
+    isDark={isDark}
+    className="md:px-[23px] md:pt-[39px] md:pb-10"
+  >
+    <Field label="Delivery *" error={errors.carrier?.message} isDark={isDark}>
+      <div className="relative">
+        <select
+          {...register('carrier')}
+          name="carrier"
+          autoComplete="shipping country"
+          className={clsx(
+            getFieldClassName(isDark, Boolean(errors.carrier)),
+            'appearance-none pr-10',
+          )}
+        >
+          {carrierOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className={clsx(
+            'pointer-events-none absolute top-1/2 right-4 h-4 w-4 -translate-y-1/2',
+            isDark ? 'text-gray-500' : 'text-[#6C7275]',
+          )}
+        />
+      </div>
+    </Field>
+
+    <Field label="Town / City *" error={errors.city?.message} isDark={isDark}>
+      <input
+        {...register('city')}
+        type="text"
+        name="city"
+        autoComplete="address-level2"
+        placeholder="Town / City"
+        className={getFieldClassName(isDark, Boolean(errors.city))}
+      />
+    </Field>
+
+    <Field
+      label="Department Code*"
+      error={errors.branchNumber?.message}
+      isDark={isDark}
+    >
+      <input
+        {...register('branchNumber')}
+        type="text"
+        name="branchNumber"
+        autoComplete="address-line2"
+        placeholder="Department code"
+        className={getFieldClassName(isDark, Boolean(errors.branchNumber))}
+      />
+    </Field>
+  </CheckoutSection>
+);
+
+interface PaymentMethodSectionProps extends CheckoutSectionProps {
+  paymentMethod: CheckoutFormValues['paymentMethod'];
+}
+
+export const PaymentMethodSection = ({
+  isDark,
+  register,
+  paymentMethod,
+}: PaymentMethodSectionProps) => (
+  <CheckoutSection
+    title="Payment method"
+    isDark={isDark}
+    className="md:px-[23px] md:pt-[39px] md:pb-10"
+  >
+    <div
+      className={clsx(
+        'space-y-6',
+        isDark ? 'border-gray-700' : 'border-[#6C7275]',
+      )}
+    >
+      <div className="space-y-6 border-b pb-6">
+        <PaymentOption
+          label="Pay with card securely"
+          value={PAYMENT_METHODS.STRIPE}
+          selectedValue={paymentMethod}
+          isDark={isDark}
+          icon={<CreditCard className="h-4 w-4" />}
+          inputProps={register('paymentMethod')}
+        />
+
+        <PaymentOption
+          label="Cash on delivery"
+          value={PAYMENT_METHODS.CASH_ON_DELIVERY}
+          selectedValue={paymentMethod}
+          isDark={isDark}
+          inputProps={register('paymentMethod')}
+        />
+      </div>
+
+      {paymentMethod === PAYMENT_METHODS.STRIPE && (
+        <StripeInfoPanel isDark={isDark} />
+      )}
+    </div>
+  </CheckoutSection>
+);
+
+export const AdditionalInformationSection = ({
+  isDark,
+  register,
+}: Pick<CheckoutSectionProps, 'isDark' | 'register'>) => (
+  <CheckoutSection
+    title="Additional information"
+    isDark={isDark}
+    className="hidden md:block md:px-[23px] md:pt-[23px] md:pb-10"
+  >
+    <Field label="Message" isDark={isDark}>
+      <TextArea
+        {...register('message')}
+        name="message"
+        autoComplete="off"
+        placeholder="Your message"
+        textAreaClassName={clsx(
+          'box-border min-h-[140px] w-full max-w-full rounded-md px-[15px] py-3 text-sm',
+          isDark
+            ? 'border-gray-700 bg-black text-white'
+            : 'border-[#CBCBCB] bg-white text-[#141718]',
+        )}
+      />
+    </Field>
+  </CheckoutSection>
+);

--- a/src/pages/Checkout/CheckoutUI.tsx
+++ b/src/pages/Checkout/CheckoutUI.tsx
@@ -1,0 +1,143 @@
+import { type ReactNode } from 'react';
+import { type UseFormRegisterReturn } from 'react-hook-form';
+import clsx from 'clsx';
+import { LockKeyhole } from 'lucide-react';
+
+import type { CheckoutFormValues } from './checkout.helpers';
+import { fieldLabelClassName } from './checkout.helpers';
+
+export const CheckoutSection = ({
+  title,
+  isDark,
+  className,
+  children,
+}: {
+  title: string;
+  isDark: boolean;
+  className?: string;
+  children: ReactNode;
+}) => (
+  <section
+    className={clsx(
+      'rounded-[4px] border px-[15px] pt-[23px] pb-6',
+      isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
+      className,
+    )}
+  >
+    <h2
+      className={clsx(
+        'mb-6 text-base leading-[26px] font-semibold md:text-[20px] md:leading-[28px] md:font-medium',
+        isDark ? 'text-white' : 'text-[#141718]',
+      )}
+    >
+      {title}
+    </h2>
+    <div className="space-y-6">{children}</div>
+  </section>
+);
+
+export const Field = ({
+  label,
+  error,
+  isDark,
+  children,
+}: {
+  label: string;
+  error?: string;
+  isDark: boolean;
+  children: ReactNode;
+}) => (
+  <div className="min-w-0 space-y-3">
+    <label className={fieldLabelClassName}>{label}</label>
+    {children}
+    {error && (
+      <p className={clsx('text-xs', isDark ? 'text-red-400' : 'text-red-500')}>
+        {error}
+      </p>
+    )}
+  </div>
+);
+
+export const PaymentOption = ({
+  label,
+  value,
+  selectedValue,
+  isDark,
+  icon,
+  inputProps,
+}: {
+  label: string;
+  value: CheckoutFormValues['paymentMethod'];
+  selectedValue: CheckoutFormValues['paymentMethod'];
+  isDark: boolean;
+  icon?: ReactNode;
+  inputProps: UseFormRegisterReturn<'paymentMethod'>;
+}) => (
+  <label
+    className={clsx(
+      'flex cursor-pointer items-center justify-between rounded-[4px] border px-[15px] py-[13px]',
+      selectedValue === value
+        ? isDark
+          ? 'border-white bg-[#111111]'
+          : 'border-[#141718] bg-[#F3F5F7]'
+        : isDark
+          ? 'border-gray-700 bg-black'
+          : 'border-[#6C7275] bg-white',
+    )}
+  >
+    <div className="flex items-center gap-3">
+      <input
+        {...inputProps}
+        value={value}
+        type="radio"
+        className="h-[18px] w-[18px] accent-[#141718]"
+      />
+      <span
+        className={clsx('text-base', isDark ? 'text-white' : 'text-[#141718]')}
+      >
+        {label}
+      </span>
+    </div>
+    {icon && (
+      <span className={clsx(isDark ? 'text-gray-400' : 'text-[#141718]')}>
+        {icon}
+      </span>
+    )}
+  </label>
+);
+
+export const StripeInfoPanel = ({ isDark }: { isDark: boolean }) => (
+  <div
+    className={clsx(
+      'rounded-[6px] border px-4 py-4 md:px-[15px]',
+      isDark
+        ? 'border-gray-700 bg-[#111111] text-white'
+        : 'border-[#6C7275] bg-[#FEFEFE] text-[#141718]',
+    )}
+  >
+    <div className="flex items-start gap-3">
+      <span
+        className={clsx(
+          'mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          isDark ? 'bg-black text-gray-300' : 'bg-[#F3F5F7] text-[#141718]',
+        )}
+      >
+        <LockKeyhole className="h-4 w-4" />
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm font-medium md:text-base">
+          Card details are entered securely on Stripe.
+        </p>
+        <p
+          className={clsx(
+            'mt-1 text-sm leading-6',
+            isDark ? 'text-gray-400' : 'text-[#6C7275]',
+          )}
+        >
+          After you continue, Stripe will open in a secure checkout page where
+          you can enter your card information once and complete the payment.
+        </p>
+      </div>
+    </div>
+  </div>
+);

--- a/src/pages/Checkout/OrderSummary.tsx
+++ b/src/pages/Checkout/OrderSummary.tsx
@@ -1,0 +1,319 @@
+import { type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Minus, Plus, TicketPercent, X } from 'lucide-react';
+
+import { Button } from '@/components';
+import { type useCartStore } from '@/store/useCartStore';
+
+import { formatCurrency } from './checkout.helpers';
+
+type CartItem = ReturnType<typeof useCartStore.getState>['items'][number];
+
+interface OrderSummaryProps {
+  isDark: boolean;
+  promoCode: string;
+  setPromoCode: (value: string) => void;
+  subtotal: number;
+  total: number;
+  items: CartItem[];
+  removeItem: ReturnType<typeof useCartStore.getState>['removeItem'];
+  updateQuantity: ReturnType<typeof useCartStore.getState>['updateQuantity'];
+}
+
+const SummaryRow = ({
+  isDark,
+  left,
+  right,
+}: {
+  isDark: boolean;
+  left: ReactNode;
+  right: ReactNode;
+}) => (
+  <div
+    className={clsx(
+      'flex items-center justify-between border-b pb-4',
+      isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+    )}
+  >
+    {left}
+    {right}
+  </div>
+);
+
+const QuantityControl = ({
+  isDark,
+  title,
+  quantity,
+  onDecrease,
+  onIncrease,
+}: {
+  isDark: boolean;
+  title: string;
+  quantity: number;
+  onDecrease: () => void;
+  onIncrease: () => void;
+}) => (
+  <div
+    className={clsx(
+      'mt-3 flex h-8 w-20 items-center rounded-[4px] border px-[7px]',
+      isDark ? 'border-gray-700' : 'border-[#6C7275]',
+    )}
+  >
+    <button
+      type="button"
+      onClick={onDecrease}
+      disabled={quantity <= 1}
+      className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current disabled:opacity-40"
+      aria-label={`Decrease quantity for ${title}`}
+    >
+      <Minus className="h-3 w-3" />
+    </button>
+    <span
+      className={clsx(
+        'flex-1 text-center text-xs font-semibold',
+        isDark ? 'text-white' : 'text-[#121212]',
+      )}
+    >
+      {quantity}
+    </span>
+    <button
+      type="button"
+      onClick={onIncrease}
+      className="flex h-4 w-4 items-center justify-center border-none bg-transparent p-0 text-current"
+      aria-label={`Increase quantity for ${title}`}
+    >
+      <Plus className="h-3 w-3" />
+    </button>
+  </div>
+);
+
+const OrderSummaryItem = ({
+  item,
+  isDark,
+  removeItem,
+  updateQuantity,
+}: {
+  item: CartItem;
+  isDark: boolean;
+  removeItem: ReturnType<typeof useCartStore.getState>['removeItem'];
+  updateQuantity: ReturnType<typeof useCartStore.getState>['updateQuantity'];
+}) => {
+  const productId = item.product.id || item.product._id!;
+  const lineTotal = item.product.price * item.quantity;
+
+  return (
+    <div
+      className={clsx(
+        'border-b pb-6',
+        isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+      )}
+    >
+      <div className="flex gap-4">
+        {item.product.imageUrl ? (
+          <img
+            src={item.product.imageUrl}
+            alt={item.product.title}
+            className="h-24 w-20 object-cover"
+          />
+        ) : (
+          <div
+            className={clsx(
+              'flex h-24 w-20 items-center justify-center',
+              isDark ? 'bg-[#111111]' : 'bg-[#F3F5F7]',
+            )}
+          >
+            <span className="text-xs text-gray-400">No image</span>
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-1 justify-between gap-4">
+          <div className="min-w-0">
+            <p
+              className={clsx(
+                'text-sm leading-[22px] font-semibold',
+                isDark ? 'text-white' : 'text-[#141718]',
+              )}
+            >
+              {item.product.title}
+            </p>
+            {item.product.categories?.[0] && (
+              <p
+                className={clsx(
+                  'mt-2 text-xs leading-5',
+                  isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                )}
+              >
+                {item.product.categories[0]}
+              </p>
+            )}
+
+            <QuantityControl
+              isDark={isDark}
+              title={item.product.title}
+              quantity={item.quantity}
+              onDecrease={() => updateQuantity(productId, item.quantity - 1)}
+              onIncrease={() => updateQuantity(productId, item.quantity + 1)}
+            />
+          </div>
+
+          <div className="flex flex-col items-end">
+            <p
+              className={clsx(
+                'text-sm leading-[22px] font-semibold',
+                isDark ? 'text-white' : 'text-[#121212]',
+              )}
+            >
+              {formatCurrency(lineTotal)}
+            </p>
+            <button
+              type="button"
+              onClick={() => removeItem(productId)}
+              className={clsx(
+                'mt-2 border-none bg-transparent p-0',
+                isDark ? 'text-gray-400' : 'text-[#141718]',
+              )}
+              aria-label={`Remove ${item.product.title}`}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export function OrderSummary({
+  isDark,
+  promoCode,
+  setPromoCode,
+  subtotal,
+  total,
+  items,
+  removeItem,
+  updateQuantity,
+}: OrderSummaryProps) {
+  return (
+    <aside
+      className={clsx(
+        'rounded-[6px] border px-[15px] py-[15px] md:px-[23px] md:py-[31px]',
+        isDark ? 'border-gray-700 bg-black' : 'border-[#6C7275] bg-white',
+      )}
+    >
+      <h2
+        className={clsx(
+          'text-[20px] leading-[28px] font-medium',
+          isDark ? 'text-white' : 'text-[#121212]',
+        )}
+      >
+        Order summary
+      </h2>
+
+      <div className="mt-6 space-y-6">
+        {items.map((item) => (
+          <OrderSummaryItem
+            key={item.product.id || item.product._id}
+            item={item}
+            isDark={isDark}
+            removeItem={removeItem}
+            updateQuantity={updateQuantity}
+          />
+        ))}
+
+        <div className="flex gap-3">
+          <input
+            value={promoCode}
+            onChange={(event) => setPromoCode(event.target.value)}
+            type="text"
+            name="promoCode"
+            autoComplete="off"
+            placeholder="Promo code"
+            className={clsx(
+              'box-border h-[52px] max-w-full flex-1 rounded-[6px] border px-[15px] text-base outline-none placeholder:text-[#605F5F]',
+              isDark
+                ? 'border-gray-700 bg-black text-white'
+                : 'border-[#CBCBCB] bg-white text-[#141718]',
+            )}
+          />
+          <Button
+            type="button"
+            onClick={() => setPromoCode('')}
+            className={clsx(
+              'h-[52px] rounded-[8px] border-none px-6 text-base font-medium shadow-none',
+              isDark
+                ? 'bg-white text-[#141718] hover:bg-gray-200'
+                : 'bg-[#141718] text-white hover:bg-black',
+            )}
+          >
+            Apply
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <SummaryRow
+            isDark={isDark}
+            left={
+              <div className="flex items-center gap-2">
+                <TicketPercent className="h-4 w-4" />
+                <span
+                  className={clsx(isDark ? 'text-white' : 'text-[#141718]')}
+                >
+                  Promo
+                </span>
+              </div>
+            }
+            right={<span className="text-[#38CB89]">Not applied</span>}
+          />
+
+          <SummaryRow
+            isDark={isDark}
+            left={
+              <span className={clsx(isDark ? 'text-white' : 'text-[#141718]')}>
+                Shipping
+              </span>
+            }
+            right={
+              <span
+                className={clsx(
+                  'text-right',
+                  isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                )}
+              >
+                Carrier tariffs | Free
+              </span>
+            }
+          />
+
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p
+                className={clsx(
+                  'text-[20px] leading-[28px] font-medium',
+                  isDark ? 'text-white' : 'text-[#141718]',
+                )}
+              >
+                Total <span className="align-top text-sm">*</span>
+              </p>
+              <p
+                className={clsx(
+                  'mt-1 text-xs',
+                  isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                )}
+              >
+                Final price may change depending on delivery cost.
+              </p>
+            </div>
+            <p
+              className={clsx(
+                'text-[20px] leading-[28px] font-medium',
+                isDark ? 'text-white' : 'text-[#141718]',
+              )}
+            >
+              {formatCurrency(total || subtotal)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/pages/Checkout/checkout.helpers.ts
+++ b/src/pages/Checkout/checkout.helpers.ts
@@ -1,0 +1,99 @@
+import clsx from 'clsx';
+import { z } from 'zod';
+
+import { PAYMENT_METHODS, SHIPPING_CARRIERS } from '@/types';
+
+export const fieldLabelClassName =
+  'text-[12px] font-bold uppercase tracking-[0.02em] text-gray-600';
+
+const baseFieldClassName =
+  'box-border h-10 w-full max-w-full rounded-md border px-[15px] text-sm outline-none transition-colors placeholder:text-gray-600';
+
+export const checkoutSchema = z.object({
+  firstName: z.string().trim().min(1, 'First name is required'),
+  lastName: z.string().trim().min(1, 'Last name is required'),
+  phone: z.string().trim().min(1, 'Phone number is required'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email address is required')
+    .email('Enter a valid email address'),
+  carrier: z.enum([
+    SHIPPING_CARRIERS.NOVA_POST,
+    SHIPPING_CARRIERS.UKRPOSHTA,
+    SHIPPING_CARRIERS.MEEST,
+  ]),
+  city: z.string().trim().min(1, 'Town / City is required'),
+  branchNumber: z.string().trim().min(1, 'Department code is required'),
+  paymentMethod: z.enum([
+    PAYMENT_METHODS.STRIPE,
+    PAYMENT_METHODS.CASH_ON_DELIVERY,
+  ]),
+  message: z.string().optional(),
+});
+
+export type CheckoutFormValues = z.infer<typeof checkoutSchema>;
+export type CheckoutFieldName = keyof CheckoutFormValues;
+
+export const carrierOptions = [
+  { value: SHIPPING_CARRIERS.NOVA_POST, label: 'Нова Пошта' },
+  { value: SHIPPING_CARRIERS.UKRPOSHTA, label: 'Укрпошта' },
+  { value: SHIPPING_CARRIERS.MEEST, label: 'Meest' },
+] as const;
+
+export const checkoutFieldNames: CheckoutFieldName[] = [
+  'firstName',
+  'lastName',
+  'phone',
+  'email',
+  'carrier',
+  'city',
+  'branchNumber',
+  'paymentMethod',
+  'message',
+];
+
+export const isMongoId = (value?: string) =>
+  Boolean(value && /^[a-f\d]{24}$/i.test(value));
+
+export const readControlValue = (
+  control: Element | RadioNodeList | null,
+): string | null => {
+  if (!control) {
+    return null;
+  }
+
+  if (
+    typeof RadioNodeList !== 'undefined' &&
+    control instanceof RadioNodeList
+  ) {
+    const checkedInput = Array.from(control).find(
+      (item): item is HTMLInputElement =>
+        item instanceof HTMLInputElement && item.checked,
+    );
+
+    return checkedInput?.value ?? null;
+  }
+
+  if (
+    control instanceof HTMLInputElement ||
+    control instanceof HTMLTextAreaElement ||
+    control instanceof HTMLSelectElement
+  ) {
+    return control.value;
+  }
+
+  return null;
+};
+
+export const getFieldClassName = (isDark: boolean, hasError = false) =>
+  clsx(
+    baseFieldClassName,
+    isDark
+      ? 'border-gray-700 bg-black text-white'
+      : 'border-[#CBCBCB] bg-white text-[#141718]',
+    hasError &&
+      (isDark ? 'border-red-500 text-red-200' : 'border-red-500 text-red-600'),
+  );
+
+export const formatCurrency = (value: number) => `$${value.toFixed(2)}`;

--- a/src/pages/Checkout/index.ts
+++ b/src/pages/Checkout/index.ts
@@ -1,0 +1,1 @@
+export { Checkout } from './Checkout';

--- a/src/pages/OrderConfirmation/OrderConfirmation.test.tsx
+++ b/src/pages/OrderConfirmation/OrderConfirmation.test.tsx
@@ -1,0 +1,151 @@
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { useTheme } from '@/hooks/useTheme';
+import { paymentService } from '@/services';
+import { checkoutStorage } from '@/utils/checkoutStorage';
+
+import { OrderConfirmation } from './OrderConfirmation';
+
+const mockClearCart = vi.fn();
+
+const orderSnapshot = {
+  orderId: 'ORD-20260325-0001',
+  amount: 76,
+  totalPrice: 76,
+  paymentMethod: 'cash_on_delivery' as const,
+  customerName: 'John Doe',
+  items: [
+    {
+      product: '507f1f77bcf86cd799439011',
+      title: 'Tray Table',
+      imageUrl: 'https://example.com/tray-table.jpg',
+      unitPrice: 38,
+      amount: 2,
+    },
+  ],
+};
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('@/services', () => ({
+  orderService: {
+    createOrder: vi.fn(),
+  },
+  paymentService: {
+    createCheckoutSession: vi.fn(),
+    getSessionStatus: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/useCartStore', () => ({
+  useCartStore: vi.fn(
+    (selector?: (state: { clearCart: typeof mockClearCart }) => unknown) =>
+      selector
+        ? selector({ clearCart: mockClearCart })
+        : { clearCart: mockClearCart },
+  ),
+}));
+
+describe('Page: OrderConfirmation', () => {
+  const renderPage = (
+    initialEntries: Parameters<typeof MemoryRouter>[0]['initialEntries'],
+  ) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Routes>
+            <Route path="/order-confirmation" element={<OrderConfirmation />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    (useTheme as unknown as Mock).mockReturnValue({ isDark: false });
+  });
+
+  it('renders a cash-on-delivery confirmation state from navigation state', async () => {
+    renderPage([
+      {
+        pathname: '/order-confirmation',
+        state: {
+          orderSnapshot,
+          paymentStatus: 'pending',
+        },
+      },
+    ]);
+
+    expect(await screen.findByText('Order confirmed')).toBeInTheDocument();
+    expect(screen.getByText('Cash on delivery')).toBeInTheDocument();
+    expect(screen.getByText('ORD-20260325-0001')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockClearCart).toHaveBeenCalled();
+    });
+  });
+
+  it('verifies a Stripe session from query params and shows success after payment', async () => {
+    checkoutStorage.save({
+      ...orderSnapshot,
+      paymentMethod: 'stripe',
+    });
+    (paymentService.getSessionStatus as Mock).mockResolvedValue({
+      status: 'complete',
+      paymentStatus: 'paid',
+    });
+
+    renderPage(['/order-confirmation?session_id=cs_test_123']);
+
+    expect(
+      await screen.findByText('Checking your payment status...'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(paymentService.getSessionStatus).toHaveBeenCalledWith(
+        'cs_test_123',
+      );
+      expect(screen.getByText('Order confirmed')).toBeInTheDocument();
+      expect(screen.getByText('paid')).toBeInTheDocument();
+      expect(mockClearCart).toHaveBeenCalled();
+    });
+  });
+
+  it('shows a retry state when the Stripe session is not complete', async () => {
+    checkoutStorage.save({
+      ...orderSnapshot,
+      paymentMethod: 'stripe',
+    });
+    (paymentService.getSessionStatus as Mock).mockResolvedValue({
+      status: 'open',
+      paymentStatus: 'unpaid',
+    });
+
+    renderPage(['/order-confirmation?session_id=cs_test_456']);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('We could not confirm this order'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Back to checkout' }),
+      ).toHaveAttribute('href', '/checkout');
+    });
+
+    expect(mockClearCart).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/OrderConfirmation/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation/OrderConfirmation.tsx
@@ -1,0 +1,279 @@
+import { useEffect } from 'react';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
+import {
+  CheckCircle2,
+  CreditCard,
+  PackageCheck,
+  Truck,
+  XCircle,
+} from 'lucide-react';
+
+import { Button } from '@/components';
+import { ROUTES } from '@/constants';
+import { useTheme } from '@/hooks/useTheme';
+import { paymentService } from '@/services';
+import { useCartStore } from '@/store/useCartStore';
+import { type CheckoutOrderSnapshot, PAYMENT_METHODS } from '@/types';
+import { checkoutStorage } from '@/utils/checkoutStorage';
+
+const formatCurrency = (value: number) => `$${value.toFixed(2)}`;
+
+interface LocationState {
+  orderSnapshot?: CheckoutOrderSnapshot;
+  paymentStatus?: string;
+}
+
+export const OrderConfirmation = () => {
+  const { isDark } = useTheme();
+  const clearCart = useCartStore((state) => state.clearCart);
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  const sessionId = searchParams.get('session_id');
+  const storedSnapshot = checkoutStorage.read();
+  const locationState = location.state as LocationState | null;
+  const orderSnapshot = locationState?.orderSnapshot ?? storedSnapshot;
+  const isCashOnDelivery =
+    orderSnapshot?.paymentMethod === PAYMENT_METHODS.CASH_ON_DELIVERY;
+
+  const sessionQuery = useQuery({
+    queryKey: ['checkout-session-status', sessionId],
+    queryFn: () => paymentService.getSessionStatus(sessionId!),
+    enabled: Boolean(sessionId),
+    retry: false,
+  });
+
+  const isStripeSuccess =
+    sessionQuery.data?.status === 'complete' &&
+    sessionQuery.data?.paymentStatus === 'paid';
+  const isCodSuccess =
+    !sessionId &&
+    isCashOnDelivery &&
+    (locationState?.paymentStatus === 'pending' || Boolean(orderSnapshot));
+  const isSuccess = isStripeSuccess || isCodSuccess;
+
+  const title = sessionQuery.isLoading
+    ? 'Checking your payment status...'
+    : isSuccess
+      ? 'Order confirmed'
+      : 'We could not confirm this order';
+
+  const description = sessionQuery.isLoading
+    ? 'Please wait while we verify the checkout session.'
+    : isSuccess
+      ? 'Your checkout has been completed successfully.'
+      : 'The payment session is incomplete or unavailable. You can return to checkout and try again.';
+
+  useEffect(() => {
+    if (isSuccess) {
+      clearCart();
+    }
+  }, [clearCart, isSuccess]);
+
+  return (
+    <div
+      className={clsx(
+        'px-4 py-12 md:px-8 md:py-20',
+        isDark ? 'bg-black' : 'bg-white',
+      )}
+    >
+      <div className="mx-auto max-w-3xl">
+        <div
+          className={clsx(
+            'rounded-2xl border px-6 py-8 md:px-10 md:py-12',
+            isDark
+              ? 'border-gray-700 bg-[#111111] text-white'
+              : 'border-[#E8ECEF] bg-white text-[#141718]',
+          )}
+        >
+          <div className="flex flex-col items-start gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-3">
+              {isSuccess ? (
+                <CheckCircle2 className="text-primary h-10 w-10" />
+              ) : (
+                <XCircle className="h-10 w-10 text-red-500" />
+              )}
+              <div>
+                <h1 className="text-[32px] leading-[38px] font-medium">
+                  {title}
+                </h1>
+                <p
+                  className={clsx(
+                    'mt-2 text-sm md:text-base',
+                    isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                  )}
+                >
+                  {description}
+                </p>
+              </div>
+            </div>
+            {orderSnapshot?.orderId && (
+              <div
+                className={clsx(
+                  'rounded-full px-4 py-2 text-sm font-semibold',
+                  isDark
+                    ? 'bg-black text-gray-300'
+                    : 'bg-[#F3F5F7] text-[#141718]',
+                )}
+              >
+                {orderSnapshot.orderId}
+              </div>
+            )}
+          </div>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            <InfoCard
+              isDark={isDark}
+              icon={<PackageCheck className="h-5 w-5" />}
+              label="Items"
+              value={String(orderSnapshot?.items.length ?? 0)}
+            />
+            <InfoCard
+              isDark={isDark}
+              icon={<Truck className="h-5 w-5" />}
+              label="Payment"
+              value={
+                isCashOnDelivery
+                  ? 'Cash on delivery'
+                  : (sessionQuery.data?.paymentStatus ?? 'Card payment')
+              }
+            />
+            <InfoCard
+              isDark={isDark}
+              icon={<CreditCard className="h-5 w-5" />}
+              label="Total"
+              value={
+                orderSnapshot
+                  ? formatCurrency(orderSnapshot.totalPrice)
+                  : 'Unavailable'
+              }
+            />
+          </div>
+
+          {orderSnapshot && (
+            <div className="mt-8">
+              <h2 className="text-xl font-medium">Order details</h2>
+              <div
+                className={clsx(
+                  'mt-4 rounded-xl border',
+                  isDark ? 'border-gray-700' : 'border-[#E8ECEF]',
+                )}
+              >
+                {orderSnapshot.items.map((item, index) => (
+                  <div
+                    key={`${item.product}-${index}`}
+                    className={clsx(
+                      'flex items-center justify-between gap-4 px-4 py-4',
+                      index !== orderSnapshot.items.length - 1 &&
+                        (isDark
+                          ? 'border-b border-gray-700'
+                          : 'border-b border-[#E8ECEF]'),
+                    )}
+                  >
+                    <div className="flex min-w-0 items-center gap-4">
+                      {item.imageUrl ? (
+                        <img
+                          src={item.imageUrl}
+                          alt={item.title}
+                          className="h-14 w-12 object-cover"
+                        />
+                      ) : (
+                        <div
+                          className={clsx(
+                            'flex h-14 w-12 items-center justify-center',
+                            isDark ? 'bg-black' : 'bg-[#F3F5F7]',
+                          )}
+                        >
+                          <span className="text-[10px] text-gray-400">
+                            No image
+                          </span>
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold">
+                          {item.title}
+                        </p>
+                        <p
+                          className={clsx(
+                            'text-xs',
+                            isDark ? 'text-gray-400' : 'text-[#6C7275]',
+                          )}
+                        >
+                          Qty: {item.amount}
+                        </p>
+                      </div>
+                    </div>
+                    <span className="text-sm font-semibold">
+                      {formatCurrency(item.unitPrice * item.amount)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link to={ROUTES.SHOP} className="sm:flex-1">
+              <Button
+                className={clsx(
+                  'h-12 w-full rounded-[8px] border-none text-base font-medium shadow-none',
+                  isDark
+                    ? 'bg-white text-[#141718] hover:bg-gray-200'
+                    : 'bg-[#141718] text-white hover:bg-black',
+                )}
+              >
+                Continue shopping
+              </Button>
+            </Link>
+            {!isSuccess && (
+              <Link to={ROUTES.CHECKOUT} className="sm:flex-1">
+                <Button
+                  className={clsx(
+                    'h-12 w-full rounded-[8px] text-base font-medium shadow-none',
+                    isDark
+                      ? 'border border-gray-700 bg-transparent text-white hover:bg-[#1A1A1A]'
+                      : 'border border-[#141718] bg-transparent text-[#141718] hover:bg-[#F3F5F7]',
+                  )}
+                >
+                  Back to checkout
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const InfoCard = ({
+  isDark,
+  icon,
+  label,
+  value,
+}: {
+  isDark: boolean;
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) => (
+  <div
+    className={clsx(
+      'rounded-xl border px-4 py-4',
+      isDark ? 'border-gray-700 bg-black' : 'border-[#E8ECEF] bg-[#F9FAFB]',
+    )}
+  >
+    <div
+      className={clsx(
+        'flex items-center gap-2 text-sm',
+        isDark ? 'text-gray-400' : 'text-[#6C7275]',
+      )}
+    >
+      {icon}
+      {label}
+    </div>
+    <div className="mt-3 text-lg font-semibold">{value}</div>
+  </div>
+);

--- a/src/pages/OrderConfirmation/index.ts
+++ b/src/pages/OrderConfirmation/index.ts
@@ -1,0 +1,1 @@
+export { OrderConfirmation } from './OrderConfirmation';

--- a/src/pages/User/MyOrders.tsx
+++ b/src/pages/User/MyOrders.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AccountSidebar, MOCK_ORDERS, OrderCard } from '@/components';
+import { ROUTES } from '@/constants';
+import { authService } from '@/services';
+import { usersService } from '@/services/users.service';
+import type { User } from '@/types/user';
+
+export function MyOrders() {
+  const navigate = useNavigate();
+
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [pageError, setPageError] = useState('');
+
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        const currentUser = await usersService.getMe();
+        setUser(currentUser);
+      } catch (err) {
+        setPageError(
+          err instanceof Error ? err.message : 'Failed to load profile',
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadUser();
+  }, []);
+
+  const handleLogout = async () => {
+    try {
+      await authService.logout();
+
+      localStorage.removeItem('token');
+      localStorage.removeItem('token_expires');
+      localStorage.removeItem('role');
+      localStorage.removeItem('user');
+
+      setUser(null);
+      navigate(ROUTES.HOME, { replace: true });
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-10">Loading...</div>;
+  }
+
+  if (pageError) {
+    return <div className="p-10 text-red-600">{pageError}</div>;
+  }
+
+  if (!user) {
+    return <div className="p-10">User not found</div>;
+  }
+
+  return (
+    <section className="min-h-screen bg-white px-4 md:px-8 lg:px-40">
+      <h1 className="mt-10 mb-16 text-center text-[54px] leading-none font-semibold text-black">
+        My Account
+      </h1>
+
+      <div className="mx-auto max-w-[1180px]">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-[220px_minmax(0,1fr)] md:items-start">
+          <AccountSidebar user={user} onLogout={handleLogout} />
+
+          <div className="-full min-w-0 px-[72px]">
+            <h2 className="mb-6 text-xl font-semibold text-black">
+              Orders History
+            </h2>
+            <div className="mb-3 hidden border-b border-gray-200 pb-3 text-sm text-gray-400 md:grid md:grid-cols-[150px_180px_140px_1fr_140px]">
+              <span>Number ID</span>
+              <span>Dates</span>
+              <span>Status</span>
+              <span>Price</span>
+              <span />
+            </div>
+            <div className="flex flex-col">
+              {MOCK_ORDERS.map((order) => (
+                <OrderCard key={order.id} order={order} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,5 @@
 export * from './Cart';
+export * from './Checkout';
 export { Home } from './Home/Home';
+export * from './OrderConfirmation';
 export { Products } from './Products/Products';

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MOCK_AUTH } from '@/constants';
+
+import { apiClient } from './api';
+
+describe('service: apiClient', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('retries a protected POST request after refreshing the auth session', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'success' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            sessionId: 'cs_test',
+            sessionUrl: 'https://stripe.test',
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      );
+
+    global.fetch = fetchMock as typeof fetch;
+
+    const response = await apiClient.post('/payments/create-checkout-session', {
+      items: [],
+    });
+
+    expect(response).toEqual({
+      sessionId: 'cs_test',
+      sessionUrl: 'https://stripe.test',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:3001/auth/refresh',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:3001/payments/create-checkout-session',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    );
+  });
+
+  it('clears local auth markers when refresh fails after a 401 response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+        }),
+      );
+
+    global.fetch = fetchMock as typeof fetch;
+
+    localStorage.setItem(MOCK_AUTH.TOKEN_KEY, 'cookie-is-set');
+    localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, String(Date.now() + 60_000));
+    localStorage.setItem(MOCK_AUTH.ROLE_KEY, 'customer');
+
+    await expect(
+      apiClient.post('/payments/create-checkout-session', { items: [] }),
+    ).rejects.toThrow('HTTP error! status: 401');
+
+    expect(localStorage.getItem(MOCK_AUTH.TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(MOCK_AUTH.EXPIRES_KEY)).toBeNull();
+    expect(localStorage.getItem(MOCK_AUTH.ROLE_KEY)).toBeNull();
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,10 @@
-import { API_BASE_URL } from '../constants';
+import { API_BASE_URL, MOCK_AUTH } from '../constants';
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string | number | boolean | undefined>;
 }
+
+let refreshPromise: Promise<boolean> | null = null;
 
 const buildUrl = (
   endpoint: string,
@@ -20,6 +22,31 @@ const buildUrl = (
 
   return url.toString();
 };
+
+const clearClientAuthState = () => {
+  localStorage.removeItem(MOCK_AUTH.TOKEN_KEY);
+  localStorage.removeItem(MOCK_AUTH.EXPIRES_KEY);
+  localStorage.removeItem(MOCK_AUTH.ROLE_KEY);
+};
+
+const refreshAuthSession = async (): Promise<boolean> => {
+  if (!refreshPromise) {
+    refreshPromise = fetch(`${API_BASE_URL}/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then((response) => response.ok)
+      .catch(() => false)
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+};
+
+const shouldAttemptRefresh = (endpoint: string, response: Response) =>
+  response.status === 401 && !endpoint.startsWith('/auth/');
 /**
  * Base API client configuration
  */
@@ -27,11 +54,25 @@ export const apiClient = {
   async get<T>(endpoint: string, options?: FetchOptions): Promise<T> {
     const url = buildUrl(endpoint, options?.params);
 
-    const response = await fetch(url, {
+    let response = await fetch(url, {
       method: 'GET',
       credentials: 'include',
       ...options,
     });
+
+    if (shouldAttemptRefresh(endpoint, response)) {
+      const refreshed = await refreshAuthSession();
+
+      if (refreshed) {
+        response = await fetch(url, {
+          method: 'GET',
+          credentials: 'include',
+          ...options,
+        });
+      } else {
+        clearClientAuthState();
+      }
+    }
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
@@ -41,7 +82,7 @@ export const apiClient = {
   },
 
   async post<T>(endpoint: string, data: unknown): Promise<T> {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    let response = await fetch(`${API_BASE_URL}${endpoint}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -50,6 +91,23 @@ export const apiClient = {
       body: JSON.stringify(data),
     });
 
+    if (shouldAttemptRefresh(endpoint, response)) {
+      const refreshed = await refreshAuthSession();
+
+      if (refreshed) {
+        response = await fetch(`${API_BASE_URL}${endpoint}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(data),
+        });
+      } else {
+        clearClientAuthState();
+      }
+    }
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -57,7 +115,7 @@ export const apiClient = {
   },
 
   async put<T>(endpoint: string, data: unknown): Promise<T> {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    let response = await fetch(`${API_BASE_URL}${endpoint}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -66,6 +124,23 @@ export const apiClient = {
       body: JSON.stringify(data),
     });
 
+    if (shouldAttemptRefresh(endpoint, response)) {
+      const refreshed = await refreshAuthSession();
+
+      if (refreshed) {
+        response = await fetch(`${API_BASE_URL}${endpoint}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(data),
+        });
+      } else {
+        clearClientAuthState();
+      }
+    }
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -73,10 +148,23 @@ export const apiClient = {
   },
 
   async delete<T>(endpoint: string): Promise<T> {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    let response = await fetch(`${API_BASE_URL}${endpoint}`, {
       method: 'DELETE',
       credentials: 'include',
     });
+
+    if (shouldAttemptRefresh(endpoint, response)) {
+      const refreshed = await refreshAuthSession();
+
+      if (refreshed) {
+        response = await fetch(`${API_BASE_URL}${endpoint}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        });
+      } else {
+        clearClientAuthState();
+      }
+    }
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -46,8 +46,10 @@ export const apiClient = {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -60,8 +62,10 @@ export const apiClient = {
       headers: {
         'Content-Type': 'application/json',
       },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -71,7 +75,9 @@ export const apiClient = {
   async delete<T>(endpoint: string): Promise<T> {
     const response = await fetch(`${API_BASE_URL}${endpoint}`, {
       method: 'DELETE',
+      credentials: 'include',
     });
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,6 +12,7 @@ export {
   CREATE_PRODUCT,
   GET_PRODUCTS_PAGE,
 } from './graphql/productAdminService';
+export { orderService } from './orderService';
 export { paymentService } from './paymentService';
 export { productService } from './productService';
 export { uploadService } from './uploadService';

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,0 +1,9 @@
+import type { CreatedOrder, CreateOrderPayload } from '@/types';
+
+import { apiClient } from './api';
+
+export const orderService = {
+  createOrder(payload: CreateOrderPayload): Promise<CreatedOrder> {
+    return apiClient.post<CreatedOrder>('/orders', payload);
+  },
+};

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,5 +1,3 @@
-import { API_BASE_URL } from '@/constants';
-
 import { apiClient } from './api';
 
 export interface CheckoutItem {
@@ -23,24 +21,12 @@ export interface SessionStatusResponse {
 export const paymentService = {
   async createCheckoutSession(
     items: CheckoutItem[],
+    orderId?: string,
   ): Promise<CheckoutSessionResponse> {
-    const response = await fetch(
-      `${API_BASE_URL}/payments/create-checkout-session`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ items }),
-      },
+    return apiClient.post<CheckoutSessionResponse>(
+      '/payments/create-checkout-session',
+      { items, orderId },
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    return response.json();
   },
 
   getSessionStatus(sessionId: string): Promise<SessionStatusResponse> {

--- a/src/types/checkout.types.ts
+++ b/src/types/checkout.types.ts
@@ -1,0 +1,67 @@
+export const SHIPPING_CARRIERS = {
+  NOVA_POST: 'nova_post',
+  UKRPOSHTA: 'ukrposhta',
+  MEEST: 'meest',
+} as const;
+
+export const PAYMENT_METHODS = {
+  CASH_ON_DELIVERY: 'cash_on_delivery',
+  STRIPE: 'stripe',
+} as const;
+
+export type ShippingCarrier =
+  (typeof SHIPPING_CARRIERS)[keyof typeof SHIPPING_CARRIERS];
+
+export type PaymentMethod =
+  (typeof PAYMENT_METHODS)[keyof typeof PAYMENT_METHODS];
+
+export interface CreateOrderItemPayload {
+  product: string;
+  amount: number;
+}
+
+export interface CreateShippingAddressPayload {
+  carrier: ShippingCarrier;
+  city: string;
+  branchNumber: string;
+}
+
+export interface CreateOrderUserPayload {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+}
+
+export interface CreateOrderPayload {
+  items: CreateOrderItemPayload[];
+  shippingAddress: CreateShippingAddressPayload;
+  user: CreateOrderUserPayload;
+  paymentMethod: PaymentMethod;
+  message?: string;
+}
+
+export interface CreatedOrderItem {
+  product: string;
+  title: string;
+  imageUrl?: string;
+  unitPrice: number;
+  amount: number;
+}
+
+export interface CreatedOrder {
+  orderId: string;
+  items: CreatedOrderItem[];
+  totalPrice: number;
+  amount: number;
+  message?: string;
+}
+
+export interface CheckoutOrderSnapshot {
+  orderId: string;
+  amount: number;
+  totalPrice: number;
+  paymentMethod: PaymentMethod;
+  items: CreatedOrderItem[];
+  customerName: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './api.types';
 export * from './category.types';
+export * from './checkout.types';
 export * from './product.types';
 export * from './table.types';
 export * from './user.types';

--- a/src/utils/checkoutStorage.ts
+++ b/src/utils/checkoutStorage.ts
@@ -1,0 +1,28 @@
+import type { CheckoutOrderSnapshot } from '@/types';
+
+const CHECKOUT_ORDER_STORAGE_KEY = 'checkout-order-snapshot';
+
+export const checkoutStorage = {
+  save(snapshot: CheckoutOrderSnapshot) {
+    localStorage.setItem(CHECKOUT_ORDER_STORAGE_KEY, JSON.stringify(snapshot));
+  },
+
+  read(): CheckoutOrderSnapshot | null {
+    const rawValue = localStorage.getItem(CHECKOUT_ORDER_STORAGE_KEY);
+
+    if (!rawValue) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(rawValue) as CheckoutOrderSnapshot;
+    } catch {
+      localStorage.removeItem(CHECKOUT_ORDER_STORAGE_KEY);
+      return null;
+    }
+  },
+
+  clear() {
+    localStorage.removeItem(CHECKOUT_ORDER_STORAGE_KEY);
+  },
+};

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,3 @@
+export const redirectToExternalUrl = (url: string) => {
+  window.location.assign(url);
+};


### PR DESCRIPTION
## Summary
Resolves `#265` by implementing the checkout experience and post-order confirmation flow.

## Implemented
- protected checkout routing inside the main user flow
- responsive checkout page matching the provided designs
- contact information, shipping, payment method, and order summary blocks
- delivery provider support for `Нова Пошта`, `Укрпошта`, and `Meest`
- hosted Stripe Checkout integration for card payments
- `Cash on delivery` order flow
- order confirmation page for both Stripe and COD outcomes
- persisted checkout snapshot across the Stripe redirect flow

## Fixed during implementation
- checkout no longer asks users to enter card details twice
- browser-restored form values no longer trigger incorrect required-field errors
- checkout requests now recover correctly after access token expiration

## Checks
- `pnpm run lint`
- `pnpm test -- --run`
- `pnpm run build`

Closes UA-5399-React/docs#265
