### PR TITLE
Feat/287 add dark theme userspage

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -37,7 +37,7 @@ export const ActionMenu = ({
     <div ref={rootRef} className="relative">
       <Button
         type="button"
-        className={`${styles.button} text-gray600 hover:text-bgSecInverted bg-transparent hover:border-transparent!`}
+        className={`${styles.button} hover:text-bgSecInverted bg-transparent text-gray-600 hover:!border-transparent`}
         onClick={() => setIsOpen((prev) => !prev)}
       >
         <EllipsisVertical className="text-bgSecInverted h-5 w-5" />
@@ -45,11 +45,11 @@ export const ActionMenu = ({
 
       {isOpen && (
         <div
-          className={`align-center bg-background border-gray300 absolute top-0 left-10 z-20 flex w-[140px] flex-col rounded-xl border p-2 shadow-lg ${className}`}
+          className={`bg-background absolute top-0 left-10 z-20 flex w-[140px] flex-col rounded-xl border border-gray-300 p-2 shadow-lg ${className ?? ''}`}
         >
           <Button
             type="button"
-            className={`${styles.button} text-text border-b-red700 border-b-2 bg-transparent`}
+            className={`${styles.button} border-fieldBorder text-text border-b-2 bg-transparent`}
             onClick={() => {
               setIsOpen(false);
               editAction();
@@ -57,19 +57,18 @@ export const ActionMenu = ({
           >
             <div className={styles.buttonActionContent}>
               <Pencil />
-
               <span>Edit</span>
             </div>
           </Button>
 
           {deleteAction && (
-            <hr className="border-t-gray300 my-2 w-full border-0 border-t border-solid" />
+            <hr className="my-2 w-full border-0 border-t border-gray-300" />
           )}
 
           {deleteAction && (
             <Button
               type="button"
-              className={`${styles.button} text-red700 bg-transparent`}
+              className={`${styles.button} bg-transparent text-red-700`}
               onClick={() => {
                 setIsOpen(false);
                 deleteAction();
@@ -77,7 +76,6 @@ export const ActionMenu = ({
             >
               <div className={styles.buttonActionContent}>
                 <Trash />
-
                 <span>Delete</span>
               </div>
             </Button>

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -9,12 +9,14 @@ interface ActionMenuProps {
   editAction: () => void;
   deleteAction?: () => void;
   className?: string;
+  triggerAriaLabel?: string;
 }
 
 export const ActionMenu = ({
   editAction,
   deleteAction,
   className,
+  triggerAriaLabel,
 }: ActionMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -37,6 +39,7 @@ export const ActionMenu = ({
     <div ref={rootRef} className="relative">
       <Button
         type="button"
+        aria-label={triggerAriaLabel}
         className={`${styles.button} hover:text-bgSecInverted bg-transparent text-gray-600 hover:!border-transparent`}
         onClick={() => setIsOpen((prev) => !prev)}
       >

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+import type { AdminUser } from '@/types/admin-user.types';
+
+interface UserAvatarProps {
+  user: AdminUser;
+}
+
+const getUserInitials = (user: AdminUser) => {
+  const firstInitial = user.firstName ? user.firstName[0] : '';
+  const lastInitial = user.lastName ? user.lastName[0] : '';
+
+  return `${firstInitial}${lastInitial}`.toUpperCase();
+};
+
+export const UserAvatar = ({ user }: UserAvatarProps) => {
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <div className="border-fieldBorder text-text dark:text-neutral-0 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full border bg-gray-100 text-sm font-semibold dark:bg-neutral-800">
+      {user.avatarUrl && !hasError ? (
+        <img
+          src={user.avatarUrl}
+          alt={`${user.firstName} ${user.lastName}`}
+          className="h-full w-full object-cover"
+          onError={() => setHasError(true)}
+        />
+      ) : (
+        <span>{getUserInitials(user)}</span>
+      )}
+    </div>
+  );
+};

--- a/src/components/UserAvatar/index.ts
+++ b/src/components/UserAvatar/index.ts
@@ -1,0 +1,1 @@
+export { UserAvatar } from './UserAvatar';

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -162,8 +162,9 @@ export function UsersTable({ items }: UsersTableProps) {
 
                 <td className="relative text-right">
                   <ActionMenu
-                    editAction={() => undefined}
-                    deleteAction={() => undefined}
+                    triggerAriaLabel={`Actions for ${getFullName(user)}`}
+                    editAction={() => {}}
+                    deleteAction={() => {}}
                     className={clsx(
                       'right-0 left-auto',
                       shouldOpenUpward ? 'top-auto bottom-10' : 'top-10',

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
 import clsx from 'clsx';
-import { EllipsisVertical, Pencil, Trash } from 'lucide-react';
 
-import { Button, Checkbox, Dropdown } from '@/components';
+import { ActionMenu, Checkbox, Dropdown } from '@/components';
+import { UserAvatar } from '@/components/UserAvatar';
 import {
   USER_ROLE_EDIT_OPTIONS,
   USER_STATUS_EDIT_OPTIONS,
@@ -32,8 +31,6 @@ const getActivityLabel = (dateString: string | undefined) => {
 };
 
 export function UsersTable({ items }: UsersTableProps) {
-  const [openedMenuId, setOpenedMenuId] = useState<string | null>(null);
-
   const { handleUpdate, isUpdating } = useUpdateAdminUser();
 
   const handleStatusChange = async (
@@ -58,18 +55,17 @@ export function UsersTable({ items }: UsersTableProps) {
 
   if (!items.length) {
     return (
-      <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white p-8 text-center text-[#8A92A6] shadow-md">
+      <div className="border-fieldBorder bg-neutral-0 text-muted dark:bg-backgroundSec mt-5 rounded-lg border p-8 text-center shadow-md">
         No users found
       </div>
     );
   }
-
   return (
-    <div className="mt-5 overflow-x-auto rounded-lg border border-[#E5E7EB] bg-white shadow-md">
-      <table className="w-full border-collapse overflow-hidden rounded-t-lg [&_td]:border-b [&_td]:border-[#E5E7EB] [&_thead_th]:border-b [&_thead_th]:border-[#E5E7EB] [&_thead_th]:px-4">
-        <thead className="h-[50px] bg-[#F9FAFB] text-[#8A92A6]">
+    <div className="border-fieldBorder mt-5 rounded-lg border shadow-md">
+      <table className="[&_td]:border-fieldBorder [&_thead_th]:border-fieldBorder w-full border-collapse rounded-t-lg [&_td]:border-b [&_thead_th]:border-b [&_thead_th]:px-4">
+        <thead className="text-muted h-[56px] bg-gray-50">
           <tr>
-            <th className="w-[250px] text-left">
+            <th className="w-[280px] text-left">
               <div className="flex items-center gap-2">
                 <Checkbox className="h-[20px] w-[20px]" />
                 <span>User</span>
@@ -82,27 +78,25 @@ export function UsersTable({ items }: UsersTableProps) {
             <th className="w-[80px]"></th>
           </tr>
         </thead>
+
         <tbody
           className={clsx(
-            'bg-white [&_td]:px-4 [&_td]:py-4',
+            'bg-neutral-0 dark:bg-backgroundSec [&_td]:px-4 [&_td]:py-5 [&_td]:text-left',
             isUpdating && 'pointer-events-none opacity-50',
           )}
         >
-          {items.map((user) => {
+          {items.map((user, index) => {
             const currentStatus = user.isActive ? 'active' : 'blocked';
             const currentRole = user.role;
+            const shouldOpenUpward = index >= items.length - 2;
 
             return (
-              <tr key={user.id} className="text-[rgb(var(--color-text))]">
+              <tr key={user.id} className="text-text text-base">
                 <td>
                   <div className="flex items-center gap-3">
                     <Checkbox className="h-[20px] w-[20px]" />
-                    <img
-                      src={user.avatarUrl}
-                      alt={getFullName(user)}
-                      className="h-10 w-10 rounded-full object-cover"
-                    />
-                    <span className="text-sm font-medium text-[#2C2C2C]">
+                    <UserAvatar user={user} />
+                    <span className="text-text text-base font-medium">
                       {getFullName(user)}
                     </span>
                   </div>
@@ -126,18 +120,18 @@ export function UsersTable({ items }: UsersTableProps) {
                     selectClassName={
                       ' ' +
                       clsx(
-                        '!flex !items-center !justify-between',
-                        '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !shadow-none hover:!bg-white',
-                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+                        '!flex !h-8 !min-w-[140px] !items-center !justify-between',
+                        '!whitespace-nowrap !rounded-[10px] !border !border-fieldBorder !bg-neutral-0 !px-3 !py-0 !text-sm !font-normal !shadow-none hover:!bg-gray-50',
+                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-blue-500',
                         currentStatus === 'active'
-                          ? '!text-[#38CB89]'
-                          : '!text-[#EF4444]',
+                          ? '!text-primary'
+                          : '!text-red-700',
                       )
                     }
                   />
                 </td>
 
-                <td className="text-sm text-[#525252]">{user.email}</td>
+                <td className="text-text text-base">{user.email}</td>
 
                 <td>
                   <Dropdown
@@ -154,59 +148,27 @@ export function UsersTable({ items }: UsersTableProps) {
                     selectClassName={
                       ' ' +
                       clsx(
-                        '!flex !items-center !justify-between',
-                        '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
-                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+                        '!flex !h-10 !min-w-[170px] !items-center !justify-between',
+                        '!whitespace-nowrap !rounded-[10px] !border !border-fieldBorder !bg-neutral-0 !px-3 !py-0 !text-sm !font-normal !text-neutral-800 !shadow-none hover:!bg-gray-50',
+                        '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-blue-500',
                       )
                     }
                   />
                 </td>
 
-                <td className="text-sm text-[#525252]">
-                  {getActivityLabel(user.updatedAt)}
+                <td className="text-text text-base">
+                  {getActivityLabel(user.lastLoginAt)}
                 </td>
 
-                <td className="relative">
-                  <Button
-                    type="button"
-                    aria-label={`Actions for ${getFullName(user)}`}
-                    className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
-                    onClick={() =>
-                      setOpenedMenuId((prev) =>
-                        prev === user.id ? null : user.id,
-                      )
-                    }
-                  >
-                    <EllipsisVertical className="h-5 w-5" />
-                  </Button>
-
-                  {openedMenuId === user.id && (
-                    <>
-                      <div
-                        className="fixed inset-0 z-10"
-                        onClick={() => setOpenedMenuId(null)}
-                      />
-                      <div className="absolute top-12 right-0 z-20 w-[140px] rounded-xl border border-[#E5E7EB] bg-white shadow-lg">
-                        <Button
-                          type="button"
-                          className="flex w-full items-center gap-2 rounded-none bg-transparent px-4 py-3 text-left text-sm text-[#2C2C2C] hover:bg-[#F9FAFB]"
-                        >
-                          <Pencil className="h-4 w-4" />
-                          Edit
-                        </Button>
-
-                        <div className="mx-3 border-t border-[#E5E7EB]" />
-
-                        <Button
-                          type="button"
-                          className="flex w-full items-center gap-2 rounded-none bg-transparent px-4 py-3 text-left text-sm text-[#DB162D] hover:bg-[#F9FAFB]"
-                        >
-                          <Trash className="h-4 w-4" />
-                          Delete
-                        </Button>
-                      </div>
-                    </>
-                  )}
+                <td className="relative text-right">
+                  <ActionMenu
+                    editAction={() => undefined}
+                    deleteAction={() => undefined}
+                    className={clsx(
+                      'right-0 left-auto',
+                      shouldOpenUpward ? 'top-auto bottom-10' : 'top-10',
+                    )}
+                  />
                 </td>
               </tr>
             );

--- a/src/components/UsersToolbar/UsersToolbar.tsx
+++ b/src/components/UsersToolbar/UsersToolbar.tsx
@@ -47,15 +47,17 @@ export function UsersToolbar({
           onChange={setSearchValue}
           placeholder="Search"
         />
+
         <Button
           type="button"
           onClick={onCreateUser}
-          className="flex h-[48px] items-center gap-2 rounded-xl bg-[#1D4ED8] px-6 text-sm font-medium text-white hover:bg-[#1E40AF]"
+          className="text-neutral-0 flex h-[48px] items-center gap-2 rounded-xl bg-blue-500 px-6 text-sm font-medium transition-colors duration-300 hover:bg-blue-800"
         >
           <UserPlus className="h-[18px] w-[18px]" />
           Create user
         </Button>
       </div>
+
       <div className="flex flex-wrap gap-4">
         <Dropdown
           label="Status"
@@ -74,12 +76,14 @@ export function UsersToolbar({
           selectClassName={
             ' ' +
             clsx(
-              '!flex !items-center !justify-between',
-              '!h-10 !min-w-[100px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
-              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+              '!flex !h-10 !min-w-[100px] !items-center !justify-between',
+              '!rounded-xl !border !border-fieldBorder !bg-backgroundSec dark:!bg-neutral-0 !px-4 !py-0 !text-sm !font-medium !text-text dark:!text-neutral-800 !shadow-none !transition-colors !duration-300',
+              'hover:!opacity-90',
+              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-blue-500',
             )
           }
         />
+
         <Dropdown
           label="Role"
           labelClassName="sr-only"
@@ -97,9 +101,10 @@ export function UsersToolbar({
           selectClassName={
             ' ' +
             clsx(
-              '!flex !items-center !justify-between',
-              '!h-10 !min-w-[140px] !rounded-xl !bg-[#F3F4F6] !px-4 !py-0 !text-sm !font-medium !text-[#1F2937] !shadow-none hover:!bg-[#E5E7EB]',
-              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+              '!flex !h-10 !min-w-[150px] !items-center !justify-between',
+              '!whitespace-nowrap !rounded-xl !border !border-fieldBorder !bg-backgroundSec dark:!bg-neutral-0 !px-4 !py-0 !text-sm !font-medium !text-text dark:!text-neutral-800 !shadow-none !transition-colors !duration-300',
+              'hover:!opacity-90',
+              '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-blue-500',
             )
           }
         />

--- a/src/components/UsersTopWidgets/UsersTopWidgets.tsx
+++ b/src/components/UsersTopWidgets/UsersTopWidgets.tsx
@@ -33,15 +33,15 @@ export function UsersTopWidgets({
         <div
           key={item.id}
           className={clsx(
-            'flex flex-col items-center justify-center py-6',
+            'flex flex-col items-center justify-center py-6 transition-colors duration-300',
             index !== widgetItems.length - 1 &&
-              'md:border-r md:border-[#D9D9D9]',
+              'md:border-fieldBorder md:border-r',
           )}
         >
-          <p className="m-0 text-6xl font-medium text-[#2C2C2C]">
+          <p className="text-text m-0 text-6xl font-medium">
             {values[item.valueKey]}
           </p>
-          <p className="text-sm font-medium text-[#BDBDBD]">{item.label}</p>
+          <p className="text-muted text-sm font-medium">{item.label}</p>
         </div>
       ))}
     </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export { TableCategories } from './TableCategories/TableCategories';
 export { TableOrders } from './TableOrders/TableOrders';
 export { TableProducts } from './TableProducts/TableProducts';
 export { TextArea } from './TextArea';
+export { UserAvatar } from './UserAvatar';
 export { AccountDetailsForm } from './UserProfile/AccountDetailsForm/AccountDetailsForm';
 export { AccountInput } from './UserProfile/AccountInput/AccountInput';
 export { AccountSidebar } from './UserProfile/AccountSidebar/AccountSidebar';

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -45,7 +45,8 @@ export const useAdminUsers = ({
     () =>
       users.filter(
         (u) =>
-          (u.role === AUTH_ROLES.ADMIN || u.role === AUTH_ROLES.SUPER_ADMIN) &&
+          (u.role.toLowerCase() === AUTH_ROLES.ADMIN.toLowerCase() ||
+            u.role.toLowerCase() === AUTH_ROLES.SUPER_ADMIN.toLowerCase()) &&
           u.isActive,
       ).length,
     [users],

--- a/src/pages/Admin/Users/AdminUsers.tsx
+++ b/src/pages/Admin/Users/AdminUsers.tsx
@@ -138,7 +138,7 @@ export const AdminUsers = () => {
   }, [usersState.totalPages, normalizeOutOfRangePage]);
 
   return (
-    <section className="min-h-screen bg-[#FCFCFC] px-6 py-8">
+    <section className="bg-background text-text min-h-screen px-6 py-8 transition-colors duration-300">
       <div className="mx-auto">
         <UsersTopWidgets
           totalUsers={usersState.totalUsers}

--- a/src/services/graphql/userAdminService.ts
+++ b/src/services/graphql/userAdminService.ts
@@ -23,6 +23,7 @@ export const GET_USERS_LIST = gql`
         createdAt
         updatedAt
         lastLoginAt
+        avatarUrl
       }
       total
     }

--- a/src/types/admin-user.types.ts
+++ b/src/types/admin-user.types.ts
@@ -15,6 +15,7 @@ export interface AdminUser {
   avatarUrl?: string;
   createdAt: string;
   updatedAt: string;
+  lastLoginAt?: string;
 }
 
 export interface UpdateUserInput {


### PR DESCRIPTION
- added dark theme support for the Admin Users page
- updated Activity in Users table to use lastLoginAt instead of updatedAt
- updated Users table, toolbar, and top widgets styles for light/dark themes
- changed unworking colour classes for ActionMenu
- added a separate UserAvatar component for rendering user avatars in users table, with fallback initials when no image is available
<img width="1004" height="577" alt="image" src="https://github.com/user-attachments/assets/12e4c44a-eeed-4ca1-b5ef-d95093e472fa" />
Resolves https://github.com/UA-5399-React/docs/issues/287