### PR TITLE
feat(283): connect registration with backend and email confirmation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AdminOrders } from './pages/Admin/Orders/AdminOrders';
 import { AdminProducts } from './pages/Admin/Products/AdminProducts';
 import { AdminSettings } from './pages/Admin/Settings/AdminSettings';
 import { AdminUsers } from './pages/Admin/Users/AdminUsers';
+import { EmailConfirmationPage } from './pages/Auth/EmailConfirmationPage';
 import { ContactUs, NotFound, Shop } from './pages/Mocks';
 import { Profile } from './pages/User/Profile';
 
@@ -41,6 +42,7 @@ function App() {
     ADMIN_PRODUCT_EDIT,
     LOGIN,
     REGISTER,
+    EMAIL_CONFIRMATION,
     ADMIN_ORDERS,
     PROFILE,
   } = ROUTES;
@@ -63,6 +65,10 @@ function App() {
         <Route element={<AuthLayout />}>
           <Route path={LOGIN} element={<LoginForm />} />
           <Route path={REGISTER} element={<RegisterForm />} />
+          <Route
+            path={EMAIL_CONFIRMATION}
+            element={<EmailConfirmationPage />}
+          />
         </Route>
 
         <Route

--- a/src/components/RegisterForm/RegisterForm.test.tsx
+++ b/src/components/RegisterForm/RegisterForm.test.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { useRegister } from '@/hooks';
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
+
+import { RegisterForm } from './RegisterForm';
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual('@/hooks');
+  return {
+    ...actual,
+    useRegister: vi.fn(),
+  };
+});
+
+describe('Feature: RegisterForm', () => {
+  const mockMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useRegister as Mock).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    });
+  });
+
+  it('should display all required form fields and submit button', () => {
+    render(<RegisterForm />);
+
+    expect(
+      screen.getByPlaceholderText(/Your email address/i),
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/^Password$/i)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/Confirm password/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign Up' })).toBeInTheDocument();
+  });
+
+  it('should show validation errors when submitted empty', async () => {
+    const user = userEvent.setup();
+
+    render(<RegisterForm />);
+
+    await user.click(screen.getByRole('button', { name: 'Sign Up' }));
+
+    expect(await screen.findByText('Email is required')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Password must be at least 8 characters, include uppercase, lowercase, number and symbol',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('Please confirm your password'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'You must agree to the Privacy Policy and Terms of Use',
+      ),
+    ).toBeInTheDocument();
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('should call register API with backend payload and show success state', async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockResolvedValueOnce({
+      status: 'success',
+      message: 'User created successfully.',
+    });
+
+    render(<RegisterForm />);
+
+    await user.type(
+      screen.getByPlaceholderText(/Your email address/i),
+      'newuser@test.com',
+    );
+    await user.type(screen.getByPlaceholderText(/^Password$/i), 'Password1!');
+    await user.type(
+      screen.getByPlaceholderText(/Confirm password/i),
+      'Password1!',
+    );
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Sign Up' }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        email: 'newuser@test.com',
+        password: 'Password1!',
+        passwordConfirmation: 'Password1!',
+      });
+    });
+
+    expect(await screen.findByText('Check your email')).toBeInTheDocument();
+    expect(
+      screen.getByText(/We sent a confirmation email to/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Back to Sign In' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should show server error and clear it after form changes', async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockRejectedValueOnce(new Error('Email already in use'));
+
+    render(<RegisterForm />);
+
+    const emailInput = screen.getByPlaceholderText(/Your email address/i);
+
+    await user.type(emailInput, 'newuser@test.com');
+    await user.type(screen.getByPlaceholderText(/^Password$/i), 'Password1!');
+    await user.type(
+      screen.getByPlaceholderText(/Confirm password/i),
+      'Password1!',
+    );
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Sign Up' }));
+
+    expect(await screen.findByText('Email already in use')).toBeInTheDocument();
+
+    await user.type(emailInput, 'a');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Email already in use'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -1,20 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
 import { Checkbox, Input } from '@/components';
-import { AUTH_ROLES, MOCK_AUTH, ROUTES } from '@/constants';
-
-const getMockExpirationTime = () => {
-  return (Date.now() + 24 * 60 * 60 * 1000).toString();
-};
+import { ROUTES } from '@/constants';
+import { useRegister } from '@/hooks';
 
 const registerSchema = z
   .object({
     email: z.string().min(1, 'Email is required').email('Invalid email format'),
-    password: z.string().min(8, 'Password must be at least 8 characters'),
+    password: z
+      .string()
+      .min(
+        8,
+        'Password must be at least 8 characters, include uppercase, lowercase, number and symbol',
+      )
+      .regex(/[A-Z]/, 'Password must include at least one uppercase letter')
+      .regex(/[a-z]/, 'Password must include at least one lowercase letter')
+      .regex(/[0-9]/, 'Password must include at least one number')
+      .regex(
+        /[^A-Za-z0-9]/,
+        'Password must include at least one special character',
+      ),
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     terms: z.boolean().refine((val) => val === true, {
       message: 'You must agree to the Privacy Policy and Terms of Use',
@@ -28,12 +37,16 @@ const registerSchema = z
 type RegisterFormValues = z.infer<typeof registerSchema>;
 
 export const RegisterForm: React.FC = () => {
-  const navigate = useNavigate();
+  const { mutateAsync: registerMutation, isPending } = useRegister();
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
     control,
+    reset,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useForm<RegisterFormValues>({
     resolver: zodResolver(registerSchema),
@@ -45,106 +58,155 @@ export const RegisterForm: React.FC = () => {
     },
   });
 
-  const onSubmit = () => {
-    const expirationTime = getMockExpirationTime();
+  const onSubmit = async (data: RegisterFormValues) => {
+    try {
+      await registerMutation({
+        email: data.email,
+        password: data.password,
+        passwordConfirmation: data.confirmPassword,
+      });
 
-    localStorage.setItem(MOCK_AUTH.TOKEN_KEY, MOCK_AUTH.MOCK_TOKEN);
-    localStorage.setItem(MOCK_AUTH.EXPIRES_KEY, expirationTime);
-    localStorage.setItem(MOCK_AUTH.ROLE_KEY, AUTH_ROLES.CUSTOMER);
-
-    navigate(ROUTES.SHOP);
+      setRegisteredEmail(data.email);
+      reset();
+      clearErrors('root');
+    } catch (error) {
+      setError('root', {
+        type: 'server',
+        message:
+          error instanceof Error ? error.message : 'Failed to create account',
+      });
+    }
   };
 
   return (
     <div className="flex w-full max-w-md flex-col px-4 sm:px-6">
       <div className="mb-8">
-        <h2 className="text-4xl font-medium text-gray-900">Sign Up</h2>
-        <p className="mt-2 text-sm text-gray-500">
-          Already have an account?{' '}
-          <Link to={ROUTES.LOGIN} className="font-medium hover:opacity-80">
-            <span className="text-green-500">Sign In</span>
-          </Link>
-        </p>
+        <h2 className="text-text text-4xl font-medium">
+          {registeredEmail ? 'Check your email' : 'Sign Up'}
+        </h2>
+        {registeredEmail ? (
+          <p className="text-text mt-2 text-sm">
+            We sent a confirmation email to{' '}
+            <span className="text-text font-bold">{registeredEmail}</span>.
+            Please check your inbox to finish registration.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-gray-500">
+            Already have an account?{' '}
+            <Link to={ROUTES.LOGIN} className="font-medium hover:opacity-80">
+              <span className="text-green-500">Sign In</span>
+            </Link>
+          </p>
+        )}
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
-        <Input
-          {...register('email')}
-          type="email"
-          variant="underlined"
-          placeholder="Your email address"
-          state={errors.email ? 'error' : 'default'}
-          helperText={errors.email?.message}
-          className="pb-2"
-        />
-
-        <div className="relative">
-          <Input
-            {...register('password')}
-            type="password"
-            variant="underlined"
-            placeholder="Password"
-            state={errors.password ? 'error' : 'default'}
-            helperText={errors.password?.message}
-            className="pr-10 pb-2"
-          />
+      {registeredEmail ? (
+        <div className="space-y-6">
+          <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-4 text-sm text-green-800 dark:border-green-700 dark:bg-green-900 dark:text-green-300">
+            Your account was created successfully. A confirmation email has been
+            sent, so you can test the next step when you're ready.
+          </div>
+          <Link
+            to={ROUTES.LOGIN}
+            className="box-border inline-flex w-full items-center justify-center rounded-lg bg-[#1a1c23] px-4 py-3.5 text-center text-sm font-medium text-white! transition-colors focus:ring-4 focus:ring-gray-300 focus:outline-none"
+          >
+            Back to Sign In
+          </Link>
         </div>
-
-        <div className="relative">
-          <Input
-            {...register('confirmPassword')}
-            type="password"
-            variant="underlined"
-            placeholder="Confirm password"
-            state={errors.confirmPassword ? 'error' : 'default'}
-            helperText={errors.confirmPassword?.message}
-            className="pr-10 pb-2"
-          />
-        </div>
-
-        <div className="pt-2">
-          <Controller
-            control={control}
-            name="terms"
-            render={({ field }) => (
-              <Checkbox
-                label={
-                  <span className="text-sm text-gray-500">
-                    I agree with{' '}
-                    <a
-                      href="#"
-                      className="font-semibold text-gray-900 hover:underline"
-                    >
-                      Privacy Policy
-                    </a>{' '}
-                    and{' '}
-                    <a
-                      href="#"
-                      className="font-semibold text-gray-900 hover:underline"
-                    >
-                      Terms of Use
-                    </a>
-                  </span>
-                }
-                checked={field.value}
-                onCheckedChange={field.onChange}
-                state={errors.terms ? 'error' : 'default'}
-                checkboxClassName="h-5 w-5 rounded border-gray-300"
-              />
-            )}
-          />
-          {errors.terms && (
-            <p className="mt-1 text-sm text-red-500">{errors.terms.message}</p>
-          )}
-        </div>
-
-        <button
-          type="submit"
-          className="mt-6 w-full rounded-lg bg-[#1a1c23] px-4 py-3.5 text-center text-sm font-medium text-white transition-colors hover:bg-black focus:ring-4 focus:ring-gray-300 focus:outline-none"
+      ) : (
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          onChange={() => clearErrors('root')}
+          className="space-y-6"
+          noValidate
         >
-          Sign Up
-        </button>
-      </form>
+          <Input
+            {...register('email')}
+            type="email"
+            variant="underlined"
+            placeholder="Your email address"
+            state={errors.email ? 'error' : 'default'}
+            helperText={errors.email?.message}
+            className="pb-2"
+          />
+
+          <div className="relative">
+            <Input
+              {...register('password')}
+              type="password"
+              variant="underlined"
+              placeholder="Password"
+              state={errors.password ? 'error' : 'default'}
+              helperText={errors.password?.message}
+              className="pr-10 pb-2"
+            />
+          </div>
+
+          <div className="relative">
+            <Input
+              {...register('confirmPassword')}
+              type="password"
+              variant="underlined"
+              placeholder="Confirm password"
+              state={errors.confirmPassword ? 'error' : 'default'}
+              helperText={errors.confirmPassword?.message}
+              className="pr-10 pb-2"
+            />
+          </div>
+
+          <div className="pt-2">
+            <Controller
+              control={control}
+              name="terms"
+              render={({ field }) => (
+                <Checkbox
+                  label={
+                    <span className="text-sm text-gray-500">
+                      I agree with{' '}
+                      <a
+                        href="#"
+                        className="font-semibold text-gray-900 hover:underline"
+                      >
+                        Privacy Policy
+                      </a>{' '}
+                      and{' '}
+                      <a
+                        href="#"
+                        className="font-semibold text-gray-900 hover:underline"
+                      >
+                        Terms of Use
+                      </a>
+                    </span>
+                  }
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  state={errors.terms ? 'error' : 'default'}
+                  checkboxClassName="h-5 w-5 rounded border-gray-300"
+                />
+              )}
+            />
+            {errors.terms && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.terms.message}
+              </p>
+            )}
+          </div>
+
+          {errors.root && (
+            <p className="text-center text-sm font-medium text-red-500">
+              {errors.root.message}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="mt-6 w-full rounded-lg bg-[#1a1c23] px-4 py-3.5 text-center text-sm font-medium text-white transition-colors hover:bg-black focus:ring-4 focus:ring-gray-300 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isPending ? 'Creating account...' : 'Sign Up'}
+          </button>
+        </form>
+      )}
     </div>
   );
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   BLOG: '/blog',
   ADMIN_LOGIN: '/admin/login',
   REGISTER: '/register',
+  EMAIL_CONFIRMATION: '/email-confirmation',
   ADMIN_CATEGORY_ADD: '/admin/categories/add',
   ADMIN_CATEGORY_EDIT: '/admin/categories/edit/:id',
   ADMIN_ORDERS: '/admin/orders',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './useDeleteAdminCategory';
 export * from './useGetAdminCategory';
 export * from './useLocalStorage';
 export * from './useLogin';
+export * from './useRegister';
 export * from './useTheme';
 export * from './useUpdateAdminCategory';
 export * from './useUploadProductImage';

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { authService, type RegisterPayload } from '@/services/authService';
+
+export const useRegister = () => {
+  return useMutation({
+    mutationFn: (payload: RegisterPayload) => authService.register(payload),
+  });
+};

--- a/src/pages/Auth/EmailConfirmationPage.test.tsx
+++ b/src/pages/Auth/EmailConfirmationPage.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { render, screen } from '@/utils/test-utils';
+
+import { EmailConfirmationPage } from './EmailConfirmationPage';
+
+describe('Page: EmailConfirmationPage', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+  });
+
+  it('should render success confirmation state from query params', () => {
+    window.history.pushState(
+      {},
+      '',
+      '/email-confirmation?status=success&message=Email%20confirmed%20successfully',
+    );
+
+    render(<EmailConfirmationPage />);
+
+    expect(screen.getByText('Email confirmed')).toBeInTheDocument();
+    expect(
+      screen.getByText('Email confirmed successfully'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Your account is ready to use.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render error confirmation state from query params', () => {
+    window.history.pushState(
+      {},
+      '',
+      '/email-confirmation?status=error&message=Token%20expired',
+    );
+
+    render(<EmailConfirmationPage />);
+
+    expect(screen.getByText('Confirmation failed')).toBeInTheDocument();
+    expect(screen.getByText('Token expired')).toBeInTheDocument();
+    expect(
+      screen.getByText('The confirmation link may be invalid or expired.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Auth/EmailConfirmationPage.tsx
+++ b/src/pages/Auth/EmailConfirmationPage.tsx
@@ -1,0 +1,57 @@
+import { Link, useSearchParams } from 'react-router-dom';
+
+import { ROUTES } from '@/constants';
+
+const DEFAULT_ERROR_MESSAGE =
+  'We could not confirm your email. Please try the link again or request a new confirmation email later.';
+
+export const EmailConfirmationPage = () => {
+  const [searchParams] = useSearchParams();
+  const status = searchParams.get('status');
+  const message = searchParams.get('message');
+
+  const isSuccess = status === 'success';
+  const title = isSuccess ? 'Email confirmed' : 'Confirmation failed';
+  const description =
+    message ??
+    (isSuccess
+      ? 'Your email has been confirmed successfully. You can sign in now.'
+      : DEFAULT_ERROR_MESSAGE);
+
+  return (
+    <div className="flex w-full max-w-md flex-col px-4 sm:px-6">
+      <div className="mb-8">
+        <h2 className="text-text text-4xl font-medium">{title}</h2>
+        <p className="text-text mt-2 text-sm">{description}</p>
+      </div>
+
+      <div
+        className={`rounded-lg border px-4 py-4 text-sm ${
+          isSuccess
+            ? 'border-green-200 bg-green-50 text-green-800 dark:border-green-700 dark:bg-green-900 dark:text-green-300'
+            : 'border-red-200 bg-red-50 text-red-800 dark:border-red-700 dark:bg-red-900 dark:text-red-300'
+        }`}
+      >
+        {isSuccess
+          ? 'Your account is ready to use.'
+          : 'The confirmation link may be invalid or expired.'}
+      </div>
+
+      <div className="mt-6 space-y-3">
+        <Link
+          to={ROUTES.LOGIN}
+          className="box-border inline-flex w-full items-center justify-center rounded-lg bg-[#1a1c23] px-4 py-3.5 text-center text-sm font-medium text-white! transition-colors focus:ring-4 focus:ring-gray-300 focus:outline-none"
+        >
+          Go to Sign In
+        </Link>
+
+        <Link
+          to={ROUTES.REGISTER}
+          className="box-border inline-flex w-full items-center justify-center rounded-lg border border-gray-300 px-4 py-3.5 text-center text-sm font-medium text-gray-900 transition-colors focus:ring-4 focus:ring-gray-300 focus:outline-none"
+        >
+          Back to Sign Up
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/src/services/authService.test.tsx
+++ b/src/services/authService.test.tsx
@@ -8,7 +8,11 @@ import {
   vi,
 } from 'vitest';
 
-import { authService, type LoginPayload } from './authService';
+import {
+  authService,
+  type LoginPayload,
+  type RegisterPayload,
+} from './authService';
 
 global.fetch = vi.fn();
 
@@ -67,6 +71,49 @@ describe('Service: authService', () => {
       // Check that the service threw our custom error
       await expect(authService.login(mockCredentials)).rejects.toThrow(
         'Invalid email or password',
+      );
+    });
+  });
+
+  describe('register()', () => {
+    const mockPayload: RegisterPayload = {
+      email: 'newuser@test.com',
+      password: 'Password1!',
+      passwordConfirmation: 'Password1!',
+    };
+
+    it('should send correct POST request and return data on success', async () => {
+      const mockResponseData = {
+        status: 'success',
+        message: 'User created successfully.',
+      };
+
+      (global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponseData,
+      });
+
+      const result = await authService.register(mockPayload);
+
+      expect(global.fetch).toHaveBeenCalledWith(`${API_URL}/auth/register`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(mockPayload),
+        credentials: 'include',
+      });
+      expect(result).toEqual(mockResponseData);
+    });
+
+    it('should throw backend error message on failed registration', async () => {
+      (global.fetch as Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ message: 'Email already in use' }),
+      });
+
+      await expect(authService.register(mockPayload)).rejects.toThrow(
+        'Email already in use',
       );
     });
   });

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -5,7 +5,38 @@ export interface LoginPayload {
   password: string;
 }
 
+export interface RegisterPayload {
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+export interface RegisterResponse {
+  status: string;
+  message: string;
+}
+
 const API_URL = API_BASE_URL;
+
+const getErrorMessage = async (response: Response, fallbackMessage: string) => {
+  try {
+    const errorData = (await response.json()) as {
+      message?: string | string[];
+    };
+
+    if (Array.isArray(errorData.message)) {
+      return errorData.message[0] ?? fallbackMessage;
+    }
+
+    if (typeof errorData.message === 'string') {
+      return errorData.message;
+    }
+  } catch {
+    return fallbackMessage;
+  }
+
+  return fallbackMessage;
+};
 
 export const authService = {
   login: async (data: LoginPayload) => {
@@ -20,6 +51,25 @@ export const authService = {
 
     if (!response.ok) {
       throw new Error('Invalid email or password');
+    }
+
+    return response.json();
+  },
+
+  register: async (data: RegisterPayload): Promise<RegisterResponse> => {
+    const response = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        await getErrorMessage(response, 'Failed to create account'),
+      );
     }
 
     return response.json();


### PR DESCRIPTION
Сonnect registration with backend and add confirmation page

### Short description:
- connect the registration form to the backend `/auth/register` endpoint
- remove mock registration logic from the frontend
- show a success state after sign up and tell the user to check email
- add a frontend email confirmation result page for success and error redirects
- add tests for the new registration and confirmation flow