### PR TITLE
fix(276): fix shop product category filtering

### DIFF
--- a/src/components/Dropdown/CategoryDropdown.tsx
+++ b/src/components/Dropdown/CategoryDropdown.tsx
@@ -17,6 +17,7 @@ export const CategoryDropdown = ({
   placeholder = 'Select options',
   hasBorder = true,
   multiple = true,
+  disabled = false,
 }: DropdownProps) => {
   const selectedOptions = selectedValues
     ? options.filter((option) => selectedValues.includes(option.value))
@@ -54,13 +55,11 @@ export const CategoryDropdown = ({
   return (
     <Field.Root className={styles.Field}>
       <Field.Label
-        className={
-          styles.Label +
-          clsx(
-            'cursor-default text-xs font-medium text-(--color-text) uppercase',
-            labelClassName,
-          )
-        }
+        className={clsx(
+          styles.Label,
+          'cursor-default text-xs font-medium text-(--color-text) uppercase',
+          labelClassName,
+        )}
         nativeLabel={false}
         render={<div />}
       >
@@ -70,10 +69,12 @@ export const CategoryDropdown = ({
         multiple={multiple}
         onValueChange={handleValueChange}
         value={value}
+        disabled={disabled}
       >
         <Select.Trigger
-          className={styles.Select + clsx(selectClassName)}
+          className={clsx(styles.Select, selectClassName)}
           data-border={hasBorder}
+          data-disabled={disabled || undefined}
         >
           <Select.Value className="hidden" />
           <span className="truncate">{content}</span>

--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -1,6 +1,7 @@
 .Field {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 8px;
 }
 
@@ -10,6 +11,11 @@
   cursor: default;
   text-transform: uppercase;
   font-size: 0.75rem;
+}
+
+.Value {
+  flex: 1 1 auto;
+  text-align: left;
 }
 
 .Value[data-placeholder] {
@@ -50,6 +56,11 @@
     background-color: var(--color-text);
   }
 
+  &[data-disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
   &:focus-visible {
     outline: 2px solid var(--color-blue);
     outline-offset: -1px;
@@ -58,6 +69,9 @@
 
 .SelectIcon {
   display: flex;
+  align-self: center;
+  justify-self: end;
+  flex: 0 0 auto;
 }
 
 .Positioner {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -17,6 +17,7 @@ export const Dropdown = ({
   placeholder = 'Select options',
   hasBorder = true,
   multiple = true,
+  disabled = false,
 }: DropdownProps) => {
   const selectedOptions = selectedValues
     ? options.filter((option) => selectedValues.includes(option.value))
@@ -48,13 +49,11 @@ export const Dropdown = ({
   return (
     <Field.Root className={styles.Field}>
       <Field.Label
-        className={
-          styles.Label +
-          clsx(
-            'cursor-default text-xs font-medium text-(--color-text) uppercase',
-            labelClassName,
-          )
-        }
+        className={clsx(
+          styles.Label,
+          'cursor-default text-xs font-medium text-(--color-text) uppercase',
+          labelClassName,
+        )}
         nativeLabel={false}
         render={<div />}
       >
@@ -66,10 +65,12 @@ export const Dropdown = ({
         onValueChange={handleValueChange}
         value={value}
         items={options}
+        disabled={disabled}
       >
         <Select.Trigger
-          className={styles.Select + clsx(selectClassName)}
+          className={clsx(styles.Select, selectClassName)}
           data-border={hasBorder}
+          data-disabled={disabled || undefined}
         >
           <Select.Value className={styles.Value} placeholder={placeholder} />
 

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -13,4 +13,5 @@ export interface DropdownProps {
   placeholder?: string;
   hasBorder?: boolean;
   multiple?: boolean;
+  disabled?: boolean;
 }

--- a/src/components/ShopFilters/ShopFilters.test.tsx
+++ b/src/components/ShopFilters/ShopFilters.test.tsx
@@ -1,0 +1,90 @@
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useShopCategoriesMock = vi.fn();
+
+vi.mock('@/hooks/useShopCategories', () => ({
+  useShopCategories: () => useShopCategoriesMock(),
+}));
+
+vi.mock('@/components/Dropdown', () => ({
+  CategoryDropdown: ({
+    placeholder,
+    disabled,
+    onChange,
+    options,
+    selectedValues,
+  }: {
+    placeholder: string;
+    disabled?: boolean;
+    onChange: (values: { label: string; value: string }[]) => void;
+    options: { label: string; value: string }[];
+    selectedValues?: string[];
+  }) => (
+    <div>
+      <div data-testid="category-placeholder">{placeholder}</div>
+      <div data-testid="category-disabled">{String(Boolean(disabled))}</div>
+      <div data-testid="category-selected">{selectedValues?.join(',') ?? ''}</div>
+      <button type="button" onClick={() => onChange(options.slice(0, 2))}>
+        Select categories
+      </button>
+    </div>
+  ),
+  Dropdown: () => <div data-testid="price-dropdown" />,
+}));
+
+import { ShopFilters } from './ShopFilters';
+
+const LocationDisplay = () => {
+  const location = useLocation();
+
+  return <div data-testid="location-search">{location.search}</div>;
+};
+
+describe('ShopFilters', () => {
+  it('shows a disabled loading state while categories are loading', () => {
+    useShopCategoriesMock.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/shop']}>
+        <ShopFilters />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('category-placeholder')).toHaveTextContent(
+      'Loading categories...',
+    );
+    expect(screen.getByTestId('category-disabled')).toHaveTextContent('true');
+  });
+
+  it('writes repeated category params when category selection changes', () => {
+    useShopCategoriesMock.mockReturnValue({
+      data: [
+        { id: 'cat-1', title: 'Phones' },
+        { id: 'cat-2', title: 'Tablets' },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/shop']}>
+        <ShopFilters />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /select categories/i }));
+
+    const search = screen.getByTestId('location-search').textContent ?? '';
+
+    expect(search).toContain('category=cat-1');
+    expect(search).toContain('category=cat-2');
+    expect(search).toContain('page=1');
+  });
+});

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 
 import { CategoryDropdown, Dropdown } from '@/components/Dropdown';
-import { useAdminCategories } from '@/hooks/useAdminCategories';
+import { useShopCategories } from '@/hooks/useShopCategories';
 
 const PRICE_OPTIONS = [
   { label: 'Under $500', value: '0-500' },
@@ -10,35 +10,72 @@ const PRICE_OPTIONS = [
   { label: 'Over $2000', value: '2000+' },
 ];
 
+const getSelectedCategories = (searchParams: URLSearchParams) => {
+  const categories = searchParams
+    .getAll('category')
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (categories.length) {
+    return categories;
+  }
+
+  const legacyCategory = searchParams.get('category');
+
+  return legacyCategory
+    ? legacyCategory
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+    : [];
+};
+
 export function ShopFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { categories } = useAdminCategories();
+  const {
+    data: categories = [],
+    isLoading,
+    isError,
+  } = useShopCategories();
 
   const categoryOptions = categories.map((c) => ({
     label: c.title,
     value: String(c.id),
   }));
 
-  const currentCategory = searchParams.get('category')?.split(',') || [];
-  const categoryLabel = currentCategory.length
-    ? currentCategory
-        .map((v) => categoryOptions.find((o) => o.value === v)?.label)
-        .filter(Boolean)
-        .join(', ')
-    : 'All Electronics';
+  const currentCategory = getSelectedCategories(searchParams);
+  const isCategoryDisabled =
+    isLoading || isError || categoryOptions.length === 0;
+  const categoryPlaceholder = isLoading
+    ? 'Loading categories...'
+    : isError
+      ? 'Failed to load categories'
+      : categoryOptions.length === 0
+        ? 'No categories available'
+        : 'All Electronics';
+  const selectedCategoryLabels = currentCategory
+    .map((v) => categoryOptions.find((o) => o.value === v)?.label)
+    .filter(Boolean)
+    .join(', ');
+  const categoryLabel = selectedCategoryLabels || categoryPlaceholder;
+
   const handleCategoryChange = (values: { value: string }[]) => {
     const filtered = values.map((v) => v.value).filter(Boolean);
 
     setSearchParams((prev) => {
-      if (filtered.length) {
-        prev.set('category', filtered.join(','));
-      } else {
-        prev.delete('category');
-      }
-      prev.set('page', '1');
-      return prev;
+      const next = new URLSearchParams(prev);
+
+      next.delete('category');
+      filtered.forEach((value) => {
+        next.append('category', value);
+      });
+      next.set('page', '1');
+
+      return next;
     });
   };
+
   const currentPriceValue =
     searchParams.get('minPrice') && searchParams.get('maxPrice')
       ? `${searchParams.get('minPrice')}-${searchParams.get('maxPrice')}`
@@ -79,6 +116,7 @@ export function ShopFilters() {
         onChange={handleCategoryChange}
         placeholder={categoryLabel}
         selectedValues={currentCategory}
+        disabled={isCategoryDisabled}
       />
       <Dropdown
         label="Price"

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -7,7 +7,7 @@ export const useProducts = (
   limit: number,
   sort?: 'price' | 'title' | 'createdAt',
   search?: string,
-  category?: string,
+  category?: string[],
   minPrice?: string,
   maxPrice?: string,
 ) => {

--- a/src/hooks/useShopCategories.ts
+++ b/src/hooks/useShopCategories.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { categoryService } from '@/services/categoryService';
+
+export function useShopCategories() {
+  return useQuery({
+    queryKey: ['shop-categories'],
+    queryFn: () => categoryService.getPublicCategories(),
+  });
+}

--- a/src/pages/Products/Products.tsx
+++ b/src/pages/Products/Products.tsx
@@ -30,7 +30,11 @@ export const Products = () => {
   const defaultLimit = viewType === 'grid-5' ? 15 : 12;
   const limit = Number(searchParams.get('limit')) || defaultLimit;
   const sort = (searchParams.get('sort') as 'title' | 'price') || 'title';
-  const category = searchParams.get('category') || '';
+  const category = searchParams
+    .getAll('category')
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
   const minPrice = searchParams.get('minPrice') || '';
   const maxPrice = searchParams.get('maxPrice') || '';
   const search = searchParams.get('search') || undefined;

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -75,6 +75,36 @@ describe('service: apiClient', () => {
     );
   });
 
+  it('serializes array query params as repeated search params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], totalPages: 1 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    global.fetch = fetchMock as typeof fetch;
+
+    await apiClient.get('/products', {
+      params: {
+        page: 1,
+        limit: 12,
+        category: ['cat-1', 'cat-2'],
+      },
+    });
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0][0]));
+
+    expect(requestUrl.searchParams.getAll('category')).toEqual([
+      'cat-1',
+      'cat-2',
+    ]);
+    expect(requestUrl.searchParams.get('page')).toBe('1');
+    expect(requestUrl.searchParams.get('limit')).toBe('12');
+  });
+
   it('clears local auth markers when refresh fails after a 401 response', async () => {
     const fetchMock = vi
       .fn()

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,10 @@
 import { API_BASE_URL, MOCK_AUTH } from '../constants';
 
 interface FetchOptions extends RequestInit {
-  params?: Record<string, string | number | boolean | undefined>;
+  params?: Record<
+    string,
+    string | number | boolean | Array<string | number | boolean> | undefined
+  >;
 }
 
 let refreshPromise: Promise<boolean> | null = null;
@@ -15,6 +18,13 @@ const buildUrl = (
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined && value !== null) {
+        if (Array.isArray(value)) {
+          value.forEach((item) => {
+            url.searchParams.append(key, String(item));
+          });
+          return;
+        }
+
         url.searchParams.append(key, String(value));
       }
     });

--- a/src/services/categoryService.test.ts
+++ b/src/services/categoryService.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from './api';
+import { categoryService } from './categoryService';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+describe('service: categoryService', () => {
+  it('maps public category response ids to client category ids', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue([
+      {
+        _id: 'cat-1',
+        title: 'Phones',
+        imageUrl: null,
+        description: 'Mobile devices',
+        parent: null,
+        depth: 1,
+        createdAt: '2026-03-20T10:00:00.000Z',
+        updatedAt: '2026-03-20T10:00:00.000Z',
+      },
+    ]);
+
+    const categories = await categoryService.getPublicCategories();
+
+    expect(categories).toEqual([
+      {
+        id: 'cat-1',
+        title: 'Phones',
+        imageUrl: null,
+        description: 'Mobile devices',
+        parent: null,
+        depth: 1,
+        createdAt: '2026-03-20T10:00:00.000Z',
+        updatedAt: '2026-03-20T10:00:00.000Z',
+      },
+    ]);
+  });
+});

--- a/src/services/categoryService.ts
+++ b/src/services/categoryService.ts
@@ -1,0 +1,35 @@
+import type { Category } from '@/types';
+
+import { apiClient } from './api';
+
+interface PublicCategoryResponse {
+  _id: string;
+  title: string;
+  imageUrl?: string | null;
+  description?: string | null;
+  parent?: string | null;
+  depth: 1 | 2;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const mapPublicCategory = (
+  category: PublicCategoryResponse,
+): Category => ({
+  id: category._id,
+  title: category.title,
+  imageUrl: category.imageUrl ?? null,
+  description: category.description ?? null,
+  parent: category.parent ?? null,
+  depth: category.depth,
+  createdAt: category.createdAt,
+  updatedAt: category.updatedAt,
+});
+
+export const categoryService = {
+  async getPublicCategories(): Promise<Category[]> {
+    const response = await apiClient.get<PublicCategoryResponse[]>('/category');
+
+    return response.map(mapPublicCategory);
+  },
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 export { apiClient } from './api';
 export { authService } from './authService';
+export { categoryService } from './categoryService';
 export {
   CREATE_CATEGORY,
   DELETE_CATEGORY,

--- a/src/services/productService.test.ts
+++ b/src/services/productService.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./api', () => ({
+  apiClient: {
+    get: vi.fn().mockResolvedValue({ items: [], totalPages: 0 }),
+  },
+}));
+
+import { apiClient } from './api';
+import { productService } from './productService';
+
+describe('service: productService', () => {
+  it('omits blank price filters from shop requests', async () => {
+    await productService.getAll(
+      1,
+      15,
+      'title',
+      undefined,
+      ['cat-1'],
+      '',
+      '   ',
+    );
+
+    expect(apiClient.get).toHaveBeenCalledWith('/products', {
+      params: {
+        page: 1,
+        limit: 15,
+        sort: 'title',
+        search: undefined,
+        category: ['cat-1'],
+        minPrice: undefined,
+        maxPrice: undefined,
+      },
+    });
+  });
+});

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -6,21 +6,32 @@ export interface PaginatedResponse<T> {
   totalPages: number;
 }
 
+const normalizePriceParam = (value?: string) => {
+  const trimmedValue = value?.trim();
+  return trimmedValue ? trimmedValue : undefined;
+};
+
 export const productService = {
   getAll: (
     page: number,
     limit: number,
     sort?: 'price' | 'title' | 'createdAt',
     search?: string,
-    category?: string,
+    category?: string[],
     minPrice?: string,
     maxPrice?: string,
   ): Promise<PaginatedResponse<Product>> =>
-    apiClient
-      .get<
-        PaginatedResponse<Product>
-      >(`/products?page=${page}&limit=${limit}${sort ? `&sort=${sort}` : ''}${search ? `&search=${search}` : ''}${category ? `&category=${category}` : ''}${minPrice ? `&minPrice=${minPrice}` : ''}${maxPrice ? `&maxPrice=${maxPrice}` : ''}`)
-      .then((res) => res),
+    apiClient.get<PaginatedResponse<Product>>('/products', {
+      params: {
+        page,
+        limit,
+        sort,
+        search,
+        category: category?.length ? category : undefined,
+        minPrice: normalizePriceParam(minPrice),
+        maxPrice: normalizePriceParam(maxPrice),
+      },
+    }),
   getById: async (id: string): Promise<Product> => {
     const response = await apiClient.get<Product>(`/products/${id}`);
     return response;


### PR DESCRIPTION
## Summary

- Switch category source from admin GraphQL to public REST `GET /category`
- Send repeated `category=` query params instead of comma-joined single param
- Fix `apiClient` to serialize array query params as repeated params
- Add loading/error/empty/disabled states to category dropdown
- Fix Dropdown component class composition and add `disabled` prop support

## Related issues

Closes UA-5399-React/docs#276

## Test plan

- [ ] `pnpm run lint` passes
- [ ] `pnpm run build` passes
- [ ] `pnpm run test` passes
- [ ] Shop page: selecting a category (Laptop, Smartphone, etc.) shows matching products
- [ ] Shop page: selecting multiple categories + price filter works together
- [ ] Category dropdown shows loading state while fetching