### PR TITLE
feat(294): add dark theme support to user profile

### DIFF
--- a/src/components/UserProfile/AccountDetailsForm/AccountDetailsForm.tsx
+++ b/src/components/UserProfile/AccountDetailsForm/AccountDetailsForm.tsx
@@ -19,7 +19,7 @@ export function AccountDetailsForm({
 }: AccountDetailsFormProps) {
   return (
     <section>
-      <h2 className="mt-0 mb-6 text-[20px] font-semibold text-[rgb(var(--color-neutral-900))]">
+      <h2 className="text-text mt-0 mb-6 text-[20px] font-semibold">
         Account Details
       </h2>
 
@@ -37,7 +37,7 @@ export function AccountDetailsForm({
           )}
         />
         {errors.firstName?.message ? (
-          <p className="text-sm text-[rgb(var(--color-red-600))]">
+          <p className="text-sm text-red-600">
             {String(errors.firstName.message)}
           </p>
         ) : null}
@@ -55,7 +55,7 @@ export function AccountDetailsForm({
           )}
         />
         {errors.lastName?.message ? (
-          <p className="text-sm text-[rgb(var(--color-red-600))]">
+          <p className="text-sm text-red-600">
             {String(errors.lastName.message)}
           </p>
         ) : null}

--- a/src/components/UserProfile/AccountInput/AccountInput.tsx
+++ b/src/components/UserProfile/AccountInput/AccountInput.tsx
@@ -34,7 +34,7 @@ export function AccountInput({
     <div className="flex flex-col gap-3">
       <label
         htmlFor={inputId}
-        className="text-[12px] font-bold text-[rgb(var(--color-gray-600))] uppercase"
+        className="text-muted text-[12px] font-bold uppercase"
       >
         {label}
       </label>
@@ -49,7 +49,7 @@ export function AccountInput({
           disabled={disabled}
           autoComplete={autoComplete}
           onChange={(e) => onChange?.(e.target.value)}
-          className="h-[40px] w-full rounded-md border border-[rgb(var(--color-gray-300))] pl-4 text-sm text-[rgb(var(--color-neutral-900))] transition outline-none focus:border-[rgb(var(--color-neutral-900))] disabled:bg-[rgb(var(--color-neutral-600))]"
+          className="border-fieldBorder bg-background text-text placeholder:text-placeholderText focus:border-text disabled:bg-backgroundSec disabled:text-muted h-[40px] w-full rounded-md border px-4 text-sm transition outline-none"
         />
 
         {isPasswordField && (
@@ -58,7 +58,7 @@ export function AccountInput({
             onClick={() => setShowPassword((prev) => !prev)}
             aria-label={showPassword ? 'Hide password' : 'Show password'}
             aria-pressed={showPassword}
-            className="absolute inset-y-0 right-1 flex items-center border-none bg-transparent text-[rgb(var(--color-gray-600))]"
+            className="text-muted absolute inset-y-0 right-1 flex items-center border-none bg-transparent"
           >
             {showPassword ? <Eye size={18} /> : <EyeOff size={18} />}
           </button>

--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
@@ -152,8 +152,11 @@ describe('AccountSidebar', () => {
     const accountLink = screen.getByRole('link', { name: 'Account' });
     const ordersLink = screen.getByRole('link', { name: 'Orders' });
 
-    expect(accountLink.className).toContain('text-neutral-0');
+    expect(accountLink.className).toContain('text-text');
+    expect(accountLink.className).toContain('border-text');
+
     expect(ordersLink.className).toContain('border-transparent');
+    expect(ordersLink.className).toContain('text-muted');
   });
 
   it('marks orders link as active on /my-orders route', () => {
@@ -162,7 +165,10 @@ describe('AccountSidebar', () => {
     const accountLink = screen.getByRole('link', { name: 'Account' });
     const ordersLink = screen.getByRole('link', { name: 'Orders' });
 
-    expect(ordersLink.className).toContain('text-neutral-0');
+    expect(ordersLink.className).toContain('text-text');
+    expect(ordersLink.className).toContain('border-text');
+
     expect(accountLink.className).toContain('border-transparent');
+    expect(accountLink.className).toContain('text-muted');
   });
 });

--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.test.tsx
@@ -6,40 +6,55 @@ import { ROUTES } from '@/constants';
 
 import { AccountSidebar } from './AccountSidebar';
 
+const mockUser = {
+  id: '1',
+  email: 'user@test.com',
+  firstName: 'Genadiy',
+  lastName: 'Pascal',
+  avatarUrl: 'https://example.com/avatar.jpg',
+  role: 'USER',
+  isActive: true,
+  isEmailConfirmed: true,
+};
+
+const userWithoutName = {
+  id: '2',
+  email: 'empty@test.com',
+  firstName: '',
+  lastName: '',
+  avatarUrl: '',
+  role: 'USER',
+  isActive: true,
+  isEmailConfirmed: true,
+};
+
+function renderComponent(
+  props?: Partial<React.ComponentProps<typeof AccountSidebar>>,
+  initialEntries: string[] = ['/profile'],
+) {
+  const defaultProps: React.ComponentProps<typeof AccountSidebar> = {
+    user: mockUser,
+    onLogout: vi.fn(),
+    onAvatarClick: vi.fn(),
+    isAvatarUploading: false,
+  };
+
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AccountSidebar {...defaultProps} {...props} />
+    </MemoryRouter>,
+  );
+}
+
 describe('AccountSidebar', () => {
-  const mockUser = {
-    firstName: 'Anna',
-    lastName: 'Smith',
-    email: 'anna@example.com',
-    avatarUrl: 'https://example.com/avatar.jpg',
-  };
-
-  const renderComponent = (
-    props?: Partial<React.ComponentProps<typeof AccountSidebar>>,
-    initialEntries: string[] = [ROUTES.PROFILE],
-  ) => {
-    return render(
-      <MemoryRouter initialEntries={initialEntries}>
-        <AccountSidebar
-          user={mockUser as never}
-          onAvatarClick={vi.fn()}
-          onLogout={vi.fn()}
-          {...props}
-        />
-      </MemoryRouter>,
-    );
-  };
-
   it('renders user full name', () => {
     renderComponent();
 
-    expect(screen.getByText('Anna Smith')).toBeInTheDocument();
+    expect(screen.getByText('Genadiy Pascal')).toBeInTheDocument();
   });
 
-  it('renders fallback name "User" when first and last name are missing', () => {
-    renderComponent({
-      user: { ...mockUser, firstName: '', lastName: '' } as never,
-    });
+  it('renders fallback name when first and last name are empty', () => {
+    renderComponent({ user: userWithoutName });
 
     expect(screen.getByText('User')).toBeInTheDocument();
   });
@@ -49,38 +64,28 @@ describe('AccountSidebar', () => {
 
     const avatar = screen.getByAltText('avatar');
     expect(avatar).toBeInTheDocument();
-    expect(avatar).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+    expect(avatar).toHaveAttribute('src', mockUser.avatarUrl);
   });
 
-  it('does not render avatar image when avatarUrl is missing', () => {
+  it('renders fallback avatar when avatarUrl does not exist', () => {
     renderComponent({
-      user: { ...mockUser, avatarUrl: '' } as never,
+      user: {
+        ...mockUser,
+        avatarUrl: '',
+      },
     });
 
     expect(screen.queryByAltText('avatar')).not.toBeInTheDocument();
-  });
-
-  it('renders avatar placeholder when avatarUrl is missing', () => {
-    const { container } = renderComponent({
-      user: { ...mockUser, avatarUrl: '' } as never,
-    });
-
-    expect(screen.queryByAltText('avatar')).not.toBeInTheDocument();
-
-    const placeholder = container.querySelector(
-      '.bg-\\[rgb\\(var\\(--color-gray-200\\)\\)\\]',
-    );
-    expect(placeholder).toBeInTheDocument();
   });
 
   it('calls onAvatarClick when file is selected', () => {
     const onAvatarClick = vi.fn();
+    renderComponent({ onAvatarClick });
 
-    const { container } = renderComponent({ onAvatarClick });
-
-    const input = container.querySelector(
+    const input = document.querySelector(
       'input[type="file"]',
     ) as HTMLInputElement;
+
     const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
 
     fireEvent.change(input, {
@@ -91,9 +96,34 @@ describe('AccountSidebar', () => {
     expect(onAvatarClick).toHaveBeenCalledWith(file);
   });
 
+  it('does not call onAvatarClick when no file is selected', () => {
+    const onAvatarClick = vi.fn();
+    renderComponent({ onAvatarClick });
+
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: { files: [] },
+    });
+
+    expect(onAvatarClick).not.toHaveBeenCalled();
+  });
+
+  it('disables avatar upload button when isAvatarUploading is true', () => {
+    renderComponent({ isAvatarUploading: true });
+
+    const buttons = screen.getAllByRole('button');
+    const uploadButton = buttons.find(
+      (button) => button !== screen.getByText('Log Out'),
+    );
+
+    expect(uploadButton).toBeDisabled();
+  });
+
   it('calls onLogout when logout button is clicked', () => {
     const onLogout = vi.fn();
-
     renderComponent({ onLogout });
 
     fireEvent.click(screen.getByRole('button', { name: /log out/i }));
@@ -101,35 +131,38 @@ describe('AccountSidebar', () => {
     expect(onLogout).toHaveBeenCalledTimes(1);
   });
 
-  it('renders account navigation link with correct href', () => {
+  it('renders navigation links', () => {
     renderComponent();
 
-    const accountLink = screen.getByRole('link', { name: /account/i });
-    expect(accountLink).toBeInTheDocument();
-    expect(accountLink).toHaveAttribute('href', ROUTES.PROFILE);
+    expect(screen.getByRole('link', { name: 'Account' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Orders' })).toBeInTheDocument();
   });
 
-  it('renders disabled items Orders and Wishlist', () => {
+  it('renders wishlist as disabled text item', () => {
     renderComponent();
 
-    const ordersLink = screen.getByRole('link', { name: /orders/i });
-    expect(ordersLink).toBeInTheDocument();
-    expect(ordersLink).toHaveAttribute('href', ROUTES.MYORDERS);
-
-    expect(screen.getByText('Wishlist')).toBeInTheDocument();
+    const wishlist = screen.getByText('Wishlist');
+    expect(wishlist).toBeInTheDocument();
+    expect(wishlist).toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('applies active class to account link when route is profile', () => {
-    renderComponent({}, [ROUTES.PROFILE]);
+  it('marks account link as active on /profile route', () => {
+    renderComponent(undefined, ['/profile']);
 
-    const accountLink = screen.getByRole('link', { name: /account/i });
-    expect(accountLink.className).toContain('text-black');
+    const accountLink = screen.getByRole('link', { name: 'Account' });
+    const ordersLink = screen.getByRole('link', { name: 'Orders' });
+
+    expect(accountLink.className).toContain('text-neutral-0');
+    expect(ordersLink.className).toContain('border-transparent');
   });
 
-  it('does not apply active class to account link when route is not profile', () => {
-    renderComponent({}, ['/some-other-route']);
+  it('marks orders link as active on /my-orders route', () => {
+    renderComponent(undefined, [ROUTES.MYORDERS]);
 
-    const accountLink = screen.getByRole('link', { name: /account/i });
+    const accountLink = screen.getByRole('link', { name: 'Account' });
+    const ordersLink = screen.getByRole('link', { name: 'Orders' });
+
+    expect(ordersLink.className).toContain('text-neutral-0');
     expect(accountLink.className).toContain('border-transparent');
   });
 });

--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
@@ -6,13 +6,8 @@ import { ROUTES } from '@/constants';
 import type { User } from '@/types/user';
 
 const SIDEBAR_LINKS = [
-  {
-    to: ROUTES.PROFILE,
-    end: true,
-    label: 'Account',
-    liClassName: 'text-black',
-  },
-  { to: ROUTES.MYORDERS, label: 'Orders', liClassName: 'text-black' },
+  { to: ROUTES.PROFILE, end: true, label: 'Account' },
+  { to: ROUTES.MYORDERS, label: 'Orders' },
 ] as const;
 
 type AccountSidebarProps = {
@@ -51,18 +46,18 @@ export function AccountSidebar({
     'block w-full border-b pb-2 text-[16px] font-semibold transition';
 
   return (
-    <aside className="w-full max-w-[220px] rounded-md bg-gray-100 px-4 py-10">
+    <aside className="border-fieldBorder bg-backgroundSec w-full max-w-[220px] rounded-md border px-4 py-10">
       <div className="flex flex-col items-center">
         <div className="relative h-[82px] w-[82px]">
           {user.avatarUrl ? (
             <img
               src={user.avatarUrl}
               alt="avatar"
-              className="h-full w-full rounded-full object-cover"
+              className="border-fieldBorder h-full w-full rounded-full border object-cover"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center rounded-full bg-gray-200">
-              <UserIcon size={32} className="text-gray-600" />
+            <div className="border-fieldBorder bg-background flex h-full w-full items-center justify-center rounded-full border">
+              <UserIcon size={32} className="text-muted" />
             </div>
           )}
 
@@ -84,23 +79,23 @@ export function AccountSidebar({
           />
         </div>
 
-        <h3 className="mt-3 mb-0 text-[20px] leading-none font-semibold text-neutral-900">
+        <h3 className="text-text mt-3 mb-0 text-center text-[20px] leading-none font-semibold">
           {displayName}
         </h3>
       </div>
 
       <nav className="mt-10">
         <ul className="flex list-none flex-col gap-3 pl-0 text-[16px] font-semibold">
-          {SIDEBAR_LINKS.map(({ to, label, liClassName }) => (
-            <li key={to} className={liClassName}>
+          {SIDEBAR_LINKS.map(({ to, label }) => (
+            <li key={to}>
               <NavLink
                 to={to}
                 end={to === ROUTES.PROFILE}
                 className={({ isActive }) =>
                   `${navItemClass} ${
                     isActive
-                      ? 'text-neutral-0 border-neutral-800'
-                      : 'border-transparent text-neutral-600 hover:text-neutral-900'
+                      ? 'text-text border-text'
+                      : 'text-muted hover:text-text border-transparent'
                   }`
                 }
               >
@@ -122,7 +117,7 @@ export function AccountSidebar({
             <button
               type="button"
               onClick={onLogout}
-              className="block w-full cursor-pointer appearance-none border-b border-transparent bg-transparent p-0 pb-2 text-left text-[15px] leading-none font-semibold text-neutral-800 transition hover:text-neutral-900"
+              className="text-text block w-full cursor-pointer appearance-none border-b border-transparent bg-transparent p-0 pb-2 text-left text-[15px] leading-none font-semibold transition hover:text-red-600"
             >
               Log Out
             </button>

--- a/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
+++ b/src/components/UserProfile/AccountSidebar/AccountSidebar.tsx
@@ -5,6 +5,16 @@ import { Camera, User as UserIcon } from 'lucide-react';
 import { ROUTES } from '@/constants';
 import type { User } from '@/types/user';
 
+const SIDEBAR_LINKS = [
+  {
+    to: ROUTES.PROFILE,
+    end: true,
+    label: 'Account',
+    liClassName: 'text-black',
+  },
+  { to: ROUTES.MYORDERS, label: 'Orders', liClassName: 'text-black' },
+] as const;
+
 type AccountSidebarProps = {
   user: User;
   onAvatarClick?: (file: File) => void;
@@ -41,7 +51,7 @@ export function AccountSidebar({
     'block w-full border-b pb-2 text-[16px] font-semibold transition';
 
   return (
-    <aside className="w-full max-w-[220px] rounded-md bg-[rgb(var(--color-gray-100))] px-4 py-10">
+    <aside className="w-full max-w-[220px] rounded-md bg-gray-100 px-4 py-10">
       <div className="flex flex-col items-center">
         <div className="relative h-[82px] w-[82px]">
           {user.avatarUrl ? (
@@ -51,11 +61,8 @@ export function AccountSidebar({
               className="h-full w-full rounded-full object-cover"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center rounded-full bg-[rgb(var(--color-gray-200))]">
-              <UserIcon
-                size={32}
-                className="text-[rgb(var(--color-gray-500))]"
-              />
+            <div className="flex h-full w-full items-center justify-center rounded-full bg-gray-200">
+              <UserIcon size={32} className="text-gray-600" />
             </div>
           )}
 
@@ -63,7 +70,7 @@ export function AccountSidebar({
             type="button"
             onClick={handleOpenFilePicker}
             disabled={isAvatarUploading}
-            className="absolute -right-1 -bottom-1 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full border-2 border-[rgb(var(--color-neutral-0))] bg-[rgb(var(--color-neutral-900))] text-[rgb(var(--color-neutral-0))] shadow-md transition hover:scale-110 disabled:cursor-not-allowed disabled:opacity-60"
+            className="border-neutral-0 text-neutral-0 absolute -right-1 -bottom-1 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full border-2 bg-neutral-900 shadow-md transition hover:scale-110 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Camera size={16} />
           </button>
@@ -77,48 +84,35 @@ export function AccountSidebar({
           />
         </div>
 
-        <h3 className="mt-3 mb-0 text-[20px] leading-none font-semibold text-[rgb(var(--color-neutral-900))]">
+        <h3 className="mt-3 mb-0 text-[20px] leading-none font-semibold text-neutral-900">
           {displayName}
         </h3>
       </div>
 
       <nav className="mt-10">
         <ul className="flex list-none flex-col gap-3 pl-0 text-[16px] font-semibold">
-          <li>
-            <NavLink
-              to={ROUTES.PROFILE}
-              end
-              className={({ isActive }) =>
-                `${navItemClass} ${
-                  isActive
-                    ? 'border-[rgb(var(--color-neutral-800))] text-black'
-                    : 'border-transparent text-[rgb(var(--color-neutral-500))] hover:text-[rgb(var(--color-neutral-900))]'
-                }`
-              }
-            >
-              Account
-            </NavLink>
-          </li>
-
-          <li>
-            <NavLink
-              to={ROUTES.MYORDERS}
-              className={({ isActive }) =>
-                `${navItemClass} ${
-                  isActive
-                    ? 'border-[rgb(var(--neutral-800))] text-black'
-                    : 'border-transparent text-[rgb(var(--color-neutral-500))] hover:text-[rgb(var(--color-neutral-900))]'
-                }`
-              }
-            >
-              Orders
-            </NavLink>
-          </li>
+          {SIDEBAR_LINKS.map(({ to, label, liClassName }) => (
+            <li key={to} className={liClassName}>
+              <NavLink
+                to={to}
+                end={to === ROUTES.PROFILE}
+                className={({ isActive }) =>
+                  `${navItemClass} ${
+                    isActive
+                      ? 'text-neutral-0 border-neutral-800'
+                      : 'border-transparent text-neutral-600 hover:text-neutral-900'
+                  }`
+                }
+              >
+                {label}
+              </NavLink>
+            </li>
+          ))}
 
           <li>
             <span
               aria-disabled="true"
-              className={`${navItemClass} border-transparent text-[rgb(var(--color-neutral-400))]`}
+              className={`${navItemClass} border-transparent text-gray-600`}
             >
               Wishlist
             </span>
@@ -128,7 +122,7 @@ export function AccountSidebar({
             <button
               type="button"
               onClick={onLogout}
-              className="block w-full cursor-pointer appearance-none border-b border-transparent bg-transparent p-0 pb-2 text-left text-[15px] leading-none font-semibold text-[rgb(var(--color-neutral-800))] transition hover:text-[rgb(var(--color-neutral-900))]"
+              className="block w-full cursor-pointer appearance-none border-b border-transparent bg-transparent p-0 pb-2 text-left text-[15px] leading-none font-semibold text-neutral-800 transition hover:text-neutral-900"
             >
               Log Out
             </button>

--- a/src/components/UserProfile/PasswordForm/PasswordForm.tsx
+++ b/src/components/UserProfile/PasswordForm/PasswordForm.tsx
@@ -13,7 +13,7 @@ type PasswordFormProps = {
 export function PasswordForm({ control, errors }: PasswordFormProps) {
   return (
     <section className="mt-10">
-      <h2 className="mt-0 mb-6 text-[20px] font-semibold text-[rgb(var(--color-neutral-900))]">
+      <h2 className="text-text mt-0 mb-6 text-[20px] font-semibold">
         Password
       </h2>
 
@@ -33,7 +33,7 @@ export function PasswordForm({ control, errors }: PasswordFormProps) {
           )}
         />
         {errors.oldPassword?.message ? (
-          <p className="text-sm text-[rgb(var(--color-red-600))]">
+          <p className="text-sm text-red-600">
             {String(errors.oldPassword.message)}
           </p>
         ) : null}
@@ -53,7 +53,7 @@ export function PasswordForm({ control, errors }: PasswordFormProps) {
           )}
         />
         {errors.newPassword?.message ? (
-          <p className="text-sm text-[rgb(var(--color-red-600))]">
+          <p className="text-sm text-red-600">
             {String(errors.newPassword.message)}
           </p>
         ) : null}
@@ -73,7 +73,7 @@ export function PasswordForm({ control, errors }: PasswordFormProps) {
           )}
         />
         {errors.repeatPassword?.message ? (
-          <p className="text-sm text-[rgb(var(--color-red-600))]">
+          <p className="text-sm text-red-600">
             {String(errors.repeatPassword.message)}
           </p>
         ) : null}

--- a/src/pages/User/Profile.tsx
+++ b/src/pages/User/Profile.tsx
@@ -192,22 +192,20 @@ export function Profile() {
   };
 
   if (isLoading) {
-    return <div className="p-10">Loading...</div>;
+    return <div className="bg-background text-text p-10">Loading...</div>;
   }
 
   if (pageError) {
-    return (
-      <div className="p-10 text-[rgb(var(--color-red-600))]">{pageError}</div>
-    );
+    return <div className="bg-background p-10 text-red-600">{pageError}</div>;
   }
 
   if (!user) {
-    return <div className="p-10">User not found</div>;
+    return <div className="bg-background text-text p-10">User not found</div>;
   }
 
   return (
-    <section className="min-h-screen bg-white px-4 md:px-8 lg:px-40">
-      <h1 className="mt-10 mb-16 text-center text-[54px] leading-none font-semibold text-black">
+    <section className="bg-background text-text min-h-screen px-4 md:px-8 lg:px-40">
+      <h1 className="text-text mt-10 mb-16 text-center text-[54px] leading-none font-semibold">
         My Account
       </h1>
 
@@ -233,21 +231,17 @@ export function Profile() {
               <button
                 type="submit"
                 disabled={isSaving}
-                className="mt-6 h-[44px] min-w-[90px] cursor-pointer rounded-md bg-black px-6 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50"
+                className="bg-text text-background mt-6 h-[44px] min-w-[90px] cursor-pointer rounded-md px-6 text-sm font-medium transition hover:opacity-90 disabled:opacity-50"
               >
                 {isSaving ? 'Saving...' : 'Save changes'}
               </button>
 
               {submitError && (
-                <p className="mt-3 text-sm text-[rgb(var(--color-red-600))]">
-                  {submitError}
-                </p>
+                <p className="mt-3 text-sm text-red-600">{submitError}</p>
               )}
 
               {successMessage && (
-                <p className="mt-3 text-sm text-[rgb(var(--color-green-600))]">
-                  {successMessage}
-                </p>
+                <p className="mt-3 text-sm text-green-600">{successMessage}</p>
               )}
             </form>
           </div>


### PR DESCRIPTION
### What was done:
- Implemented dark theme styles for:
  - AccountSidebar
  - AccountDetailsForm
  - PasswordForm
  - AccountInput
- Replaced hardcoded colors with theme-based tokens (text, background, border, etc.)


### How it looks:
<img width="1195" height="893" alt="image" src="https://github.com/user-attachments/assets/93d60752-7bec-4a66-a474-eb5e6a2a63d6" />
