### PR TITLE
refactor(282): extract shared cart counter component for header

### DIFF
--- a/src/components/CartCounter/CartCounter.test.tsx
+++ b/src/components/CartCounter/CartCounter.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useTheme } from '@/hooks/useTheme';
+import { useCartStore } from '@/store/useCartStore';
+
+import { CartCounter } from './CartCounter';
+
+vi.mock('@/store/useCartStore', () => ({
+  useCartStore: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('CartCounter', () => {
+  it('does not render when cart is empty', () => {
+    vi.mocked(useCartStore).mockReturnValue({
+      items: [],
+    } as never);
+
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: false,
+    } as never);
+
+    const { container } = render(<CartCounter />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when total quantity is 0', () => {
+    vi.mocked(useCartStore).mockReturnValue({
+      items: [{ quantity: 0 }, { quantity: 0 }],
+    } as never);
+
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: false,
+    } as never);
+
+    const { container } = render(<CartCounter />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders total quantity for light theme', () => {
+    vi.mocked(useCartStore).mockReturnValue({
+      items: [{ quantity: 2 }, { quantity: 3 }],
+    } as never);
+
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: false,
+    } as never);
+
+    render(<CartCounter />);
+
+    const counter = screen.getByText('5');
+    expect(counter).toBeInTheDocument();
+    expect(counter).toHaveClass('bg-black', 'text-white');
+  });
+
+  it('renders total quantity for dark theme', () => {
+    vi.mocked(useCartStore).mockReturnValue({
+      items: [{ quantity: 1 }],
+    } as never);
+
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: true,
+    } as never);
+
+    render(<CartCounter />);
+
+    const counter = screen.getByText('1');
+    expect(counter).toBeInTheDocument();
+    expect(counter).toHaveClass('bg-white', 'text-black');
+  });
+});

--- a/src/components/CartCounter/CartCounter.tsx
+++ b/src/components/CartCounter/CartCounter.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from '@/hooks/useTheme';
+import { useCartStore } from '@/store/useCartStore';
+
+export const CartCounter = () => {
+  const { items } = useCartStore();
+  const { isDark } = useTheme();
+
+  const cartItemCount = items.reduce((total, item) => total + item.quantity, 0);
+
+  if (cartItemCount <= 0) return null;
+
+  return (
+    <span
+      className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
+        isDark ? 'bg-white text-black' : 'bg-black text-white'
+      }`}
+    >
+      {cartItemCount}
+    </span>
+  );
+};

--- a/src/components/CartCounter/index.ts
+++ b/src/components/CartCounter/index.ts
@@ -1,0 +1,1 @@
+export { CartCounter } from './CartCounter';

--- a/src/components/Features/Features.tsx
+++ b/src/components/Features/Features.tsx
@@ -58,7 +58,7 @@ export const Features: React.FC = () => {
                 <h3 className="m-0 text-base/7 font-medium text-neutral-900 md:text-xl/7">
                   {feature.title}
                 </h3>
-                <p className="m-0 mt-1 text-xs/5 font-normal text-neutral-500 md:text-sm/6">
+                <p className="m-0 mt-1 text-xs/5 font-normal text-neutral-700 md:text-sm/6">
                   {feature.description}
                 </p>
               </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -13,7 +13,7 @@ import {
 
 import logoDark from '@/assets/logo/dark_theme_logo.png';
 import logoLight from '@/assets/logo/light_theme_logo.png';
-import { Button, FlyoutCart, SearchInput } from '@/components';
+import { Button, CartCounter, FlyoutCart, SearchInput } from '@/components';
 import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
@@ -33,11 +33,7 @@ export const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
 
-  const { items: cartItems, openCart } = useCartStore();
-  const cartItemCount = cartItems.reduce(
-    (total, item) => total + item.quantity,
-    0,
-  );
+  const { openCart } = useCartStore();
 
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -127,15 +123,7 @@ export const Header = () => {
               aria-label="Cart"
             >
               <ShoppingBag className="h-6 w-6" />
-              {cartItemCount > 0 && (
-                <span
-                  className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
-                    isDark ? 'bg-white text-black' : 'bg-black text-white'
-                  }`}
-                >
-                  {cartItemCount}
-                </span>
-              )}
+              <CartCounter />
             </button>
           </div>
         </div>
@@ -219,15 +207,7 @@ export const Header = () => {
               aria-label="Cart"
             >
               <ShoppingBag className="h-6 w-6" />
-              {cartItemCount > 0 && (
-                <span
-                  className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
-                    isDark ? 'bg-white text-black' : 'bg-black text-white'
-                  }`}
-                >
-                  {cartItemCount}
-                </span>
-              )}
+              <CartCounter />
             </button>
           </div>
         </div>
@@ -298,15 +278,7 @@ export const Header = () => {
                 <span>Cart</span>
                 <div className="flex items-center gap-2">
                   <ShoppingBag className="h-5 w-5 shrink-0 text-gray-400" />
-                  {cartItemCount > 0 && (
-                    <span
-                      className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
-                        isDark ? 'bg-white text-black' : 'bg-black text-white'
-                      }`}
-                    >
-                      {cartItemCount}
-                    </span>
-                  )}
+                  <CartCounter />
                 </div>
               </button>
 

--- a/src/components/UserAvatar/UserAvatar.test.tsx
+++ b/src/components/UserAvatar/UserAvatar.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { AdminUser } from '@/types/admin-user.types';
+
+import { UserAvatar } from './UserAvatar';
+
+describe('UserAvatar', () => {
+  const baseUser: AdminUser = {
+    id: '1',
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john@example.com',
+    role: 'customer',
+    isActive: true,
+    avatarUrl: '',
+    createdAt: '2025-01-01',
+    updatedAt: '2025-01-01',
+    lastLoginAt: '2025-01-01',
+  };
+
+  it('renders user image when avatarUrl exists', () => {
+    render(
+      <UserAvatar
+        user={{
+          ...baseUser,
+          avatarUrl: 'https://example.com/avatar.jpg',
+        }}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'John Doe' });
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+
+  it('renders initials when avatarUrl is missing', () => {
+    render(<UserAvatar user={baseUser} />);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders initials when image loading fails', () => {
+    render(
+      <UserAvatar
+        user={{
+          ...baseUser,
+          avatarUrl: 'https://example.com/avatar.jpg',
+        }}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'John Doe' });
+    fireEvent.error(image);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders only available initials when user has one name part', () => {
+    render(
+      <UserAvatar
+        user={{
+          ...baseUser,
+          firstName: 'John',
+          lastName: '',
+          avatarUrl: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { ActionMenu } from './ActionMenu/ActionMenu';
 export { AdminPageHeader } from './AdminPageHeader';
 export { Button } from './Button';
+export { CartCounter } from './CartCounter';
 export { CategoryForm } from './CategoryForm/CategoryForm';
 export { Checkbox } from './Checkbox';
 export { ConfirmModal } from './ConfirmModal/ConfirmModal';


### PR DESCRIPTION
- extracted cart counter into a shared`CartCounter component
- removed duplicated cart count logic from Header
- reused the shared counter in header views

- сhanged the description text color in Features to match the dark theme design on light cards

Resolves https://github.com/UA-5399-React/docs/issues/282