### PR TITLE
feat(292): add delete order from admin panel

### DIFF
--- a/src/components/TableOrders/TableOrders.test.tsx
+++ b/src/components/TableOrders/TableOrders.test.tsx
@@ -1,4 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/useDeleteAdminOrder', () => ({
+  useDeleteAdminOrder: () => ({
+    deleteOrder: vi.fn(),
+    data: undefined,
+    loading: false,
+    error: undefined,
+  }),
+}));
 
 import { ORDER_STATUS, type OrderItem } from '@/types/tableOrders.types';
 import { formatDate } from '@/utils';
@@ -66,7 +75,6 @@ describe('UI Component: TableOrders', () => {
 
   it('should render empty state when there are no orders', () => {
     render(<TableOrders items={[]} loading={false} error={null} />);
-
     expect(screen.getByText('No orders found')).toBeInTheDocument();
   });
 

--- a/src/components/TableOrders/TableOrders.test.tsx
+++ b/src/components/TableOrders/TableOrders.test.tsx
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const deleteOrderMock = vi.fn();
 
 vi.mock('@/hooks/useDeleteAdminOrder', () => ({
   useDeleteAdminOrder: () => ({
-    deleteOrder: vi.fn(),
+    deleteOrder: deleteOrderMock,
     data: undefined,
     loading: false,
     error: undefined,
@@ -39,6 +42,10 @@ const orderItem: OrderItem = {
 };
 
 describe('UI Component: TableOrders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should render the table', () => {
     render(<TableOrders items={[]} loading={false} error={null} />);
     expect(screen.getByRole('table')).toBeInTheDocument();
@@ -98,5 +105,36 @@ describe('UI Component: TableOrders', () => {
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
       'Processing',
     );
+  });
+
+  it('should open delete confirmation modal', async () => {
+    const user = userEvent.setup();
+
+    render(<TableOrders items={[orderItem]} loading={false} error={null} />);
+
+    const actionButtons = screen.getAllByRole('button');
+    await user.click(actionButtons[actionButtons.length - 1]);
+
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Delete'));
+
+    expect(
+      screen.getByText('Are you sure you want to delete this order?'),
+    ).toBeInTheDocument();
+  });
+
+  it('should call deleteOrder with orderId after confirm', async () => {
+    const user = userEvent.setup();
+
+    render(<TableOrders items={[orderItem]} loading={false} error={null} />);
+
+    const actionButtons = screen.getAllByRole('button');
+    await user.click(actionButtons[actionButtons.length - 1]);
+
+    await user.click(screen.getByText('Delete'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteOrderMock).toHaveBeenCalledWith(orderItem.orderId);
   });
 });

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import clsx from 'clsx';
 
-import { ActionMenu, Dropdown, MainTable } from '@/components';
+import { ActionMenu, ConfirmModal, Dropdown, MainTable } from '@/components';
 import { useDeleteAdminOrder } from '@/hooks/useDeleteAdminOrder';
 import type { Column } from '@/types';
 import { ORDER_STATUS, type OrderItem } from '@/types/tableOrders.types';
@@ -31,17 +32,27 @@ const statusOptions = Object.values(ORDER_STATUS).map((status) => ({
 export function TableOrders({ items, loading, error }: TableOrdersProps) {
   const { deleteOrder } = useDeleteAdminOrder();
 
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+
   const handleEdit = () => {};
 
-  const handleDelete = async (id: string) => {
-    const confirmed = window.confirm(
-      'Are you sure you want to delete this order?',
-    );
+  const openDeleteModal = (orderId: string) => {
+    setSelectedOrderId(orderId);
+    setIsDeleteModalOpen(true);
+  };
 
-    if (!confirmed) return;
+  const closeDeleteModal = () => {
+    setSelectedOrderId(null);
+    setIsDeleteModalOpen(false);
+  };
+
+  const confirmDelete = async () => {
+    if (!selectedOrderId) return;
 
     try {
-      await deleteOrder(id);
+      await deleteOrder(selectedOrderId);
+      closeDeleteModal();
     } catch (error) {
       console.error('Failed to delete order:', error);
     }
@@ -111,7 +122,7 @@ export function TableOrders({ items, loading, error }: TableOrdersProps) {
           <ActionMenu
             className="top-0 left-[-135px]"
             editAction={() => handleEdit()}
-            deleteAction={() => handleDelete(item.orderId)}
+            deleteAction={() => openDeleteModal(item.orderId)}
           />
         </td>
       </>
@@ -119,13 +130,27 @@ export function TableOrders({ items, loading, error }: TableOrdersProps) {
   };
 
   return (
-    <MainTable
-      columns={columns}
-      items={items}
-      loading={loading}
-      error={error}
-      emptyMessage="No orders found"
-      renderRow={renderProductRow}
-    />
+    <>
+      <MainTable
+        columns={columns}
+        items={items}
+        loading={loading}
+        error={error}
+        emptyMessage="No orders found"
+        renderRow={renderProductRow}
+      />
+
+      {isDeleteModalOpen && (
+        <ConfirmModal
+          title="Delete order"
+          description="Are you sure you want to delete this order?"
+          confirmText="Delete"
+          cancelText="Cancel"
+          isCritical={true}
+          onConfirm={confirmDelete}
+          onCancel={closeDeleteModal}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 
 import { ActionMenu, Dropdown, MainTable } from '@/components';
+import { useDeleteAdminOrder } from '@/hooks/useDeleteAdminOrder';
 import type { Column } from '@/types';
 import { ORDER_STATUS, type OrderItem } from '@/types/tableOrders.types';
 import { capitalizeFirst, formatDate } from '@/utils';
@@ -27,73 +28,96 @@ const statusOptions = Object.values(ORDER_STATUS).map((status) => ({
   value: status,
 }));
 
-const handleEdit = () => {};
+export function TableOrders({ items, loading, error }: TableOrdersProps) {
+  const { deleteOrder } = useDeleteAdminOrder();
 
-const renderProductRow = (item: OrderItem) => {
-  const handleStatusChange = () => {
-    // TODO: handle status change
+  const handleEdit = () => {};
+
+  const handleDelete = async (id: string) => {
+    const confirmed = window.confirm(
+      'Are you sure you want to delete this order?',
+    );
+
+    if (!confirmed) return;
+
+    try {
+      await deleteOrder(id);
+    } catch (error) {
+      console.error('Failed to delete order:', error);
+    }
   };
 
-  const firstProduct = item.items[0];
-  const customerName = `${item.user.firstName} ${item.user.lastName}`.trim();
-  const selectedStatus = item.status ? [String(item.status).toLowerCase()] : [];
+  const renderProductRow = (item: OrderItem) => {
+    const handleStatusChange = () => {
+      // TODO: handle status change
+    };
 
-  return (
-    <>
-      <td>
-        <div className="flex flex-row gap-2">
-          {firstProduct?.imageUrl ? (
-            <img
-              src={firstProduct.imageUrl}
-              alt={firstProduct.title}
-              className="h-10 w-10 rounded object-cover"
-            />
-          ) : null}
-          <div className="flex flex-col gap-1 text-left">
-            <span>{firstProduct?.title ?? 'No items'}</span>
+    const firstProduct = item.items[0];
+    const customerName = `${item.user.firstName} ${item.user.lastName}`.trim();
+    const selectedStatus = item.status
+      ? [String(item.status).toLowerCase()]
+      : [];
 
-            <span> Items: {item.items.length}</span>
+    return (
+      <>
+        <td>
+          <div className="flex flex-row gap-2">
+            {firstProduct?.imageUrl ? (
+              <img
+                src={firstProduct.imageUrl}
+                alt={firstProduct.title}
+                className="h-10 w-10 rounded object-cover"
+              />
+            ) : null}
+
+            <div className="flex flex-col gap-1 text-left">
+              <span>{firstProduct?.title ?? 'No items'}</span>
+              <span>Items: {item.items.length}</span>
+            </div>
           </div>
-        </div>
-      </td>
-      <td>{customerName}</td>
-      <td>#{item.orderId}</td>
-      <td>${item.totalPrice.toFixed(2)}</td>
-      <td>
-        <div className="flex justify-center">
-          <Dropdown
-            label="Status"
-            labelClassName="hidden"
-            options={statusOptions}
-            selectedValues={selectedStatus}
-            onChange={() => handleStatusChange()}
-            multiple={false}
-            hasBorder={true}
-            placeholder="Status"
-            selectClassName={
-              ' ' +
-              clsx(
-                '!flex !items-center !justify-between',
-                '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
-                '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
-              )
-            }
-          />
-        </div>
-      </td>
-      <td>{formatDate(new Date(item.createdAt))}</td>
-      <td>{item.user.phone}</td>
-      <td>
-        <ActionMenu
-          className="top-0 left-[-135px]"
-          editAction={() => handleEdit()}
-        />
-      </td>
-    </>
-  );
-};
+        </td>
 
-export function TableOrders({ items, loading, error }: TableOrdersProps) {
+        <td>{customerName}</td>
+        <td>#{item.orderId}</td>
+        <td>${item.totalPrice.toFixed(2)}</td>
+
+        <td>
+          <div className="flex justify-center">
+            <Dropdown
+              label="Status"
+              labelClassName="hidden"
+              options={statusOptions}
+              selectedValues={selectedStatus}
+              onChange={() => handleStatusChange()}
+              multiple={false}
+              hasBorder={true}
+              placeholder="Status"
+              selectClassName={
+                ' ' +
+                clsx(
+                  '!flex !items-center !justify-between',
+                  '!h-8 !w-[120px] !rounded-[10px] !border !border-[#8F96A3] !bg-white !px-3 !py-0 !text-xs !font-normal !text-[#2C2C2C] !shadow-none hover:!bg-white',
+                  '[&_svg]:!h-4 [&_svg]:!w-4 [&_svg]:!text-[#2563EB]',
+                )
+              }
+            />
+          </div>
+        </td>
+
+        <td>{formatDate(new Date(item.createdAt))}</td>
+        <td>{item.user.phone}</td>
+
+        <td>
+          <ActionMenu
+            className="top-0 left-[-135px]"
+            editAction={() => handleEdit()}
+            deleteAction={() => handleDelete(item.orderId)}
+          />
+        </td>
+      </>
+    );
+  };
+
   return (
     <MainTable
       columns={columns}

--- a/src/hooks/useDeleteAdminOrder.ts
+++ b/src/hooks/useDeleteAdminOrder.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@apollo/client/react';
+
+import { DELETE_ORDER } from '@/services/graphql/ordersAdminService';
+
+interface DeleteOrderData {
+  deleteOrder: boolean;
+}
+
+interface DeleteOrderVariables {
+  orderId: string;
+}
+
+export function useDeleteAdminOrder() {
+  const [deleteOrderMutation, { data, loading, error }] = useMutation<
+    DeleteOrderData,
+    DeleteOrderVariables
+  >(DELETE_ORDER, {
+    refetchQueries: 'active',
+    awaitRefetchQueries: true,
+  });
+
+  const deleteOrder = async (orderId: string) => {
+    return deleteOrderMutation({
+      variables: { orderId },
+    });
+  };
+
+  return { deleteOrder, data, loading, error };
+}

--- a/src/services/graphql/ordersAdminService.ts
+++ b/src/services/graphql/ordersAdminService.ts
@@ -36,3 +36,9 @@ export const GET_ORDERS = gql`
     }
   }
 `;
+
+export const DELETE_ORDER = gql`
+  mutation DeleteOrder($orderId: String!) {
+    deleteOrder(orderId: $orderId)
+  }
+`;


### PR DESCRIPTION
Implemented order deletion functionality in the admin panel.

### Changes:
- added `deleteOrder` GraphQL mutation
- created `useDeleteAdminOrder` hook for handling deletion
- integrated delete action into `TableOrders` via `ActionMenu`
- added confirmation before deleting an order

### Result:
Admins can now delete orders directly from the table, and UI updates correctly after deletion.