### PR TITLE
fix(299): add fallback for missing admin user names

### DIFF
--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -7,10 +7,11 @@ interface UserAvatarProps {
 }
 
 const getUserInitials = (user: AdminUser) => {
-  const firstInitial = user.firstName ? user.firstName[0] : '';
-  const lastInitial = user.lastName ? user.lastName[0] : '';
+  const firstInitial = user.firstName?.trim()?.[0] ?? '';
+  const lastInitial = user.lastName?.trim()?.[0] ?? '';
+  const initials = `${firstInitial}${lastInitial}`.toUpperCase();
 
-  return `${firstInitial}${lastInitial}`.toUpperCase();
+  return initials || user.email?.[0]?.toUpperCase() || '_';
 };
 
 export const UserAvatar = ({ user }: UserAvatarProps) => {

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -13,7 +13,13 @@ interface UsersTableProps {
   items: AdminUser[];
 }
 
-const getFullName = (user: AdminUser) => `${user.firstName} ${user.lastName}`;
+const getFullName = (user: AdminUser) => {
+  const fullName = [user.firstName, user.lastName]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(' ');
+
+  return fullName || '_';
+};
 
 const getActivityLabel = (dateString: string | undefined) => {
   if (!dateString) return 'Never';

--- a/src/hooks/useAdminUsers.test.ts
+++ b/src/hooks/useAdminUsers.test.ts
@@ -46,8 +46,7 @@ describe('useAdminUsers', () => {
   it('filters users by full name, ignoring case and extra spaces', () => {
     mockApolloResponse();
     const targetUser = mockUsers[0];
-    const searchValue = `  ${targetUser.firstName.toUpperCase()} ${targetUser.lastName.toUpperCase()}  `;
-
+    const searchValue = `  ${(targetUser.firstName ?? '').toUpperCase()} ${(targetUser.lastName ?? '').toUpperCase()}  `;
     const { result } = renderHook(() =>
       useAdminUsers({
         currentPage: 1,
@@ -152,7 +151,10 @@ describe('useAdminUsers', () => {
     );
 
     const expectedUsers = mockUsers.filter((user) => {
-      const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+      const fullName = [user.firstName, user.lastName]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join(' ')
+        .toLowerCase();
       const email = user.email.toLowerCase();
 
       const matchesSearch =

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -61,7 +61,10 @@ export const useAdminUsers = ({
 
   const filteredUsers = useMemo(() => {
     return users.filter((user) => {
-      const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+      const fullName = [user.firstName, user.lastName]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join(' ')
+        .toLowerCase();
       const email = user.email.toLowerCase();
 
       const matchesSearch =

--- a/src/types/admin-user.types.ts
+++ b/src/types/admin-user.types.ts
@@ -7,17 +7,16 @@ export type UserRoleFilter = 'all' | UserRole;
 
 export interface AdminUser {
   id: string;
-  firstName: string;
-  lastName: string;
+  firstName?: string | null;
+  lastName?: string | null;
   email: string;
   role: UserRole;
   isActive: boolean;
-  avatarUrl?: string;
+  avatarUrl?: string | null;
   createdAt: string;
   updatedAt: string;
   lastLoginAt?: string;
 }
-
 export interface UpdateUserInput {
   id: string;
   role?: UserRole;


### PR DESCRIPTION
Users registered with email and password only may not have firstName and lastName.
Because of that, the Admin Users table displayed null null instead of a proper fallback value.

- updated AdminUser type to allow nullable firstName and lastName
- added safe full name fallback in UsersTable
- updated full name generation in useAdminUsers search logic
- improved fallback initials in UserAvatar

Result
- users without firstName and lastName are now displayed as _
- search no longer relies on invalid null null full name values
- avatar fallback now shows valid initials or email-based placeholder

