### PR TITLE
Fix checkout confirmation payment status

### DIFF
--- a/src/pages/OrderConfirmation/OrderConfirmation.test.tsx
+++ b/src/pages/OrderConfirmation/OrderConfirmation.test.tsx
@@ -52,6 +52,15 @@ vi.mock('@/store/useCartStore', () => ({
 }));
 
 describe('Page: OrderConfirmation', () => {
+  const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolver) => {
+      resolve = resolver;
+    });
+
+    return { promise, resolve };
+  };
+
   const renderPage = (
     initialEntries: Parameters<typeof MemoryRouter>[0]['initialEntries'],
   ) => {
@@ -104,16 +113,30 @@ describe('Page: OrderConfirmation', () => {
       ...orderSnapshot,
       paymentMethod: 'stripe',
     });
-    (paymentService.getSessionStatus as Mock).mockResolvedValue({
-      status: 'complete',
-      paymentStatus: 'paid',
-    });
+    const deferredStatus = createDeferred<{
+      status: string;
+      paymentStatus: string;
+    }>();
+    (paymentService.getSessionStatus as Mock).mockReturnValue(
+      deferredStatus.promise,
+    );
 
     renderPage(['/order-confirmation?session_id=cs_test_123']);
 
     expect(
       await screen.findByText('Checking your payment status...'),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('We could not confirm this order'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Back to checkout' }),
+    ).not.toBeInTheDocument();
+
+    deferredStatus.resolve({
+      status: 'complete',
+      paymentStatus: 'paid',
+    });
 
     await waitFor(() => {
       expect(paymentService.getSessionStatus).toHaveBeenCalledWith(

--- a/src/pages/OrderConfirmation/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation/OrderConfirmation.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import {
   CheckCircle2,
   CreditCard,
+  LoaderCircle,
   PackageCheck,
   Truck,
   XCircle,
@@ -45,7 +46,10 @@ export const OrderConfirmation = () => {
     retry: false,
   });
 
+  const isStripeStatusPending =
+    Boolean(sessionId) && sessionQuery.status === 'pending';
   const isStripeSuccess =
+    Boolean(sessionId) &&
     sessionQuery.data?.status === 'complete' &&
     sessionQuery.data?.paymentStatus === 'paid';
   const isCodSuccess =
@@ -54,13 +58,13 @@ export const OrderConfirmation = () => {
     (locationState?.paymentStatus === 'pending' || Boolean(orderSnapshot));
   const isSuccess = isStripeSuccess || isCodSuccess;
 
-  const title = sessionQuery.isLoading
+  const title = isStripeStatusPending
     ? 'Checking your payment status...'
     : isSuccess
       ? 'Order confirmed'
       : 'We could not confirm this order';
 
-  const description = sessionQuery.isLoading
+  const description = isStripeStatusPending
     ? 'Please wait while we verify the checkout session.'
     : isSuccess
       ? 'Your checkout has been completed successfully.'
@@ -90,7 +94,9 @@ export const OrderConfirmation = () => {
         >
           <div className="flex flex-col items-start gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-3">
-              {isSuccess ? (
+              {isStripeStatusPending ? (
+                <LoaderCircle className="h-10 w-10 animate-spin text-[#6C7275]" />
+              ) : isSuccess ? (
                 <CheckCircle2 className="text-primary h-10 w-10" />
               ) : (
                 <XCircle className="h-10 w-10 text-red-500" />
@@ -137,7 +143,9 @@ export const OrderConfirmation = () => {
               value={
                 isCashOnDelivery
                   ? 'Cash on delivery'
-                  : (sessionQuery.data?.paymentStatus ?? 'Card payment')
+                  : isStripeStatusPending
+                    ? 'Checking status...'
+                    : (sessionQuery.data?.paymentStatus ?? 'Card payment')
               }
             />
             <InfoCard
@@ -227,7 +235,7 @@ export const OrderConfirmation = () => {
                 Continue shopping
               </Button>
             </Link>
-            {!isSuccess && (
+            {!isStripeStatusPending && !isSuccess && (
               <Link to={ROUTES.CHECKOUT} className="sm:flex-1">
                 <Button
                   className={clsx(


### PR DESCRIPTION
## What changed
- keep the order confirmation page in a loading state until the Stripe session status resolves
- stop rendering the failure icon and retry action while the payment check is still pending
- add a regression test that proves the page does not flash the failed-payment state before success

## Why
The confirmation page treated "not successful yet" as a failure state, so users coming back from Stripe briefly saw the error UI before the real payment status arrived.

## Impact
Customers returning from Stripe now see a neutral loading state first and then the correct confirmation state.

## Validation
- pnpm test
- pnpm run build
- pnpm run lint

Related to UA-5399-React/docs#265