### PR TITLE
fix(302): auto-dismiss success/error messages

### DIFF
--- a/src/pages/User/Profile.tsx
+++ b/src/pages/User/Profile.tsx
@@ -90,6 +90,28 @@ export function Profile() {
     void loadUser();
   }, [navigate, reset, handleUnauthorized]);
 
+  // Autoclear success messages
+  useEffect(() => {
+    if (!successMessage) return;
+
+    const timer = setTimeout(() => {
+      setSuccessMessage('');
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [successMessage]);
+
+  // Autoclear error messages
+  useEffect(() => {
+    if (!submitError) return;
+
+    const timer = setTimeout(() => {
+      setSubmitError('');
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [submitError]);
+
   const handleAvatarUpload = async (file: File) => {
     if (!user) return;
 


### PR DESCRIPTION
Fixed a situation where messages about successful profile update or errors would not disappear over time. Messages now disappear after a 5 second delay.