### PR TITLE
fix(321): show subcategory search results

### DIFF
--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -157,6 +157,23 @@ describe('UI Component: TableCategories', () => {
     expect(screen.queryByText('Ultrabooks')).not.toBeInTheDocument();
   });
 
+  it('should auto-expand parent categories passed from search results', () => {
+    render(
+      <TableCategories
+        items={mockCategories}
+        loading={false}
+        autoExpandedIds={['parent-1']}
+        onDelete={mockDelete}
+        onEdit={mockEdit}
+      />,
+    );
+
+    expect(screen.getByText('Ultrabooks')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Collapse Laptops' }),
+    ).toBeInTheDocument();
+  });
+
   it('should render image fallback and action buttons', async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -11,6 +11,7 @@ interface TableCategoriesProps {
   items: Category[];
   loading: boolean;
   error?: Error | null;
+  autoExpandedIds?: string[];
   deletingId?: string | null;
   onDelete: (category: Category) => void;
   onEdit: (category: Category) => void;
@@ -143,6 +144,7 @@ function TableCategoriesContent({
   loading,
   error,
   isDark,
+  autoExpandedIds,
   deletingId,
   onDelete,
   onEdit,
@@ -151,11 +153,15 @@ function TableCategoriesContent({
   loading: boolean;
   error: Error | null;
   isDark: boolean;
+  autoExpandedIds?: string[];
   deletingId?: string | null;
   onDelete: (category: Category) => void;
   onEdit: (category: Category) => void;
 }) {
-  const [expandedIds, setExpandedIds] = useState<string[]>([]);
+  const resolvedAutoExpandedIds = autoExpandedIds ?? [];
+  const [expandedIds, setExpandedIds] = useState<string[]>(
+    resolvedAutoExpandedIds,
+  );
 
   if (loading) {
     return (
@@ -273,11 +279,13 @@ export function TableCategories({
   items,
   loading,
   error,
+  autoExpandedIds,
   deletingId,
   onDelete,
   onEdit,
 }: TableCategoriesProps) {
   const { isDark } = useTheme();
+  const autoExpandedIdsSignature = (autoExpandedIds ?? []).join('|');
 
   return (
     <div className="mx-5 mt-5 overflow-x-auto rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
@@ -297,10 +305,12 @@ export function TableCategories({
 
         <tbody>
           <TableCategoriesContent
+            key={autoExpandedIdsSignature}
             items={items}
             loading={loading}
             error={error ?? null}
             isDark={isDark}
+            autoExpandedIds={autoExpandedIds}
             deletingId={deletingId}
             onDelete={onDelete}
             onEdit={onEdit}

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { act, render, screen, userEvent, waitFor } from '@/utils/test-utils';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@/utils/test-utils';
 
 import { AdminCategories } from './AdminCategories';
 
@@ -36,6 +43,7 @@ vi.mock('@/hooks/useTheme', () => ({
 describe('Page: AdminCategories', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('should read page from URL params', () => {
@@ -327,5 +335,55 @@ describe('Page: AdminCategories', () => {
     });
 
     expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('should auto-expand parent row when backend returns a matching subcategory', async () => {
+    vi.useFakeTimers();
+
+    useAdminCategoriesPageMock.mockReturnValue({
+      categories: [
+        {
+          id: 'parent-1',
+          title: 'Laptops',
+          imageUrl: null,
+          description: 'Main laptops category',
+          parent: null,
+          depth: 1,
+          createdAt: '2025-10-10T12:00:00Z',
+          updatedAt: '2025-10-11T12:00:00Z',
+        },
+        {
+          id: 'child-1',
+          title: 'Ultrabooks',
+          imageUrl: null,
+          description: 'Slim laptops',
+          parent: 'parent-1',
+          depth: 2,
+          createdAt: '2025-10-12T12:00:00Z',
+          updatedAt: '2025-10-13T12:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      totalPages: 1,
+      total: 1,
+    });
+
+    render(<AdminCategories />);
+
+    expect(screen.queryByText('Ultrabooks')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'ultra' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('Ultrabooks')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Collapse Laptops' }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/Admin/Categories/AdminCategories.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.tsx
@@ -38,12 +38,23 @@ export function AdminCategories() {
   } = usePaginationPageParam();
 
   const debouncedSearch = useDebouncedValue(search.trim(), 500);
+  const isSearchActive = debouncedSearch.length > 0;
 
   const { categories, loading, error, totalPages } = useAdminCategoriesPage({
     page: currentPage,
     limit: ADMIN_PAGE_LIMIT,
     search: debouncedSearch,
   });
+  const autoExpandedIds = isSearchActive
+    ? Array.from(
+        new Set(
+          categories
+            .filter((category) => Boolean(category.parent))
+            .map((category) => category.parent!)
+            .filter(Boolean),
+        ),
+      )
+    : [];
 
   const handlePageChange = (nextPage: number) => {
     setPage(nextPage);
@@ -99,6 +110,7 @@ export function AdminCategories() {
 
       <div className="flex items-center justify-end border-b border-[#e5e7eb] px-4 py-3">
         <Button
+          className="ml-3 bg-blue-800 text-white hover:bg-transparent hover:text-blue-800"
           variant="primary"
           type="button"
           onClick={() => navigate(ROUTES.ADMIN_CATEGORY_ADD)}
@@ -143,6 +155,7 @@ export function AdminCategories() {
           items={categories}
           loading={loading}
           error={error}
+          autoExpandedIds={autoExpandedIds}
           deletingId={deletingId}
           onDelete={handleDeleteCategory}
           onEdit={handleEditCategory}


### PR DESCRIPTION

### Desctiption
Show subcategory search results in admin categories table

Now the page:
- uses backend search results
- opens the parent row when a matching subcategory is found
- shows the matching subcategory in the table

### Result
Subcategory search results are now visible on the admin categories page.