### PR TITLE
fix(310): cart duplication bug solving

### DIFF
--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -83,16 +83,28 @@ export const LoginForm: React.FC = () => {
 
       try {
         const store = useCartStore.getState();
-        const guestItems = store.items.map((item) => ({
-          productId: String(item.product.id || item.product._id),
-          quantity: item.quantity,
-        }));
+        const guestItems = store.items;
 
-        const syncedCart = await cartService.syncCart(guestItems);
-        const newCartItems = syncedCart.items.map((i) => ({
-          product: i.product,
-          quantity: i.quantity,
-        }));
+        let newCartItems;
+
+        if (guestItems.length > 0) {
+          const payload = guestItems.map((item) => ({
+            productId: String(item.product.id || item.product._id),
+            quantity: item.quantity,
+          }));
+
+          const syncedCart = await cartService.syncCart(payload);
+          newCartItems = syncedCart.items.map((i) => ({
+            product: i.product,
+            quantity: i.quantity,
+          }));
+        } else {
+          const dbCart = await cartService.getCart();
+          newCartItems = dbCart.items.map((i) => ({
+            product: i.product,
+            quantity: i.quantity,
+          }));
+        }
         store.setCart(newCartItems);
       } catch (err) {
         console.error('Failed to sync cart:', err);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { MOCK_AUTH } from '@/constants';
 import { authService } from '@/services/authService';
+import { useCartStore } from '@/store/useCartStore';
 import {
   canAccessAdminPanel,
   isAdminRole,
@@ -32,6 +33,8 @@ export const useAuth = () => {
       localStorage.removeItem(MOCK_AUTH.TOKEN_KEY);
       localStorage.removeItem(MOCK_AUTH.EXPIRES_KEY);
       localStorage.removeItem(MOCK_AUTH.ROLE_KEY);
+
+      useCartStore.getState().clearCart();
 
       queryClient.removeQueries({ queryKey: ['me'] });
       setIsAuth(false);


### PR DESCRIPTION
**Problem** -> After logout - login, cart items were duplicated (x2 for each item).
 `useAuth.logout()` removed auth tokens but did not clear cart state
`LoginForm` always called `syncCart` with local items, even when those items were leftovers from a previous session

**Changes**
- `useAuth.ts` — added `useCartStore.getState().clearCart()` on logout to reset persisted cart state
- `LoginForm.tsx` — added logic to distinguish between a real guest cart and an empty cart: if no local items exist, fetch cart from DB via `getCart()` instead of calling `syncCart`