### PR TITLE
Feat/311 unify products action menu

### DIFF
--- a/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/ActionMenu.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import type * as LucideIcons from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { ActionMenu } from './ActionMenu';
+import { ActionMenu, type ActionMenuItem } from './ActionMenu';
 
 vi.mock('lucide-react', async (importOriginal) => {
   const actual = await importOriginal<typeof LucideIcons>();
@@ -13,24 +13,37 @@ vi.mock('lucide-react', async (importOriginal) => {
     EllipsisVertical: (props: HTMLAttributes<HTMLDivElement>) => (
       <div data-testid="ellipsis-icon" {...props} />
     ),
-    Pencil: (props: HTMLAttributes<HTMLDivElement>) => (
-      <div data-testid="pencil-icon" {...props} />
-    ),
-    Trash: (props: HTMLAttributes<HTMLDivElement>) => (
-      <div data-testid="trash-icon" {...props} />
-    ),
   };
 });
 
+function createAction(overrides: Partial<ActionMenuItem> = {}): ActionMenuItem {
+  return {
+    label: 'Edit',
+    onClick: vi.fn(),
+    icon: <span data-testid="action-icon" />,
+    ...overrides,
+  };
+}
+
+function renderActionMenu(actions: ActionMenuItem[]) {
+  render(<ActionMenu triggerAriaLabel="Open actions menu" actions={actions} />);
+}
+
 function getTriggerButton() {
-  const buttons = screen.getAllByRole('button');
-  return buttons[0];
+  return screen.getByRole('button', { name: /open actions menu/i });
 }
 
 describe('ActionMenu', () => {
-  it('shows only the trigger initially; Edit is not visible', () => {
-    const editAction = vi.fn();
-    render(<ActionMenu editAction={editAction} />);
+  it('does not render anything when actions are empty', () => {
+    renderActionMenu([]);
+
+    expect(
+      screen.queryByRole('button', { name: /open actions menu/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows only the trigger initially; actions are not visible', () => {
+    renderActionMenu([createAction({ label: 'Edit' })]);
 
     expect(screen.getAllByRole('button')).toHaveLength(1);
     expect(
@@ -38,20 +51,26 @@ describe('ActionMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('opens the panel on trigger click and shows Edit', async () => {
+  it('opens the panel on trigger click and shows actions', async () => {
     const user = userEvent.setup();
-    const editAction = vi.fn();
-    render(<ActionMenu editAction={editAction} />);
+
+    renderActionMenu([createAction({ label: 'Edit' })]);
 
     await user.click(getTriggerButton());
 
     expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
   });
 
-  it('calls editAction and closes the panel when Edit is clicked', async () => {
+  it('calls action.onClick and closes the panel when an action is clicked', async () => {
     const user = userEvent.setup();
     const editAction = vi.fn();
-    render(<ActionMenu editAction={editAction} />);
+
+    renderActionMenu([
+      createAction({
+        label: 'Edit',
+        onClick: editAction,
+      }),
+    ]);
 
     await user.click(getTriggerButton());
     await user.click(screen.getByRole('button', { name: /edit/i }));
@@ -62,41 +81,79 @@ describe('ActionMenu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders Delete when deleteAction is provided', async () => {
+  it('renders multiple actions when they are provided', async () => {
     const user = userEvent.setup();
-    const deleteAction = vi.fn();
-    render(<ActionMenu editAction={vi.fn()} deleteAction={deleteAction} />);
+
+    renderActionMenu([
+      createAction({ label: 'Edit' }),
+      createAction({
+        label: 'Delete',
+        icon: <span data-testid="delete-icon" />,
+        onClick: vi.fn(),
+        variant: 'danger',
+      }),
+    ]);
 
     await user.click(getTriggerButton());
 
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
   });
 
-  it('does not render Delete when deleteAction is omitted', async () => {
-    const user = userEvent.setup();
-    render(<ActionMenu editAction={vi.fn()} />);
-
-    await user.click(getTriggerButton());
-
-    expect(
-      screen.queryByRole('button', { name: /delete/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('calls deleteAction when Delete is clicked', async () => {
+  it('does not call onClick for a disabled action', async () => {
     const user = userEvent.setup();
     const deleteAction = vi.fn();
-    render(<ActionMenu editAction={vi.fn()} deleteAction={deleteAction} />);
+
+    renderActionMenu([
+      createAction({
+        label: 'Delete',
+        icon: <span data-testid="delete-icon" />,
+        onClick: deleteAction,
+        disabled: true,
+      }),
+    ]);
 
     await user.click(getTriggerButton());
     await user.click(screen.getByRole('button', { name: /delete/i }));
 
-    expect(deleteAction).toHaveBeenCalledTimes(1);
+    expect(deleteAction).not.toHaveBeenCalled();
+  });
+
+  it('renders separators between actions', async () => {
+    const user = userEvent.setup();
+
+    renderActionMenu([
+      createAction({ label: 'Edit' }),
+      createAction({
+        label: 'Duplicate',
+        icon: <span data-testid="duplicate-icon" />,
+        onClick: vi.fn(),
+      }),
+      createAction({
+        label: 'Delete',
+        icon: <span data-testid="delete-icon" />,
+        onClick: vi.fn(),
+        variant: 'danger',
+      }),
+    ]);
+
+    await user.click(getTriggerButton());
+
+    expect(screen.getAllByRole('separator')).toHaveLength(2);
   });
 
   it('closes the panel on pointerdown outside the menu', async () => {
     const user = userEvent.setup();
-    render(<ActionMenu editAction={vi.fn()} deleteAction={vi.fn()} />);
+
+    renderActionMenu([
+      createAction({ label: 'Edit' }),
+      createAction({
+        label: 'Delete',
+        icon: <span data-testid="delete-icon" />,
+        onClick: vi.fn(),
+        variant: 'danger',
+      }),
+    ]);
 
     await user.click(getTriggerButton());
     expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();

--- a/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/ActionMenu.test.tsx
@@ -17,11 +17,14 @@ vi.mock('lucide-react', async (importOriginal) => {
 });
 
 function createAction(overrides: Partial<ActionMenuItem> = {}): ActionMenuItem {
+  const { id = 'edit', ...rest } = overrides;
+
   return {
+    id,
     label: 'Edit',
     onClick: vi.fn(),
     icon: <span data-testid="action-icon" />,
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -43,7 +46,7 @@ describe('ActionMenu', () => {
   });
 
   it('shows only the trigger initially; actions are not visible', () => {
-    renderActionMenu([createAction({ label: 'Edit' })]);
+    renderActionMenu([createAction({ id: 'edit', label: 'Edit' })]);
 
     expect(screen.getAllByRole('button')).toHaveLength(1);
     expect(
@@ -54,7 +57,7 @@ describe('ActionMenu', () => {
   it('opens the panel on trigger click and shows actions', async () => {
     const user = userEvent.setup();
 
-    renderActionMenu([createAction({ label: 'Edit' })]);
+    renderActionMenu([createAction({ id: 'edit', label: 'Edit' })]);
 
     await user.click(getTriggerButton());
 
@@ -67,6 +70,7 @@ describe('ActionMenu', () => {
 
     renderActionMenu([
       createAction({
+        id: 'edit',
         label: 'Edit',
         onClick: editAction,
       }),
@@ -85,8 +89,9 @@ describe('ActionMenu', () => {
     const user = userEvent.setup();
 
     renderActionMenu([
-      createAction({ label: 'Edit' }),
+      createAction({ id: 'edit', label: 'Edit' }),
       createAction({
+        id: 'delete',
         label: 'Delete',
         icon: <span data-testid="delete-icon" />,
         onClick: vi.fn(),
@@ -106,6 +111,7 @@ describe('ActionMenu', () => {
 
     renderActionMenu([
       createAction({
+        id: 'delete',
         label: 'Delete',
         icon: <span data-testid="delete-icon" />,
         onClick: deleteAction,
@@ -123,13 +129,15 @@ describe('ActionMenu', () => {
     const user = userEvent.setup();
 
     renderActionMenu([
-      createAction({ label: 'Edit' }),
+      createAction({ id: 'edit', label: 'Edit' }),
       createAction({
+        id: 'duplicate',
         label: 'Duplicate',
         icon: <span data-testid="duplicate-icon" />,
         onClick: vi.fn(),
       }),
       createAction({
+        id: 'delete',
         label: 'Delete',
         icon: <span data-testid="delete-icon" />,
         onClick: vi.fn(),
@@ -146,8 +154,9 @@ describe('ActionMenu', () => {
     const user = userEvent.setup();
 
     renderActionMenu([
-      createAction({ label: 'Edit' }),
+      createAction({ id: 'edit', label: 'Edit' }),
       createAction({
+        id: 'delete',
         label: 'Delete',
         icon: <span data-testid="delete-icon" />,
         onClick: vi.fn(),

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -1,20 +1,28 @@
-import { useEffect, useRef, useState } from 'react';
-import { EllipsisVertical, Pencil, Trash } from 'lucide-react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+import { EllipsisVertical } from 'lucide-react';
 
 import { Button } from '@/components/Button';
 
 import styles from './ActionMenu.module.css';
 
+export type ActionMenuItem = {
+  label: string;
+  onClick: () => void;
+  icon: ReactNode;
+  variant?: 'default' | 'danger';
+  disabled?: boolean;
+  title?: string;
+};
+
 interface ActionMenuProps {
-  editAction?: () => void;
-  deleteAction?: () => void;
+  actions: ActionMenuItem[];
   className?: string;
   triggerAriaLabel?: string;
 }
 
 export const ActionMenu = ({
-  editAction,
-  deleteAction,
+  actions,
   className,
   triggerAriaLabel,
 }: ActionMenuProps) => {
@@ -35,12 +43,17 @@ export const ActionMenu = ({
     return () => document.removeEventListener('pointerdown', close);
   }, [isOpen]);
 
+  if (!actions.length) return null;
+
   return (
     <div ref={rootRef} className="relative">
       <Button
         type="button"
-        aria-label={triggerAriaLabel}
-        className={`${styles.button} hover:text-bgSecInverted bg-transparent text-gray-600 hover:!border-transparent`}
+        aria-label={triggerAriaLabel ?? 'Open actions menu'}
+        className={clsx(
+          styles.button,
+          'bg-transparent text-gray-600 hover:!border-transparent',
+        )}
         onClick={() => setIsOpen((prev) => !prev)}
       >
         <EllipsisVertical className="text-bgSecInverted h-5 w-5" />
@@ -48,43 +61,38 @@ export const ActionMenu = ({
 
       {isOpen && (
         <div
-          className={`bg-background absolute top-0 left-10 z-20 flex w-[140px] flex-col rounded-xl border border-gray-300 p-2 shadow-lg ${className ?? ''}`}
+          className={clsx(
+            'bg-background absolute top-full right-0 z-20 mt-2 flex w-[160px] flex-col rounded-xl border border-gray-300 p-2 shadow-lg',
+            className,
+          )}
         >
-          {editAction && (
-            <Button
-              type="button"
-              className={`${styles.button} border-fieldBorder text-text border-b-2 bg-transparent`}
-              onClick={() => {
-                setIsOpen(false);
-                editAction();
-              }}
-            >
-              <div className={styles.buttonActionContent}>
-                <Pencil />
-                <span>Edit</span>
-              </div>
-            </Button>
-          )}
+          {actions.map((action, index) => (
+            <div key={`${action.label}-${index}`}>
+              {index > 0 && (
+                <hr className="my-2 w-full border-0 border-t border-gray-300" />
+              )}
 
-          {deleteAction && editAction && (
-            <hr className="my-2 w-full border-0 border-t border-gray-300" />
-          )}
-
-          {deleteAction && (
-            <Button
-              type="button"
-              className={`${styles.button} bg-transparent text-red-700`}
-              onClick={() => {
-                setIsOpen(false);
-                deleteAction();
-              }}
-            >
-              <div className={styles.buttonActionContent}>
-                <Trash />
-                <span>Delete</span>
-              </div>
-            </Button>
-          )}
+              <Button
+                type="button"
+                title={action.title}
+                disabled={action.disabled}
+                className={clsx(
+                  styles.button,
+                  'bg-transparent disabled:cursor-not-allowed disabled:opacity-50',
+                  action.variant === 'danger' ? 'text-red-700' : 'text-text',
+                )}
+                onClick={() => {
+                  setIsOpen(false);
+                  action.onClick();
+                }}
+              >
+                <div className={styles.buttonActionContent}>
+                  {action.icon}
+                  <span>{action.label}</span>
+                </div>
+              </Button>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/Button';
 import styles from './ActionMenu.module.css';
 
 export type ActionMenuItem = {
+  id: string;
   label: string;
   onClick: () => void;
   icon: ReactNode;
@@ -14,7 +15,6 @@ export type ActionMenuItem = {
   disabled?: boolean;
   title?: string;
 };
-
 interface ActionMenuProps {
   actions: ActionMenuItem[];
   className?: string;
@@ -67,7 +67,7 @@ export const ActionMenu = ({
           )}
         >
           {actions.map((action, index) => (
-            <div key={`${action.label}-${index}`}>
+            <div key={action.id}>
               {index > 0 && (
                 <hr className="my-2 w-full border-0 border-t border-gray-300" />
               )}

--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Category } from '@/types';
-import { render, screen, userEvent } from '@/utils/test-utils';
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
 
 import { TableCategories } from './TableCategories';
 
@@ -56,6 +56,10 @@ const mockCategories: Category[] = [
 ];
 
 describe('UI Component: TableCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should render the table and all column headers', () => {
     render(
       <TableCategories
@@ -175,7 +179,7 @@ describe('UI Component: TableCategories', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render image fallback and action buttons', async () => {
+  it('should render image fallback and action menu actions', async () => {
     const user = userEvent.setup();
 
     render(
@@ -192,22 +196,34 @@ describe('UI Component: TableCategories', () => {
     await user.click(
       screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
-    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /edit/i }));
-    expect(mockEdit).toHaveBeenCalledWith(mockCategories[2]);
+    expect(
+      await screen.findByRole('button', { name: /^edit$/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /^delete$/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    await waitFor(() => {
+      expect(mockEdit).toHaveBeenCalledWith(mockCategories[2]);
+    });
 
     await user.click(
       screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
-    await user.click(screen.getByRole('button', { name: /delete/i }));
-    expect(mockDelete).toHaveBeenCalledWith(mockCategories[2]);
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(mockCategories[2]);
+    });
 
     await user.click(
       screen.getByRole('button', { name: 'Actions for Laptops' }),
     );
-    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
+
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
   });
 
   it('should disable delete button for currently deleting category', async () => {
@@ -227,7 +243,7 @@ describe('UI Component: TableCategories', () => {
       screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
 
-    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
   });
 
   it('should render formatted dates and parent category label', () => {

--- a/src/components/TableCategories/TableCategories.test.tsx
+++ b/src/components/TableCategories/TableCategories.test.tsx
@@ -136,6 +136,7 @@ describe('UI Component: TableCategories', () => {
 
   it('should expand and collapse subcategories on toggle click', async () => {
     const user = userEvent.setup();
+
     render(
       <TableCategories
         items={mockCategories}
@@ -157,8 +158,9 @@ describe('UI Component: TableCategories', () => {
     expect(screen.queryByText('Ultrabooks')).not.toBeInTheDocument();
   });
 
-  it('should render image fallback and action buttons', async () => {
+  it('should render image fallback and action menu actions', async () => {
     const user = userEvent.setup();
+
     render(
       <TableCategories
         items={mockCategories}
@@ -170,26 +172,30 @@ describe('UI Component: TableCategories', () => {
 
     expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
 
-    const editButton = screen.getByRole('button', { name: 'Edit Accessories' });
-    const deleteButton = screen.getByRole('button', {
-      name: 'Delete Accessories',
-    });
-    const parentDeleteButton = screen.getByRole('button', {
-      name: 'Delete Laptops',
-    });
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
+    );
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
 
-    expect(editButton).toBeInTheDocument();
-    expect(deleteButton).toBeInTheDocument();
-    expect(parentDeleteButton).toBeDisabled();
-
-    await user.click(editButton);
-    await user.click(deleteButton);
-
+    await user.click(screen.getByRole('button', { name: /edit/i }));
     expect(mockEdit).toHaveBeenCalledWith(mockCategories[2]);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
+    );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
     expect(mockDelete).toHaveBeenCalledWith(mockCategories[2]);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Laptops' }),
+    );
+    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
   });
 
-  it('should disable delete button for currently deleting category', () => {
+  it('should disable delete button for currently deleting category', async () => {
+    const user = userEvent.setup();
+
     render(
       <TableCategories
         items={mockCategories}
@@ -200,9 +206,11 @@ describe('UI Component: TableCategories', () => {
       />,
     );
 
-    expect(
-      screen.getByRole('button', { name: 'Delete Accessories' }),
-    ).toBeDisabled();
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
+    );
+
+    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
   });
 
   it('should render formatted dates and parent category label', () => {

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -120,11 +120,13 @@ function CategoryRow({
             triggerAriaLabel={`Actions for ${category.title}`}
             actions={[
               {
+                id: 'edit',
                 label: 'Edit',
                 icon: <Pencil className="h-[20px] w-[20px]" />,
                 onClick: () => onEdit(category),
               },
               {
+                id: 'delete',
                 label: 'Delete',
                 icon: <Trash className="h-[20px] w-[20px]" />,
                 onClick: () => onDelete(category),

--- a/src/components/TableCategories/TableCategories.tsx
+++ b/src/components/TableCategories/TableCategories.tsx
@@ -2,10 +2,9 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import { AlertCircle, Minus, Pencil, Plus, Trash } from 'lucide-react';
 
+import { ActionMenu } from '@/components';
 import { useTheme } from '@/hooks/useTheme';
 import type { Category } from '@/types';
-
-import { Button } from '../Button';
 
 interface TableCategoriesProps {
   items: Category[];
@@ -115,24 +114,26 @@ function CategoryRow({
       <td className="text-center">{formatCategoryDate(category.createdAt)}</td>
       <td className="text-center">{formatCategoryDate(category.updatedAt)}</td>
       <td className="text-center">
-        <Button
-          aria-label={`Delete ${category.title}`}
-          className="bg-transparent text-[#DB162D] hover:bg-transparent disabled:cursor-not-allowed disabled:opacity-50"
-          type="button"
-          disabled={isDeleteDisabled}
-          onClick={() => onDelete(category)}
-          title={deleteButtonTitle}
-        >
-          <Trash className="h-[20px] w-[20px]" />
-        </Button>
-        <Button
-          aria-label={`Edit ${category.title}`}
-          className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
-          type="button"
-          onClick={() => onEdit(category)}
-        >
-          <Pencil className="h-[20px] w-[20px]" />
-        </Button>
+        <div className="flex justify-end pr-2">
+          <ActionMenu
+            triggerAriaLabel={`Actions for ${category.title}`}
+            actions={[
+              {
+                label: 'Edit',
+                icon: <Pencil className="h-[20px] w-[20px]" />,
+                onClick: () => onEdit(category),
+              },
+              {
+                label: 'Delete',
+                icon: <Trash className="h-[20px] w-[20px]" />,
+                onClick: () => onDelete(category),
+                variant: 'danger',
+                disabled: isDeleteDisabled,
+                title: deleteButtonTitle,
+              },
+            ]}
+          />
+        </div>
       </td>
     </tr>
   );

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -144,6 +144,7 @@ export function TableOrders({
             className="top-0 left-[-135px]"
             actions={[
               {
+                id: 'delete',
                 label: 'Delete',
                 icon: <Trash className="h-[20px] w-[20px]" />,
                 onClick: () => openDeleteModal(item.orderId),

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import clsx from 'clsx';
+import { Trash } from 'lucide-react';
 
 import { ActionMenu, ConfirmModal, Dropdown, MainTable } from '@/components';
 import { useDeleteAdminOrder } from '@/hooks/useDeleteAdminOrder';
@@ -139,8 +140,16 @@ export function TableOrders({
 
         <td>
           <ActionMenu
+            triggerAriaLabel={`Actions for order ${item.orderId}`}
             className="top-0 left-[-135px]"
-            deleteAction={() => openDeleteModal(item.orderId)}
+            actions={[
+              {
+                label: 'Delete',
+                icon: <Trash className="h-[20px] w-[20px]" />,
+                onClick: () => openDeleteModal(item.orderId),
+                variant: 'danger',
+              },
+            ]}
           />
         </td>
       </>

--- a/src/components/TableProducts/TableProducts.test.tsx
+++ b/src/components/TableProducts/TableProducts.test.tsx
@@ -190,8 +190,9 @@ describe('UI Component: TableProducts', () => {
     expect(screen.getByText('First product')).toBeInTheDocument();
   });
 
-  it('should navigate to the product edit page when the edit button is clicked', async () => {
+  it('should navigate to the product edit page when the edit action is clicked', async () => {
     const user = userEvent.setup();
+
     render(
       <TableProducts
         items={[mockProducts[0]]}
@@ -201,17 +202,21 @@ describe('UI Component: TableProducts', () => {
       />,
     );
 
-    const editButton = screen.getByRole('button', {
-      name: `Edit ${mockProducts[0].title}`,
+    const triggerButton = screen.getByRole('button', {
+      name: `Open actions for ${mockProducts[0].title}`,
     });
-    await user.click(editButton);
+
+    await user.click(triggerButton);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.stringContaining(mockProducts[0].id),
     );
   });
 
-  it('should disable delete button for non-draft products', () => {
+  it('should disable delete action for non-draft products', async () => {
+    const user = userEvent.setup();
+
     render(
       <TableProducts
         items={[mockProducts[0]]}
@@ -221,8 +226,12 @@ describe('UI Component: TableProducts', () => {
       />,
     );
 
-    expect(
-      screen.getByRole('button', { name: `Delete ${mockProducts[0].title}` }),
-    ).toBeDisabled();
+    await user.click(
+      screen.getByRole('button', {
+        name: `Open actions for ${mockProducts[0].title}`,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled();
   });
 });

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -2,12 +2,10 @@ import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { AlertCircle, Copy, Pencil, Trash } from 'lucide-react';
 
+import { ActionMenu, Checkbox } from '@/components';
 import { ROUTES } from '@/constants';
 import { useTheme } from '@/hooks/useTheme';
 import { type Product, PRODUCT_STATUS } from '@/types';
-
-import { Button } from '../Button';
-import { Checkbox } from '../Checkbox';
 
 interface TableProductsProps {
   items: Product[] | [];
@@ -90,31 +88,34 @@ function renderBodyContent(
         <td>{item.price}</td>
         <td>{item.description}</td>
         <td>
-          <Button
-            aria-label={`Delete ${item.title}`}
-            className="bg-transparent text-[#DB162D] hover:bg-transparent disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!isDraft}
-            onClick={() => onDelete(item.id)}
-            title={
-              isDraft ? 'Delete product' : 'Only draft products can be deleted'
-            }
-          >
-            <Trash className="h-[20px] w-[20px]" />
-          </Button>
-          <Button
-            aria-label={`Edit ${item.title}`}
-            className="bg-transparent text-gray-500 hover:bg-transparent hover:text-black"
-            onClick={() => navigate(`${ROUTES.ADMIN_PRODUCTS}/${item.id}`)}
-          >
-            <Pencil />
-          </Button>
-          <Button
-            aria-label={`Duplicate ${item.title}`}
-            className="bg-transparent text-gray-500 hover:text-black"
-            onClick={() => onDuplicate(item.id)}
-          >
-            <Copy />
-          </Button>
+          <div className="flex justify-end pr-2">
+            <ActionMenu
+              triggerAriaLabel={`Open actions for ${item.title}`}
+              actions={[
+                {
+                  label: 'Edit',
+                  icon: <Pencil className="h-[20px] w-[20px]" />,
+                  onClick: () =>
+                    navigate(`${ROUTES.ADMIN_PRODUCTS}/${item.id}`),
+                },
+                {
+                  label: 'Duplicate',
+                  icon: <Copy className="h-[20px] w-[20px]" />,
+                  onClick: () => onDuplicate(item.id),
+                },
+                {
+                  label: 'Delete',
+                  icon: <Trash className="h-[20px] w-[20px]" />,
+                  onClick: () => onDelete(item.id),
+                  variant: 'danger',
+                  disabled: !isDraft,
+                  title: isDraft
+                    ? 'Delete product'
+                    : 'Only draft products can be deleted',
+                },
+              ]}
+            />
+          </div>
         </td>
       </tr>
     );

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -93,17 +93,20 @@ function renderBodyContent(
               triggerAriaLabel={`Open actions for ${item.title}`}
               actions={[
                 {
+                  id: 'edit',
                   label: 'Edit',
                   icon: <Pencil className="h-[20px] w-[20px]" />,
                   onClick: () =>
                     navigate(`${ROUTES.ADMIN_PRODUCTS}/${item.id}`),
                 },
                 {
+                  id: 'duplicate',
                   label: 'Duplicate',
                   icon: <Copy className="h-[20px] w-[20px]" />,
                   onClick: () => onDuplicate(item.id),
                 },
                 {
+                  id: 'delete',
                   label: 'Delete',
                   icon: <Trash className="h-[20px] w-[20px]" />,
                   onClick: () => onDelete(item.id),

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -1,6 +1,6 @@
 import { generatePath, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, Pencil, Trash } from 'lucide-react';
 
 import { ActionMenu, Checkbox, Dropdown } from '@/components';
 import { UserAvatar } from '@/components/UserAvatar';
@@ -201,12 +201,24 @@ export function UsersTable({
                 <td className="relative text-right">
                   <ActionMenu
                     triggerAriaLabel={`Actions for ${getFullName(user)}`}
-                    editAction={() =>
-                      navigate(
-                        generatePath(ROUTES.ADMIN_USER_EDIT, { id: user.id }),
-                      )
-                    }
-                    deleteAction={() => {}}
+                    actions={[
+                      {
+                        label: 'Edit',
+                        icon: <Pencil />,
+                        onClick: () =>
+                          navigate(
+                            generatePath(ROUTES.ADMIN_USER_EDIT, {
+                              id: user.id,
+                            }),
+                          ),
+                      },
+                      {
+                        label: 'Delete',
+                        icon: <Trash />,
+                        onClick: () => {},
+                        variant: 'danger',
+                      },
+                    ]}
                     className={clsx(
                       'right-0 left-auto',
                       shouldOpenUpward ? 'top-auto bottom-10' : 'top-10',

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -203,8 +203,9 @@ export function UsersTable({
                     triggerAriaLabel={`Actions for ${getFullName(user)}`}
                     actions={[
                       {
+                        id: 'edit',
                         label: 'Edit',
-                        icon: <Pencil />,
+                        icon: <Pencil className="h-[20px] w-[20px]" />,
                         onClick: () =>
                           navigate(
                             generatePath(ROUTES.ADMIN_USER_EDIT, {
@@ -213,8 +214,9 @@ export function UsersTable({
                           ),
                       },
                       {
+                        id: 'delete',
                         label: 'Delete',
-                        icon: <Trash />,
+                        icon: <Trash className="h-[20px] w-[20px]" />,
                         onClick: () => {},
                         variant: 'danger',
                       },

--- a/src/pages/Admin/Categories/AdminCategories.test.tsx
+++ b/src/pages/Admin/Categories/AdminCategories.test.tsx
@@ -162,8 +162,9 @@ describe('Page: AdminCategories', () => {
     render(<AdminCategories />);
 
     await user.click(
-      screen.getByRole('button', { name: 'Delete Accessories' }),
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
 
     expect(openConfirmModalMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -213,12 +214,17 @@ describe('Page: AdminCategories', () => {
 
     render(<AdminCategories />);
 
-    await user.click(screen.getByRole('button', { name: 'Edit Accessories' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
+    );
+    await user.click(screen.getByRole('button', { name: /edit/i }));
 
     expect(window.location.pathname).toBe('/admin/categories/edit/parent-2');
   });
 
   it('should execute delete mutation when modal confirm callback is called', async () => {
+    const user = userEvent.setup();
+
     useAdminCategoriesPageMock.mockReturnValue({
       categories: [
         {
@@ -241,9 +247,10 @@ describe('Page: AdminCategories', () => {
 
     render(<AdminCategories />);
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Delete Accessories' }),
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
 
     const modalConfig = openConfirmModalMock.mock.calls[0]?.[0];
 
@@ -255,6 +262,8 @@ describe('Page: AdminCategories', () => {
   });
 
   it('should show delete error message when mutation rejects with Error', async () => {
+    const user = userEvent.setup();
+
     useAdminCategoriesPageMock.mockReturnValue({
       categories: [
         {
@@ -277,9 +286,10 @@ describe('Page: AdminCategories', () => {
 
     render(<AdminCategories />);
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Delete Accessories' }),
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
 
     const modalConfig = openConfirmModalMock.mock.calls.at(-1)?.[0];
 
@@ -294,6 +304,8 @@ describe('Page: AdminCategories', () => {
   });
 
   it('should show fallback delete error message when mutation rejects with non-Error value', async () => {
+    const user = userEvent.setup();
+
     useAdminCategoriesPageMock.mockReturnValue({
       categories: [
         {
@@ -316,9 +328,10 @@ describe('Page: AdminCategories', () => {
 
     render(<AdminCategories />);
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Delete Accessories' }),
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Accessories' }),
     );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
 
     const modalConfig = openConfirmModalMock.mock.calls.at(-1)?.[0];
 


### PR DESCRIPTION
- replaced separate product action buttons with shared ActionMenu
- refactored ActionMenu to use a reusable actions array API
- added support for configurable action items, disabled states, danger styling, and separators
- preserved delete restriction for non-draft products
- updated related usages and tests