### PR TITLE
fix(315): handle deleted cart products

### DIFF
--- a/src/pages/Cart/Cart.test.tsx
+++ b/src/pages/Cart/Cart.test.tsx
@@ -7,6 +7,14 @@ import { useCartStore } from '@/store/useCartStore';
 
 import { Cart } from './Cart';
 
+vi.mock('@apollo/client/react', () => ({
+  useQuery: vi.fn(() => ({
+    data: null,
+    loading: false,
+    error: null,
+  })),
+}));
+
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -33,6 +41,7 @@ vi.mock('@/hooks/useTheme', () => ({
 const mockUpdateQuantity = vi.fn();
 const mockRemoveItem = vi.fn();
 const mockGetCartTotal = vi.fn(() => 100);
+const mockValidateCart = vi.fn(() => false);
 
 vi.mock('@/store/useCartStore', () => ({
   useCartStore: vi.fn(),
@@ -48,6 +57,7 @@ describe('Cart Page', () => {
       updateQuantity: mockUpdateQuantity,
       removeItem: mockRemoveItem,
       getCartTotal: mockGetCartTotal,
+      validateCart: mockValidateCart,
     });
   });
 
@@ -69,6 +79,7 @@ describe('Cart Page', () => {
       updateQuantity: mockUpdateQuantity,
       removeItem: mockRemoveItem,
       getCartTotal: mockGetCartTotal,
+      validateCart: mockValidateCart,
     });
   };
 
@@ -165,6 +176,7 @@ describe('Cart Page', () => {
       updateQuantity: mockUpdateQuantity,
       removeItem: mockRemoveItem,
       getCartTotal: mockGetCartTotal,
+      validateCart: mockValidateCart,
     });
 
     render(

--- a/src/pages/Cart/Cart.tsx
+++ b/src/pages/Cart/Cart.tsx
@@ -1,19 +1,55 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@apollo/client/react';
 import clsx from 'clsx';
-import { Minus, Plus, Ticket, X } from 'lucide-react';
+import { AlertCircle, Minus, Plus, Ticket, X } from 'lucide-react';
 
 import { Button, Input } from '@/components';
 import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
+import { GET_PRODUCTS_PAGE } from '@/services/graphql/productAdminService';
 import { useCartStore } from '@/store/useCartStore';
+import type { Product } from '@/types/product.types';
+
+interface ProductsPageData {
+  productsPage: {
+    items: Product[];
+    total: number;
+    totalPages: number;
+    page: number;
+    limit: number;
+  };
+}
 
 export const Cart = () => {
-  const { items, updateQuantity, removeItem, getCartTotal } = useCartStore();
+  const { items, updateQuantity, removeItem, getCartTotal, validateCart } =
+    useCartStore();
   const { isAuth } = useAuth();
   const { isDark } = useTheme();
   const navigate = useNavigate();
+
+  const [showWarning, setShowWarning] = useState(false);
+
+  const { data } = useQuery<ProductsPageData>(GET_PRODUCTS_PAGE, {
+    variables: {
+      limit: 100,
+      page: 1,
+    },
+    skip: items.length === 0,
+  });
+
+  useEffect(() => {
+    if (data?.productsPage?.items && items.length > 0) {
+      const wasCleaned = validateCart(data.productsPage.items);
+
+      if (wasCleaned) {
+        setTimeout(() => {
+          setShowWarning(true);
+        }, 0);
+      }
+    }
+  }, [data, validateCart]);
 
   const [shippingOption, setShippingOption] = useState<
     'free' | 'express' | 'pickup'
@@ -147,6 +183,34 @@ export const Cart = () => {
         </div>
       </div>
 
+      {showWarning && (
+        <div
+          className={clsx(
+            'animate-in fade-in slide-in-from-top-2 mb-8 flex items-center justify-between rounded-xl border p-4 text-sm transition-all',
+            isDark
+              ? 'border-neutral-800 bg-neutral-900 text-red-600'
+              : 'bg-backgroundSec border-fieldBorder text-red-600',
+          )}
+        >
+          <div className="flex items-center gap-3">
+            <AlertCircle className="h-5 w-5 text-red-600" />
+            <p className="font-medium text-red-600">
+              Some items were no longer available and have been removed from
+              your cart.
+            </p>
+          </div>
+
+          <button
+            onClick={() => setShowWarning(false)}
+            className={clsx(
+              'rounded-full border-none bg-transparent p-2 shadow-none transition-colors outline-none',
+              isDark ? 'hover:bg-neutral-800' : 'hover:bg-gray-200',
+            )}
+          >
+            <X className="h-4 w-4 text-gray-600" />
+          </button>
+        </div>
+      )}
       <div className="grid gap-8 lg:grid-cols-12">
         <div className="lg:col-span-8">
           <div

--- a/src/store/useCartStore.ts
+++ b/src/store/useCartStore.ts
@@ -15,6 +15,7 @@ interface CartState {
   setCart: (items: CartItem[]) => void;
   clearCart: () => void;
   getCartTotal: () => number;
+  validateCart: (serverProducts: Product[]) => boolean;
 }
 
 export const useCartStore = create<CartState>()(
@@ -90,7 +91,26 @@ export const useCartStore = create<CartState>()(
           0,
         );
       },
+
+      validateCart: (serverProducts: Product[]) => {
+        const currentItems = get().items;
+
+        const serverIds = new Set(serverProducts.map((p) => p.id || p._id));
+
+        const validItems = currentItems.filter((item) => {
+          const id = item.product.id || item.product._id;
+          return serverIds.has(id);
+        });
+
+        if (validItems.length !== currentItems.length) {
+          set({ items: validItems });
+          return true;
+        }
+
+        return false;
+      },
     }),
+
     {
       name: 'cart-storage',
       partialize: (state) => ({ items: state.items }),


### PR DESCRIPTION
I added a cart validation mechanism that syncs local items with the server. If a product is no longer in the database, it is automatically removed from the cart, and a UI warning alert is displayed to the user.

Added a validateCart function to filter out non-existent products by comparing local IDs with server data.

Implemented a theme-aware Alert notification using Lucide React icons and Tailwind CSS.

Updated Cart.test.tsx by mocking the Apollo useQuery hook 