### PR TITLE
fix(338): prevent search flicker on /shop with opacity fade

### DIFF
--- a/src/components/ProductsGrid/ProductsGrid.tsx
+++ b/src/components/ProductsGrid/ProductsGrid.tsx
@@ -79,7 +79,7 @@ export const ProductsGrid: React.FC<ProductGridProps> = ({
 
   return (
     <div
-      className={`grid gap-4 pb-12 transition-opacity duration-300 sm:gap-5 lg:gap-6 ${isLoading ? 'opacity-50' : 'opacity-100'} ${gridClass}`}
+      className={`grid gap-4 pb-12 transition-opacity duration-500 sm:gap-5 lg:gap-6 ${isLoading ? 'opacity-50' : 'opacity-100'} ${gridClass}`}
     >
       {products.map((product) => {
         const key = product._id || product.id;

--- a/src/components/ProductsGrid/ProductsGrid.tsx
+++ b/src/components/ProductsGrid/ProductsGrid.tsx
@@ -23,7 +23,7 @@ export const ProductsGrid: React.FC<ProductGridProps> = ({
     list: 'grid-cols-2',
   }[viewType];
 
-  if (isLoading) {
+  if (isLoading && (!products || products.length === 0)) {
     return (
       <div className="w-full">
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-5 lg:grid-cols-4 lg:gap-6">
@@ -78,7 +78,9 @@ export const ProductsGrid: React.FC<ProductGridProps> = ({
   }
 
   return (
-    <div className={`grid gap-4 pb-12 sm:gap-5 lg:gap-6 ${gridClass}`}>
+    <div
+      className={`grid gap-4 pb-12 transition-opacity duration-300 sm:gap-5 lg:gap-6 ${isLoading ? 'opacity-50' : 'opacity-100'} ${gridClass}`}
+    >
       {products.map((product) => {
         const key = product._id || product.id;
         return viewType === 'list' ? (

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { productService } from '../services/productService';
 
@@ -32,5 +32,6 @@ export const useProducts = (
         minPrice,
         maxPrice,
       ),
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/pages/Products/Products.tsx
+++ b/src/pages/Products/Products.tsx
@@ -57,7 +57,7 @@ export const Products = () => {
     normalizeInvalidPageParam();
   }, [normalizeInvalidPageParam]);
 
-  const { data, isLoading, isError } = useProducts(
+  const { data, isLoading, isFetching, isError } = useProducts(
     currentPage,
     limit,
     sort,
@@ -90,9 +90,6 @@ export const Products = () => {
       params.set('page', '1');
     });
   };
-
-  if (isLoading)
-    return <div className="p-8 text-center text-gray-500">Loading...</div>;
 
   if (isError)
     return (
@@ -127,17 +124,23 @@ export const Products = () => {
         </div>
       </div>
 
-      {!data?.items?.length ? (
-        <div className="p-8 text-center text-gray-500">No products found.</div>
-      ) : (
+      {isLoading || isFetching || data?.items?.length ? (
         <>
-          <ProductsGrid products={data.items} viewType={viewType} />
-          <Pagination
-            currentPage={currentPage}
-            totalPages={data.totalPages || 1}
-            onPageChange={handlePageChange}
+          <ProductsGrid
+            products={data?.items ?? []}
+            viewType={viewType}
+            isLoading={isLoading || isFetching}
           />
+          {data && (
+            <Pagination
+              currentPage={currentPage}
+              totalPages={data.totalPages || 1}
+              onPageChange={handlePageChange}
+            />
+          )}
         </>
+      ) : (
+        <div className="p-8 text-center text-gray-500">No products found.</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `placeholderData: keepPreviousData` to `useProducts` so `isLoading` stays `false` on re-fetch
- Replace full-page loading state with `isFetching` passed to `ProductsGrid`
- Show skeleton only on first load (no data); on subsequent searches — fade existing products with `opacity-50 → opacity-100` transition (500ms)

Closes UA-5399-React/docs#338