### PR TITLE
feat(286): delete user

### DIFF
--- a/src/components/UsersTable/UsersTable.test.tsx
+++ b/src/components/UsersTable/UsersTable.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { mockUsers } from '@/constants/mockUsers';
 
@@ -10,6 +10,21 @@ vi.mock('@/hooks/useUpdateAdminUser', () => ({
   useUpdateAdminUser: () => ({
     handleUpdate: vi.fn(),
     isUpdating: false,
+  }),
+}));
+
+const mockDeleteUser = vi.fn();
+vi.mock('@/hooks/useDeleteAdminUser', () => ({
+  useDeleteAdminUser: () => ({
+    deleteUser: mockDeleteUser,
+    loading: false,
+  }),
+}));
+
+const mockOpenConfirmModal = vi.fn();
+vi.mock('@/hooks/useConfirmModal', () => ({
+  useConfirmModal: () => ({
+    openConfirmModal: mockOpenConfirmModal,
   }),
 }));
 
@@ -36,6 +51,10 @@ describe('UsersTable', () => {
       </MemoryRouter>,
     );
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders "No users found" when list is empty', () => {
     renderTable([]);
     expect(screen.getByText(/no users found/i)).toBeInTheDocument();
@@ -50,7 +69,7 @@ describe('UsersTable', () => {
     expect(screen.getByText(firstUser.email)).toBeInTheDocument();
   });
 
-  it('opens action menu and interacts with buttons', () => {
+  it('opens action menu and interacts with buttons', async () => {
     renderTable();
     const firstUser = mockUsers[0];
     const menuBtn = screen.getByLabelText(
@@ -58,7 +77,22 @@ describe('UsersTable', () => {
     );
     fireEvent.click(menuBtn);
     expect(screen.getByText(/edit/i)).toBeInTheDocument();
-    expect(screen.getByText(/delete/i)).toBeInTheDocument();
+
+    const deleteBtn = screen.getByText(/delete/i);
+    expect(deleteBtn).toBeInTheDocument();
+
+    fireEvent.click(deleteBtn);
+    expect(mockOpenConfirmModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete User',
+        isCritical: true,
+      }),
+    );
+
+    // Call the onConfirm callback to verify it triggers deleteUser
+    const confirmModalArg = mockOpenConfirmModal.mock.calls[0][0];
+    confirmModalArg.onConfirm();
+    expect(mockDeleteUser).toHaveBeenCalledWith(firstUser.id);
   });
 
   it('renders dropdowns for status and role', () => {

--- a/src/components/UsersTable/UsersTable.tsx
+++ b/src/components/UsersTable/UsersTable.tsx
@@ -9,6 +9,8 @@ import {
   USER_ROLE_EDIT_OPTIONS,
   USER_STATUS_EDIT_OPTIONS,
 } from '@/constants/adminUsers';
+import { useConfirmModal } from '@/hooks/useConfirmModal';
+import { useDeleteAdminUser } from '@/hooks/useDeleteAdminUser';
 import { useUpdateAdminUser } from '@/hooks/useUpdateAdminUser';
 import type {
   AdminUser,
@@ -52,6 +54,8 @@ export function UsersTable({
 }: UsersTableProps) {
   const navigate = useNavigate();
   const { handleUpdate, isUpdating } = useUpdateAdminUser();
+  const { deleteUser, loading: isDeleting } = useDeleteAdminUser();
+  const { openConfirmModal } = useConfirmModal();
 
   const handleStatusChange = async (
     userId: string,
@@ -71,6 +75,16 @@ export function UsersTable({
     if (newValue && newValue !== 'all') {
       await handleUpdate(userId, { role: newValue as UserRoleValue });
     }
+  };
+
+  const handleDeleteUser = (id: string) => {
+    openConfirmModal({
+      title: 'Delete User',
+      description: 'Are you sure you want to delete this user?',
+      isCritical: true,
+      confirmText: 'Delete',
+      onConfirm: () => deleteUser(id),
+    });
   };
 
   if (!items.length) {
@@ -120,7 +134,7 @@ export function UsersTable({
         <tbody
           className={clsx(
             'bg-neutral-0 dark:bg-backgroundSec [&_td]:px-4 [&_td]:py-5 [&_td]:text-left',
-            isUpdating && 'pointer-events-none opacity-50',
+            (isUpdating || isDeleting) && 'pointer-events-none opacity-50',
           )}
         >
           {items.map((user, index) => {
@@ -217,7 +231,7 @@ export function UsersTable({
                         id: 'delete',
                         label: 'Delete',
                         icon: <Trash className="h-[20px] w-[20px]" />,
-                        onClick: () => {},
+                        onClick: () => handleDeleteUser(user.id),
                         variant: 'danger',
                       },
                     ]}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,7 @@ export * from './useCheckout';
 export * from './useCreateAdminCategory';
 export * from './useCreateAdminUser';
 export * from './useDeleteAdminCategory';
+export * from './useDeleteAdminUser';
 export * from './useGetAdminCategory';
 export * from './useGetAdminUser';
 export * from './useLocalStorage';

--- a/src/hooks/useDeleteAdminUser.test.ts
+++ b/src/hooks/useDeleteAdminUser.test.ts
@@ -1,0 +1,76 @@
+import * as ApolloClient from '@apollo/client/react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DELETE_USER } from '@/services/graphql/userAdminService';
+
+import { useDeleteAdminUser } from './useDeleteAdminUser';
+
+vi.mock('@apollo/client/react', () => ({
+  useMutation: vi.fn(),
+}));
+
+describe('useDeleteAdminUser', () => {
+  const deleteUserMutationMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('configures mutation with active refetch options', () => {
+    vi.mocked(ApolloClient.useMutation).mockReturnValue([
+      deleteUserMutationMock,
+      { data: undefined, loading: false, error: undefined },
+    ] as unknown as ReturnType<typeof ApolloClient.useMutation>);
+
+    renderHook(() => useDeleteAdminUser());
+
+    expect(ApolloClient.useMutation).toHaveBeenCalledWith(DELETE_USER, {
+      refetchQueries: 'active',
+      awaitRefetchQueries: true,
+    });
+  });
+
+  it('calls delete mutation with id variable', async () => {
+    const mutationResponse = { data: { deleteUser: true } };
+    deleteUserMutationMock.mockResolvedValueOnce(mutationResponse);
+
+    vi.mocked(ApolloClient.useMutation).mockReturnValue([
+      deleteUserMutationMock,
+      {
+        data: mutationResponse.data,
+        loading: false,
+        error: undefined,
+      },
+    ] as unknown as ReturnType<typeof ApolloClient.useMutation>);
+
+    const { result } = renderHook(() => useDeleteAdminUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.deleteUser('USER-123');
+    });
+
+    expect(deleteUserMutationMock).toHaveBeenCalledWith({
+      variables: { id: 'USER-123' },
+    });
+    expect(response).toEqual(mutationResponse);
+    expect(result.current.data).toEqual(mutationResponse.data);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('exposes loading and error from mutation state', () => {
+    const apolloError = new Error('Delete failed');
+
+    vi.mocked(ApolloClient.useMutation).mockReturnValue([
+      deleteUserMutationMock,
+      { data: undefined, loading: true, error: apolloError },
+    ] as unknown as ReturnType<typeof ApolloClient.useMutation>);
+
+    const { result } = renderHook(() => useDeleteAdminUser());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBe(apolloError);
+  });
+});

--- a/src/hooks/useDeleteAdminUser.ts
+++ b/src/hooks/useDeleteAdminUser.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@apollo/client/react';
+
+import { DELETE_USER } from '@/services/graphql/userAdminService';
+
+export function useDeleteAdminUser() {
+  const [deleteUserMutation, { data, loading, error }] = useMutation(
+    DELETE_USER,
+    {
+      refetchQueries: 'active',
+      awaitRefetchQueries: true,
+    },
+  );
+
+  const deleteUser = async (id: string) => {
+    return deleteUserMutation({
+      variables: { id },
+    });
+  };
+
+  return { deleteUser, data, loading, error };
+}

--- a/src/services/graphql/userAdminService.ts
+++ b/src/services/graphql/userAdminService.ts
@@ -58,3 +58,9 @@ export const GET_USERS_LIST = gql`
   }
   ${USER_ADMIN_FIELDS}
 `;
+
+export const DELETE_USER = gql`
+  mutation DeleteUser($id: ID!) {
+    deleteUser(id: $id)
+  }
+`;


### PR DESCRIPTION
- Added the corresponding `DELETE_USER` GraphQL mutation to `src/services/graphql/userAdminService.ts.`
- Created the custom `useDeleteAdminUser` hook (with its unit test `useDeleteAdminUser.test.ts`).
- Updated the `UsersTable` component to handle the Delete action, which importantly first triggers a critical warning confirmation modal asking if they "Are you sure you want to delete this user?" before executing the backend action.
- Updated the tests of `UsersTable` so we also confirm that the newly implemented behaviour with confirm modals integrates and responds as expected.