### PR TITLE
fix(373): render product thumbnail in admin table

### DIFF
--- a/src/components/TableProducts/TableProducts.test.tsx
+++ b/src/components/TableProducts/TableProducts.test.tsx
@@ -214,6 +214,35 @@ describe('UI Component: TableProducts', () => {
     );
   });
 
+  it('should render product thumbnail image when imageUrl is provided', () => {
+    render(
+      <TableProducts
+        items={[mockProducts[0]]}
+        loading={false}
+        onDelete={mockDelete}
+        onDuplicate={mockDuplicate}
+      />,
+    );
+    const img = screen.getByRole('img', { name: mockProducts[0].title });
+    expect(img).toHaveAttribute('src', mockProducts[0].imageUrl);
+  });
+
+  it('should render a placeholder div when imageUrl is not provided', () => {
+    const productWithoutImage: Product = {
+      ...mockProducts[0],
+      imageUrl: undefined,
+    };
+    render(
+      <TableProducts
+        items={[productWithoutImage]}
+        loading={false}
+        onDelete={mockDelete}
+        onDuplicate={mockDuplicate}
+      />,
+    );
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
   it('should disable delete action for non-draft products', async () => {
     const user = userEvent.setup();
 

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -80,7 +80,15 @@ function renderBodyContent(
         <td>
           <div className="flex items-center gap-2">
             <Checkbox className="h-[20px] w-[20px]" />
-            <span>Image</span>
+            {item.imageUrl ? (
+              <img
+                src={item.imageUrl}
+                alt={item.title}
+                className="h-10 w-10 rounded object-cover"
+              />
+            ) : (
+              <div className="h-10 w-10 rounded bg-gray-100" />
+            )}
           </div>
         </td>
         <td>{item.title}</td>

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -28,6 +28,7 @@ export const GET_PRODUCTS_PAGE = gql`
         status
         description
         categories
+        imageUrl
         createdAt
         updatedAt
       }


### PR DESCRIPTION
## Summary

Admin products table was showing a hardcoded `Image` text string in every product row instead of the actual product thumbnail.

## Details

- **`TableProducts.tsx`** — replaced the hardcoded `<span>Image</span>` with conditional rendering: shows an `<img>` tag when `imageUrl` is present, or a gray placeholder `<div>` when it is not
- **`productAdminService.ts`** — added `imageUrl` to the `GET_PRODUCTS_PAGE` GraphQL query fields so the field is actually fetched from the API
- **`TableProducts.test.tsx`** — added 2 tests: thumbnail renders with correct `src` when `imageUrl` is provided; no `<img>` is rendered when `imageUrl` is absent

Closes UA-5399-React/docs#373