### PR TITLE
feat(371): add name field for registration

### DIFF
--- a/src/components/RegisterForm/RegisterForm.test.tsx
+++ b/src/components/RegisterForm/RegisterForm.test.tsx
@@ -35,6 +35,7 @@ describe('Feature: RegisterForm', () => {
   it('should display all required form fields and submit button', () => {
     render(<RegisterForm />);
 
+    expect(screen.getByPlaceholderText(/First name/i)).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText(/Your email address/i),
     ).toBeInTheDocument();
@@ -55,6 +56,9 @@ describe('Feature: RegisterForm', () => {
 
     await user.click(screen.getByRole('button', { name: 'Sign Up' }));
 
+    expect(
+      await screen.findByText('First name is required'),
+    ).toBeInTheDocument();
     expect(await screen.findByText('Email is required')).toBeInTheDocument();
     expect(
       await screen.findByText(
@@ -81,6 +85,7 @@ describe('Feature: RegisterForm', () => {
 
     render(<RegisterForm />);
 
+    await user.type(screen.getByPlaceholderText(/First name/i), 'John');
     await user.type(
       screen.getByPlaceholderText(/Your email address/i),
       'newuser@test.com',
@@ -95,6 +100,7 @@ describe('Feature: RegisterForm', () => {
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
+        firstName: 'John',
         email: 'newuser@test.com',
         password: 'Password1!',
         passwordConfirmation: 'Password1!',
@@ -118,6 +124,7 @@ describe('Feature: RegisterForm', () => {
 
     const emailInput = screen.getByPlaceholderText(/Your email address/i);
 
+    await user.type(screen.getByPlaceholderText(/First name/i), 'John');
     await user.type(emailInput, 'newuser@test.com');
     await user.type(screen.getByPlaceholderText(/^Password$/i), 'Password1!');
     await user.type(

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -12,6 +12,11 @@ import { authService } from '@/services/authService';
 
 const registerSchema = z
   .object({
+    firstName: z
+      .string()
+      .trim()
+      .min(1, 'First name is required')
+      .max(50, 'First name must be at most 50 characters'),
     email: z.string().min(1, 'Email is required').email('Invalid email format'),
     password: z
       .string()
@@ -53,6 +58,7 @@ export const RegisterForm: React.FC = () => {
   } = useForm<RegisterFormValues>({
     resolver: zodResolver(registerSchema),
     defaultValues: {
+      firstName: '',
       email: '',
       password: '',
       confirmPassword: '',
@@ -63,6 +69,7 @@ export const RegisterForm: React.FC = () => {
   const onSubmit = async (data: RegisterFormValues) => {
     try {
       await registerMutation({
+        firstName: data.firstName,
         email: data.email,
         password: data.password,
         passwordConfirmation: data.confirmPassword,
@@ -149,6 +156,17 @@ export const RegisterForm: React.FC = () => {
             </span>
             <span className="bg-fieldBorder/80 h-px flex-1" />
           </div>
+
+          <Input
+            {...register('firstName')}
+            type="text"
+            variant="underlined"
+            placeholder="First name"
+            autoComplete="given-name"
+            state={errors.firstName ? 'error' : 'default'}
+            helperText={errors.firstName?.message}
+            className="pb-2"
+          />
 
           <Input
             {...register('email')}

--- a/src/pages/Auth/EmailConfirmationPage.test.tsx
+++ b/src/pages/Auth/EmailConfirmationPage.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { authService } from '@/services/authService';
@@ -24,7 +25,11 @@ describe('Page: EmailConfirmationPage', () => {
 
     window.history.pushState({}, '', '/email-confirmation?token=valid-token');
 
-    render(<EmailConfirmationPage />);
+    render(
+      <StrictMode>
+        <EmailConfirmationPage />
+      </StrictMode>,
+    );
 
     expect(await screen.findByText('Email confirmed')).toBeInTheDocument();
     expect(
@@ -35,6 +40,7 @@ describe('Page: EmailConfirmationPage', () => {
     ).toBeInTheDocument();
 
     expect(authService.confirmEmail).toHaveBeenCalledWith('valid-token');
+    expect(authService.confirmEmail).toHaveBeenCalledTimes(1);
   });
 
   it('should render error state when confirmation fails', async () => {

--- a/src/pages/Auth/EmailConfirmationPage.tsx
+++ b/src/pages/Auth/EmailConfirmationPage.tsx
@@ -7,52 +7,81 @@ import { authService } from '@/services/authService';
 const DEFAULT_ERROR_MESSAGE =
   'We could not confirm your email. Please try the link again or request a new confirmation email later.';
 
+type ConfirmationState = {
+  message: string | null;
+  status: 'loading' | 'success' | 'error';
+  token: string | null;
+};
+
 export const EmailConfirmationPage = () => {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
-  const hasStartedRef = useRef(false);
-  const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
-    'loading',
-  );
-  const [message, setMessage] = useState<string | null>(null);
+  const mountedRef = useRef(false);
+  const startedTokenRef = useRef<string | null>(null);
+  const activeTokenRef = useRef<string | null>(null);
+  const [confirmation, setConfirmation] = useState<ConfirmationState>({
+    message: null,
+    status: 'loading',
+    token: null,
+  });
   const isTokenMissing = !token;
-  const resolvedStatus = isTokenMissing ? 'error' : status;
+  const resolvedStatus = isTokenMissing
+    ? 'error'
+    : confirmation.token === token
+      ? confirmation.status
+      : 'loading';
   const resolvedMessage = isTokenMissing
     ? 'Confirmation token is missing.'
-    : message;
+    : confirmation.token === token
+      ? confirmation.message
+      : null;
 
   useEffect(() => {
-    if (isTokenMissing || hasStartedRef.current) {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isTokenMissing) {
+      activeTokenRef.current = null;
       return;
     }
 
-    hasStartedRef.current = true;
-    let isActive = true;
+    if (startedTokenRef.current === token) {
+      return;
+    }
+
+    startedTokenRef.current = token;
+    activeTokenRef.current = token;
 
     authService
       .confirmEmail(token)
       .then((response) => {
-        if (!isActive) {
+        if (!mountedRef.current || activeTokenRef.current !== token) {
           return;
         }
 
-        setStatus('success');
-        setMessage(response.message);
+        setConfirmation({
+          message: response.message,
+          status: 'success',
+          token,
+        });
       })
       .catch((error: unknown) => {
-        if (!isActive) {
+        if (!mountedRef.current || activeTokenRef.current !== token) {
           return;
         }
 
-        setStatus('error');
-        setMessage(
-          error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE,
-        );
+        setConfirmation({
+          message:
+            error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE,
+          status: 'error',
+          token,
+        });
       });
-
-    return () => {
-      isActive = false;
-    };
   }, [isTokenMissing, token]);
 
   const isLoading = resolvedStatus === 'loading';

--- a/src/services/authService.test.tsx
+++ b/src/services/authService.test.tsx
@@ -83,6 +83,7 @@ describe('Service: authService', () => {
 
   describe('register()', () => {
     const mockPayload: RegisterPayload = {
+      firstName: 'John',
       email: 'newuser@test.com',
       password: 'Password1!',
       passwordConfirmation: 'Password1!',

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -6,6 +6,7 @@ export interface LoginPayload {
 }
 
 export interface RegisterPayload {
+  firstName: string;
   email: string;
   password: string;
   passwordConfirmation: string;


### PR DESCRIPTION
Added first name to registration.

- Added required `First name` field with max length validation.
- Sent `firstName` in the register payload.
- Updated related form and auth service tests.
- Fixed email confirmation page loading state under `React.StrictMode`.
