### PR TITLE
feat(364): add product import UI with drag-and-drop and result summary

### DIFF
--- a/src/components/ImportProductsModal/ImportProductsModal.test.tsx
+++ b/src/components/ImportProductsModal/ImportProductsModal.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, userEvent } from '@/utils/test-utils';
+
+import { ImportProductsModal } from './ImportProductsModal';
+
+// ── controllable mock state ──────────────────────────────────────────────────
+const mockOnClose = vi.fn();
+const mockImportProducts = vi.fn();
+const mockReset = vi.fn();
+const mockValidateFile = vi.fn();
+
+const hookState: {
+  loading: boolean;
+  error: string | null;
+  result: {
+    imported: number;
+    failed: { row: number; reason: string }[];
+  } | null;
+} = {
+  loading: false,
+  error: null,
+  result: null,
+};
+
+vi.mock('@/hooks/useImportProducts', () => ({
+  useImportProducts: () => ({
+    importProducts: mockImportProducts,
+    loading: hookState.loading,
+    error: hookState.error,
+    result: hookState.result,
+    reset: mockReset,
+    validateFile: mockValidateFile,
+  }),
+}));
+
+vi.mock('@apollo/client/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useApolloClient: () => ({ refetchQueries: vi.fn() }) };
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const resetHookState = () => {
+  hookState.loading = false;
+  hookState.error = null;
+  hookState.result = null;
+};
+
+// ── tests ────────────────────────────────────────────────────────────────────
+describe('UI Component: ImportProductsModal — idle state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetHookState();
+    mockValidateFile.mockReturnValue(null);
+    mockImportProducts.mockResolvedValue(undefined);
+  });
+
+  it('renders the drop zone', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(
+      screen.getByRole('button', { name: /file upload area/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/drag & drop your file here/i)).toBeInTheDocument();
+  });
+
+  it('renders the modal title', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByText('Import Products')).toBeInTheDocument();
+  });
+
+  it('shows accepted formats hint', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByText(/accepted:/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the X button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    await user.click(screen.getByRole('button', { name: /close modal/i }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    await user.click(screen.getByRole('dialog'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a validation error when an invalid file type is selected', () => {
+    mockValidateFile.mockReturnValue('Only .xlsx, .csv files are accepted');
+    render(<ImportProductsModal onClose={mockOnClose} />);
+
+    const file = new File(['content'], 'products.txt', { type: 'text/plain' });
+    const input = screen.getByLabelText(/file input/i);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(
+      screen.getByText(/only .xlsx, .csv files are accepted/i),
+    ).toBeInTheDocument();
+    expect(mockImportProducts).not.toHaveBeenCalled();
+  });
+
+  it('calls importProducts with the selected file when validation passes', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+
+    const file = new File(['a,b'], 'products.csv', { type: 'text/csv' });
+    const input = screen.getByLabelText(/file input/i);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(mockImportProducts).toHaveBeenCalledWith(file);
+  });
+});
+
+describe('UI Component: ImportProductsModal — loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetHookState();
+    hookState.loading = true;
+  });
+
+  it('shows loading spinner text', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByText(/importing/i)).toBeInTheDocument();
+  });
+
+  it('hides the footer buttons while loading', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(
+      screen.queryByRole('button', { name: /cancel/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('UI Component: ImportProductsModal — result state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetHookState();
+    mockReset.mockImplementation(() => resetHookState());
+  });
+
+  it('shows success message when all rows imported', () => {
+    hookState.result = { imported: 5, failed: [] };
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(
+      screen.getByText(/5 products imported successfully/i),
+    ).toBeInTheDocument();
+  });
+
+  it('uses singular "product" when 1 item imported', () => {
+    hookState.result = { imported: 1, failed: [] };
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(
+      screen.getByText(/1 product imported successfully/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows failed rows when partial import', () => {
+    hookState.result = {
+      imported: 2,
+      failed: [
+        { row: 3, reason: 'Missing required field: title' },
+        { row: 5, reason: 'Invalid status "published"' },
+      ],
+    };
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByText(/2 rows had errors/i)).toBeInTheDocument();
+    expect(screen.getByText(/row 3/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Missing required field: title/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows Done button instead of Cancel in result state', () => {
+    hookState.result = { imported: 3, failed: [] };
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^cancel$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls reset when "Import another file" is clicked', async () => {
+    hookState.result = { imported: 1, failed: [] };
+    const user = userEvent.setup();
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    await user.click(
+      screen.getByRole('button', { name: /import another file/i }),
+    );
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('UI Component: ImportProductsModal — error state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetHookState();
+    hookState.error = 'Network failure';
+  });
+
+  it('shows the error alert', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('displays the error message', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(screen.getByText(/network failure/i)).toBeInTheDocument();
+  });
+
+  it('shows "Import another file" button to retry', () => {
+    render(<ImportProductsModal onClose={mockOnClose} />);
+    expect(
+      screen.getByRole('button', { name: /import another file/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ImportProductsModal/ImportProductsModal.tsx
+++ b/src/components/ImportProductsModal/ImportProductsModal.tsx
@@ -1,0 +1,248 @@
+import { useRef, useState } from 'react';
+import clsx from 'clsx';
+import { AlertCircle, CheckCircle2, Loader2, Upload, X } from 'lucide-react';
+
+import { Button } from '@/components/Button';
+import { useImportProducts } from '@/hooks/useImportProducts';
+
+interface ImportProductsModalProps {
+  onClose: () => void;
+}
+
+const ACCEPTED_EXTENSIONS = ['.xlsx', '.csv'];
+
+export function ImportProductsModal({ onClose }: ImportProductsModalProps) {
+  const { importProducts, loading, error, result, reset, validateFile } =
+    useImportProducts();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    if (loading) return;
+    reset();
+    onClose();
+  };
+
+  const handleFile = (file: File) => {
+    const validationError = validateFile(file);
+    if (validationError) {
+      setFileError(validationError);
+      return;
+    }
+    setFileError(null);
+    void importProducts(file);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    // reset input so the same file can be re-selected after reset
+    e.target.value = '';
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => setDragOver(false);
+
+  const handleReset = () => {
+    reset();
+    setFileError(null);
+  };
+
+  const isIdle = !loading && !error && !result;
+  const isLoading = loading;
+  const hasResult = !loading && !error && result !== null;
+  const hasError = !loading && error !== null && result === null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import products"
+    >
+      <div
+        className="flex w-full max-w-[560px] flex-col rounded-lg bg-[rgb(var(--color-bg-sec))] shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+          <h2 className="text-lg font-semibold text-[rgb(var(--color-text))]">
+            Import Products
+          </h2>
+          <button
+            onClick={handleClose}
+            disabled={isLoading}
+            aria-label="Close modal"
+            className="text-muted hover:text-[rgb(var(--color-text))] disabled:opacity-40"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          {/* ── Idle: drop zone ── */}
+          {isIdle && (
+            <>
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label="File upload area"
+                onClick={() => fileInputRef.current?.click()}
+                onKeyDown={(e) =>
+                  e.key === 'Enter' && fileInputRef.current?.click()
+                }
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                className={clsx(
+                  'flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-10 transition-colors',
+                  dragOver
+                    ? 'border-blue-500 bg-blue-500/5'
+                    : 'border-gray-300 bg-gray-50 hover:border-blue-500 hover:bg-blue-500/5',
+                )}
+              >
+                <Upload className="text-muted h-10 w-10" />
+                <div className="text-center">
+                  <p className="font-medium text-[rgb(var(--color-text))]">
+                    Drag &amp; drop your file here
+                  </p>
+                  <p className="text-muted mt-1 text-sm">or click to browse</p>
+                </div>
+                <p className="text-muted text-xs">
+                  Accepted: {ACCEPTED_EXTENSIONS.join(', ')} · Max 10 MB
+                </p>
+              </div>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ACCEPTED_EXTENSIONS.join(',')}
+                className="hidden"
+                onChange={handleInputChange}
+                aria-label="File input"
+              />
+
+              {fileError && (
+                <p
+                  role="alert"
+                  className="mt-3 flex items-center gap-2 text-sm text-red-600"
+                >
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  {fileError}
+                </p>
+              )}
+            </>
+          )}
+
+          {/* ── Loading ── */}
+          {isLoading && (
+            <div className="flex flex-col items-center gap-4 py-6">
+              <Loader2 className="h-10 w-10 animate-spin text-blue-500" />
+              <p className="font-medium text-[rgb(var(--color-text))]">
+                Importing…
+              </p>
+              <p className="text-muted text-sm">
+                Please wait while the file is being processed
+              </p>
+            </div>
+          )}
+
+          {/* ── Error (network / server) ── */}
+          {hasError && (
+            <div
+              role="alert"
+              className="flex items-start gap-3 rounded-lg border border-red-600 bg-red-600/10 p-4 text-red-600"
+            >
+              <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+              <div>
+                <p className="font-medium">Import failed</p>
+                <p className="mt-1 text-sm">{error}</p>
+              </div>
+            </div>
+          )}
+
+          {/* ── Result ── */}
+          {hasResult && result && (
+            <div className="flex flex-col gap-4">
+              {/* Success row */}
+              <div
+                role="status"
+                className="flex items-center gap-3 rounded-lg border border-green-500/30 bg-green-500/10 p-4 text-green-500"
+              >
+                <CheckCircle2 className="h-5 w-5 shrink-0" />
+                <p className="font-medium">
+                  {result.imported}{' '}
+                  {result.imported === 1 ? 'product' : 'products'} imported
+                  successfully
+                </p>
+              </div>
+
+              {/* Failed rows */}
+              {result.failed.length > 0 && (
+                <div className="rounded-lg border border-orange-500/30 bg-orange-500/10 p-4">
+                  <p className="flex items-center gap-2 font-medium text-orange-500">
+                    <AlertCircle className="h-4 w-4 shrink-0" />
+                    {result.failed.length}{' '}
+                    {result.failed.length === 1 ? 'row' : 'rows'} had errors
+                  </p>
+                  <ul
+                    className="mt-3 max-h-[200px] overflow-y-auto"
+                    aria-label="Import errors"
+                  >
+                    {result.failed.map(({ row, reason }) => (
+                      <li
+                        key={row}
+                        className="border-t border-orange-500/20 py-1.5 text-sm text-orange-500 first:border-t-0"
+                      >
+                        <span className="font-mono font-semibold">
+                          Row {row}:
+                        </span>{' '}
+                        {reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {!isLoading && (
+          <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
+            {(hasError || hasResult) && (
+              <Button
+                onClick={handleReset}
+                className="border border-gray-300 bg-transparent text-[rgb(var(--color-text))] hover:border-blue-500 hover:text-blue-500"
+              >
+                Import another file
+              </Button>
+            )}
+            <Button
+              onClick={handleClose}
+              className="bg-blue-800 text-white hover:bg-transparent hover:text-blue-800"
+              variant="primary"
+            >
+              {hasResult ? 'Done' : 'Cancel'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TableProducts/TableProducts.test.tsx
+++ b/src/components/TableProducts/TableProducts.test.tsx
@@ -214,6 +214,35 @@ describe('UI Component: TableProducts', () => {
     );
   });
 
+  it('should render product thumbnail image when imageUrl is provided', () => {
+    render(
+      <TableProducts
+        items={[mockProducts[0]]}
+        loading={false}
+        onDelete={mockDelete}
+        onDuplicate={mockDuplicate}
+      />,
+    );
+    const img = screen.getByRole('img', { name: mockProducts[0].title });
+    expect(img).toHaveAttribute('src', mockProducts[0].imageUrl);
+  });
+
+  it('should render a placeholder div when imageUrl is not provided', () => {
+    const productWithoutImage: Product = {
+      ...mockProducts[0],
+      imageUrl: undefined,
+    };
+    render(
+      <TableProducts
+        items={[productWithoutImage]}
+        loading={false}
+        onDelete={mockDelete}
+        onDuplicate={mockDuplicate}
+      />,
+    );
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
   it('should disable delete action for non-draft products', async () => {
     const user = userEvent.setup();
 

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -80,7 +80,15 @@ function renderBodyContent(
         <td>
           <div className="flex items-center gap-2">
             <Checkbox className="h-[20px] w-[20px]" />
-            <span>Image</span>
+            {item.imageUrl ? (
+              <img
+                src={item.imageUrl}
+                alt={item.title}
+                className="h-10 w-10 rounded object-cover"
+              />
+            ) : (
+              <div className="h-10 w-10 rounded bg-gray-100" />
+            )}
           </div>
         </td>
         <td>{item.title}</td>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { Dropdown } from './Dropdown';
 export { Features } from './Features';
 export { FlyoutCart } from './FlyoutCart';
 export { Header } from './Header';
+export { ImportProductsModal } from './ImportProductsModal/ImportProductsModal';
 export { Input } from './Input';
 export { LoginForm } from './LoginForm/LoginForm';
 export { LogoutButton } from './LogoutButton/LogoutButton';

--- a/src/hooks/useImportProducts.ts
+++ b/src/hooks/useImportProducts.ts
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useApolloClient } from '@apollo/client/react';
+
+import { GET_PRODUCTS_PAGE } from '@/services/graphql/productAdminService';
+import { productsImportService } from '@/services/productsImportService';
+import type { ImportResult } from '@/types/import.types';
+
+const MAX_FILE_SIZE_MB = 10;
+const ACCEPTED_EXTENSIONS = ['.xlsx', '.csv'];
+
+export function useImportProducts() {
+  const client = useApolloClient();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const validateFile = (file: File): string | null => {
+    const ext = '.' + (file.name.split('.').pop()?.toLowerCase() ?? '');
+    if (!ACCEPTED_EXTENSIONS.includes(ext)) {
+      return `Only ${ACCEPTED_EXTENSIONS.join(', ')} files are accepted`;
+    }
+    if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      return `File must be smaller than ${MAX_FILE_SIZE_MB} MB`;
+    }
+    return null;
+  };
+
+  const importProducts = async (file: File): Promise<void> => {
+    const validationError = validateFile(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const data = await productsImportService.importProducts(file);
+      setResult(data);
+      await client.refetchQueries({ include: [GET_PRODUCTS_PAGE] });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Unexpected error during import',
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setLoading(false);
+    setError(null);
+    setResult(null);
+  };
+
+  return { importProducts, loading, error, result, reset, validateFile };
+}

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -5,6 +5,7 @@ import { ListFilter } from 'lucide-react';
 import {
   AdminPageHeader,
   Button,
+  ImportProductsModal,
   Pagination,
   ProductFiltersBar,
   SearchInput,
@@ -39,6 +40,7 @@ export function AdminProducts() {
   } = usePaginationPageParam();
 
   const [showFilters, setShowFilters] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
 
   const debouncedSearch = useDebouncedValue(search.trim(), 500);
   const { duplicateProduct } = useDuplicate();
@@ -101,6 +103,10 @@ export function AdminProducts() {
 
   return (
     <div>
+      {showImportModal && (
+        <ImportProductsModal onClose={() => setShowImportModal(false)} />
+      )}
+
       <AdminPageHeader />
 
       <div className="flex items-center justify-between px-4 pt-6">
@@ -120,6 +126,13 @@ export function AdminProducts() {
             onClick={handleCreateProduct}
           >
             + Add Product
+          </Button>
+
+          <Button
+            className="ml-3 border border-gray-300 bg-transparent text-[rgb(var(--color-text))] hover:border-blue-500 hover:text-blue-500"
+            onClick={() => setShowImportModal(true)}
+          >
+            Import
           </Button>
         </div>
 

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -28,6 +28,7 @@ export const GET_PRODUCTS_PAGE = gql`
         status
         description
         categories
+        imageUrl
         createdAt
         updatedAt
       }

--- a/src/services/productsImportService.ts
+++ b/src/services/productsImportService.ts
@@ -1,0 +1,27 @@
+import { API_BASE_URL } from '@/constants';
+import type { ImportResult } from '@/types/import.types';
+
+export const productsImportService = {
+  async importProducts(file: File): Promise<ImportResult> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(`${API_BASE_URL}/admin/products/import`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorData = await response
+        .json()
+        .catch(() => ({ message: 'Import failed' }));
+      const message = Array.isArray(errorData.message)
+        ? errorData.message[0]
+        : (errorData.message ?? 'Import failed');
+      throw new Error(message);
+    }
+
+    return response.json() as Promise<ImportResult>;
+  },
+};

--- a/src/types/import.types.ts
+++ b/src/types/import.types.ts
@@ -1,0 +1,9 @@
+export interface ImportFailedRow {
+  row: number;
+  reason: string;
+}
+
+export interface ImportResult {
+  imported: number;
+  failed: ImportFailedRow[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './admin-user.types';
 export * from './api.types';
 export * from './category.types';
 export * from './checkout.types';
+export * from './import.types';
 export * from './product.types';
 export * from './shipping.types';
 export * from './table.types';


### PR DESCRIPTION
## Summary

- Added **Import** button to the Admin Products toolbar
- New `ImportProductsModal` component with drag-and-drop file upload (`.xlsx`, `.csv`, max 10 MB)
- Upload progress state with spinner while file is processed
- Result summary: success count in green, per-row error details in amber (scrollable list)
- Inline network error display (red alert) matching existing error patterns
- Full light/dark theme support via CSS custom properties and Tailwind tokens
- Table auto-refreshes via Apollo `refetchQueries` after a successful import

## Details

New files:
- `src/types/import.types.ts` — `ImportResult`, `ImportFailedRow` interfaces
- `src/services/productsImportService.ts` — `POST /admin/products/import` with `multipart/form-data` and `credentials: 'include'`
- `src/hooks/useImportProducts.ts` — loading / error / result state, client-side file validation, Apollo refetch
- `src/components/ImportProductsModal/ImportProductsModal.tsx` — full modal UI (4 states: idle, loading, result, error)
- `src/components/ImportProductsModal/ImportProductsModal.test.tsx` — 18 unit tests covering all states and interactions

Modified:
- `src/components/index.ts` — export `ImportProductsModal`
- `src/types/index.ts` — export `import.types`
- `src/pages/Admin/Products/AdminProducts.tsx` — Import button + modal integration

Closes UA-5399-React/docs#364