### PR TITLE
Feat/368 sortable admin tables

### DIFF
--- a/src/components/TableOrders/TableOrders.test.tsx
+++ b/src/components/TableOrders/TableOrders.test.tsx
@@ -43,6 +43,24 @@ const orderItem: OrderItem = {
 
 const onStatusChange = vi.fn(async () => {});
 const onEdit = vi.fn();
+const onSortChange = vi.fn();
+
+const defaultProps = {
+  items: [] as OrderItem[],
+  loading: false,
+  error: null,
+  sort: null,
+  order: 'desc' as const,
+  onSortChange,
+  onStatusChange,
+  onEdit,
+};
+
+const renderTable = (
+  props: Partial<React.ComponentProps<typeof TableOrders>> = {},
+) => {
+  return render(<TableOrders {...defaultProps} {...props} />);
+};
 
 describe('UI Component: TableOrders', () => {
   beforeEach(() => {
@@ -50,28 +68,13 @@ describe('UI Component: TableOrders', () => {
   });
 
   it('should render the table', () => {
-    render(
-      <TableOrders
-        items={[]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable();
+
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('should render all column headers', () => {
-    render(
-      <TableOrders
-        items={[]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable();
 
     expect(
       screen.getByRole('columnheader', { name: 'Product Name' }),
@@ -83,14 +86,12 @@ describe('UI Component: TableOrders', () => {
       screen.getByRole('columnheader', { name: 'Order ID' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', { name: 'Amount' }),
+      screen.getByRole('button', { name: /total price/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', { name: 'Status' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('columnheader', { name: 'Date' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /date/i })).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', { name: 'Phone' }),
     ).toBeInTheDocument();
@@ -100,29 +101,15 @@ describe('UI Component: TableOrders', () => {
   });
 
   it('should render empty state when there are no orders', () => {
-    render(
-      <TableOrders
-        items={[]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable();
 
     expect(screen.getByText('No orders found')).toBeInTheDocument();
   });
 
   it('should render order row values', () => {
-    render(
-      <TableOrders
-        items={[orderItem]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable({
+      items: [orderItem],
+    });
 
     expect(screen.getByText('Test product')).toBeInTheDocument();
     expect(screen.getByText('Items: 1')).toBeInTheDocument();
@@ -135,16 +122,36 @@ describe('UI Component: TableOrders', () => {
     ).toBeInTheDocument();
   });
 
+  it('should call onSortChange when total price header is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderTable({
+      sort: null,
+    });
+
+    await user.click(screen.getByRole('button', { name: /total price/i }));
+
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+    expect(onSortChange).toHaveBeenCalledWith('totalPrice');
+  });
+
+  it('should call onSortChange when date header is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderTable({
+      sort: null,
+    });
+
+    await user.click(screen.getByRole('button', { name: /date/i }));
+
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+    expect(onSortChange).toHaveBeenCalledWith('createdAt');
+  });
+
   it('should show selected order status in dropdown trigger', () => {
-    render(
-      <TableOrders
-        items={[orderItem]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable({
+      items: [orderItem],
+    });
 
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
       'Processing',
@@ -154,22 +161,17 @@ describe('UI Component: TableOrders', () => {
   it('should open delete confirmation modal', async () => {
     const user = userEvent.setup();
 
-    render(
-      <TableOrders
-        items={[orderItem]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
+    renderTable({
+      items: [orderItem],
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: `Actions for order ${orderItem.orderId}`,
+      }),
     );
 
-    const actionButtons = screen.getAllByRole('button');
-    await user.click(actionButtons[actionButtons.length - 1]);
-
-    expect(screen.getByText('Delete')).toBeInTheDocument();
-
-    await user.click(screen.getByText('Delete'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
 
     expect(
       screen.getByText('Are you sure you want to delete this order?'),
@@ -179,20 +181,17 @@ describe('UI Component: TableOrders', () => {
   it('should call deleteOrder with orderId after confirm', async () => {
     const user = userEvent.setup();
 
-    render(
-      <TableOrders
-        items={[orderItem]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
+    renderTable({
+      items: [orderItem],
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: `Actions for order ${orderItem.orderId}`,
+      }),
     );
 
-    const actionButtons = screen.getAllByRole('button');
-    await user.click(actionButtons[actionButtons.length - 1]);
-
-    await user.click(screen.getByText('Delete'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
     await user.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(deleteOrderMock).toHaveBeenCalledWith(orderItem.orderId);
@@ -201,15 +200,9 @@ describe('UI Component: TableOrders', () => {
   it('should call onStatusChange with orderId and new status when status changes', async () => {
     const user = userEvent.setup();
 
-    render(
-      <TableOrders
-        items={[orderItem]}
-        loading={false}
-        error={null}
-        onStatusChange={onStatusChange}
-        onEdit={onEdit}
-      />,
-    );
+    renderTable({
+      items: [orderItem],
+    });
 
     await user.click(screen.getByRole('combobox', { name: 'Status' }));
     await user.click(screen.getByRole('option', { name: 'Completed' }));
@@ -217,6 +210,7 @@ describe('UI Component: TableOrders', () => {
     await waitFor(() => {
       expect(onStatusChange).toHaveBeenCalledTimes(1);
     });
+
     expect(onStatusChange).toHaveBeenCalledWith(
       orderItem.orderId,
       ORDER_STATUS.COMPLETED,

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import { Pencil, Trash } from 'lucide-react';
 
-import { ActionMenu, ConfirmModal, Dropdown, MainTable } from '@/components';
+import {
+  ActionMenu,
+  ConfirmModal,
+  Dropdown,
+  MainTable,
+  TableSortControl,
+} from '@/components';
+import type { OrdersSortField, SortOrder } from '@/hooks/useAdminOrders';
 import { useDeleteAdminOrder } from '@/hooks/useDeleteAdminOrder';
 import type { Column } from '@/types';
 import {
@@ -12,29 +19,19 @@ import {
 } from '@/types/tableOrders.types';
 import { capitalizeFirst, formatDate } from '@/utils';
 
-import type { DropdownOption } from '../Dropdown/Dropdown.types';
-
 interface TableOrdersProps {
   items: OrderItem[];
   loading: boolean;
   error: Error | null | undefined;
+  sort: OrdersSortField | null;
+  order: SortOrder;
+  onSortChange: (field: OrdersSortField) => void;
   onEdit: (item: OrderItem) => void;
   onStatusChange: (
     orderId: string,
     status: OrderItem['status'],
   ) => Promise<void>;
 }
-
-const columns: Column[] = [
-  { key: 'product', label: 'Product Name', className: '!min-w-[55%]' },
-  { key: 'customer', label: 'Customer name', className: 'min-w-[5%]' },
-  { key: 'orderId', label: 'Order ID', className: 'min-w-[6%]' },
-  { key: 'amount', label: 'Amount', className: 'min-w-[10%]' },
-  { key: 'status', label: 'Status', className: 'min-w-[10%]' },
-  { key: 'date', label: 'Date', className: 'min-w-[10%]' },
-  { key: 'phone', label: 'Phone', className: 'min-w-[15%]' },
-  { key: 'actions', label: 'Actions', className: '' },
-];
 
 const statusOptions = Object.values(ORDER_STATUS).map((status) => ({
   label: capitalizeFirst(status),
@@ -45,6 +42,9 @@ export function TableOrders({
   items,
   loading,
   error,
+  sort,
+  order,
+  onSortChange,
   onStatusChange,
   onEdit,
 }: TableOrdersProps) {
@@ -52,6 +52,41 @@ export function TableOrders({
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+
+  const columns: Column[] = [
+    { key: 'product', label: 'Product Name', className: '!min-w-[55%]' },
+    { key: 'customer', label: 'Customer name', className: 'min-w-[5%]' },
+    { key: 'orderId', label: 'Order ID', className: 'min-w-[6%]' },
+    {
+      key: 'totalPrice',
+      label: (
+        <TableSortControl<OrdersSortField>
+          label="Total Price"
+          field="totalPrice"
+          currentSort={sort as OrdersSortField}
+          currentOrder={order}
+          onSortChange={onSortChange}
+        />
+      ),
+      className: 'min-w-[10%]',
+    },
+    { key: 'status', label: 'Status', className: 'min-w-[10%]' },
+    {
+      key: 'date',
+      label: (
+        <TableSortControl<OrdersSortField>
+          label="Date"
+          field="createdAt"
+          currentSort={sort as OrdersSortField}
+          currentOrder={order}
+          onSortChange={onSortChange}
+        />
+      ),
+      className: 'min-w-[10%]',
+    },
+    { key: 'phone', label: 'Phone', className: 'min-w-[15%]' },
+    { key: 'actions', label: 'Actions', className: '' },
+  ];
 
   const openDeleteModal = (orderId: string) => {
     setSelectedOrderId(orderId);
@@ -65,16 +100,17 @@ export function TableOrders({
 
   const confirmDelete = async () => {
     if (!selectedOrderId) return;
+
     try {
       await deleteOrder(selectedOrderId);
       closeDeleteModal();
-    } catch (error) {
-      console.error('Failed to delete order:', error);
+    } catch (deleteError) {
+      console.error('Failed to delete order:', deleteError);
     }
   };
 
   const renderProductRow = (item: OrderItem) => {
-    const handleStatusSelect = (selected: DropdownOption[]) => {
+    const handleStatusSelect = (selected: { value: string }[]) => {
       const nextStatus = selected[0]?.value as OrderStatus;
       const currentStatus = item.status.toLowerCase();
 

--- a/src/components/TableProducts/TableProducts.test.tsx
+++ b/src/components/TableProducts/TableProducts.test.tsx
@@ -8,6 +8,7 @@ import { TableProducts } from './TableProducts';
 const mockNavigate = vi.fn();
 const mockDuplicate = vi.fn();
 const mockDelete = vi.fn();
+const mockSortChange = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -26,6 +27,8 @@ const mockProducts: Product[] = [
     price: 99,
     description: 'First product',
     imageUrl: 'https://example.com/alpha.jpg',
+    createdAt: '2026-04-07T10:00:00.000Z',
+    purchaseCount: 7,
   },
   {
     id: '2',
@@ -34,8 +37,27 @@ const mockProducts: Product[] = [
     price: 49,
     description: 'Second product',
     imageUrl: 'https://example.com/beta.jpg',
+    createdAt: '2026-04-08T10:00:00.000Z',
+    purchaseCount: 3,
   },
 ];
+
+const defaultProps = {
+  items: [] as Product[],
+  loading: false,
+  error: undefined,
+  sort: 'title' as const,
+  order: 'asc' as const,
+  onSortChange: mockSortChange,
+  onDelete: mockDelete,
+  onDuplicate: mockDuplicate,
+};
+
+const renderTable = (
+  props: Partial<React.ComponentProps<typeof TableProducts>> = {},
+) => {
+  return render(<TableProducts {...defaultProps} {...props} />);
+};
 
 describe('UI Component: TableProducts', () => {
   beforeEach(() => {
@@ -43,164 +65,130 @@ describe('UI Component: TableProducts', () => {
   });
 
   it('should render the table element', () => {
-    render(
-      <TableProducts
-        items={[]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable();
+
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('should render all column headers', () => {
-    render(
-      <TableProducts
-        items={[]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable();
 
     expect(screen.getByText('Image')).toBeInTheDocument();
-    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /name/i })).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Price')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /price/i })).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /created date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /units purchased/i }),
+    ).toBeInTheDocument();
   });
 
   it('should display "Loading..." when loading is true', () => {
-    render(
-      <TableProducts
-        items={[]}
-        loading={true}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      loading: true,
+    });
+
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('should not render product rows when loading', () => {
-    render(
-      <TableProducts
-        items={mockProducts}
-        loading={true}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      items: mockProducts,
+      loading: true,
+    });
+
     expect(screen.queryByText('Product Alpha')).not.toBeInTheDocument();
   });
 
   it('should display the error message when error prop is provided', () => {
     const error = new Error('Network failure');
-    render(
-      <TableProducts
-        items={[]}
-        loading={false}
-        error={error}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+
+    renderTable({
+      error,
+    });
+
     expect(screen.getByText('Failed to load products')).toBeInTheDocument();
     expect(screen.getByText('Network failure')).toBeInTheDocument();
   });
 
   it('should render an alert role row when error is present', () => {
     const error = new Error('Oops');
-    render(
-      <TableProducts
-        items={[]}
-        loading={false}
-        error={error}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+
+    renderTable({
+      error,
+    });
+
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
   it('should not render product rows when error is present', () => {
     const error = new Error('Oops');
-    render(
-      <TableProducts
-        items={mockProducts}
-        loading={false}
-        error={error}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+
+    renderTable({
+      items: mockProducts,
+      error,
+    });
+
     expect(screen.queryByText('Product Alpha')).not.toBeInTheDocument();
   });
 
   it('should display "No products found" when items array is empty', () => {
-    render(
-      <TableProducts
-        items={[]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable();
+
     expect(screen.getByText('No products found')).toBeInTheDocument();
   });
 
   it('should not display "No products found" when items are present', () => {
-    render(
-      <TableProducts
-        items={mockProducts}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      items: mockProducts,
+    });
+
     expect(screen.queryByText('No products found')).not.toBeInTheDocument();
   });
 
   it('should render a row for each product', () => {
-    render(
-      <TableProducts
-        items={mockProducts}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      items: mockProducts,
+    });
+
     expect(screen.getByText('Product Alpha')).toBeInTheDocument();
     expect(screen.getByText('Product Beta')).toBeInTheDocument();
   });
 
-  it('should display product title, status, price, and description', () => {
-    render(
-      <TableProducts
-        items={[mockProducts[0]]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+  it('should display product title, status, price, description, and purchase count', () => {
+    renderTable({
+      items: [mockProducts[0]],
+    });
+
     expect(screen.getByText('Product Alpha')).toBeInTheDocument();
     expect(screen.getByText('active')).toBeInTheDocument();
     expect(screen.getByText('99')).toBeInTheDocument();
     expect(screen.getByText('First product')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('should call onSortChange when sortable header is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderTable({
+      items: mockProducts,
+    });
+
+    await user.click(screen.getByRole('button', { name: /price/i }));
+
+    expect(mockSortChange).toHaveBeenCalledTimes(1);
+    expect(mockSortChange).toHaveBeenCalledWith('price');
   });
 
   it('should navigate to the product edit page when the edit action is clicked', async () => {
     const user = userEvent.setup();
 
-    render(
-      <TableProducts
-        items={[mockProducts[0]]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      items: [mockProducts[0]],
+    });
 
     const triggerButton = screen.getByRole('button', {
       name: `Open actions for ${mockProducts[0].title}`,
@@ -217,14 +205,9 @@ describe('UI Component: TableProducts', () => {
   it('should disable delete action for non-draft products', async () => {
     const user = userEvent.setup();
 
-    render(
-      <TableProducts
-        items={[mockProducts[0]]}
-        loading={false}
-        onDelete={mockDelete}
-        onDuplicate={mockDuplicate}
-      />,
-    );
+    renderTable({
+      items: [mockProducts[0]],
+    });
 
     await user.click(
       screen.getByRole('button', {

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -2,15 +2,20 @@ import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { AlertCircle, Copy, Pencil, Trash } from 'lucide-react';
 
-import { ActionMenu, Checkbox } from '@/components';
+import { ActionMenu, Checkbox, TableSortControl } from '@/components';
 import { ROUTES } from '@/constants';
 import { useTheme } from '@/hooks/useTheme';
 import { type Product, PRODUCT_STATUS } from '@/types';
+import type { ProductSortField, SortOrder } from '@/types/productsSort';
+import { formatDate } from '@/utils';
 
 interface TableProductsProps {
   items: Product[] | [];
   loading: boolean;
   error?: Error | null;
+  sort: ProductSortField;
+  order: SortOrder;
+  onSortChange: (field: ProductSortField) => void;
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
 }
@@ -27,14 +32,15 @@ function renderBodyContent(
   if (loading) {
     return (
       <tr>
-        <td colSpan={6}>Loading...</td>
+        <td colSpan={8}>Loading...</td>
       </tr>
     );
   }
+
   if (error) {
     return (
       <tr role="alert">
-        <td colSpan={6} className="py-8">
+        <td colSpan={8} className="py-8">
           <div
             className={clsx(
               'mx-auto flex max-w-md items-center gap-3 rounded-lg border p-4',
@@ -54,11 +60,12 @@ function renderBodyContent(
       </tr>
     );
   }
+
   if (!items?.length) {
     return (
       <tr>
         <td
-          colSpan={6}
+          colSpan={8}
           className={clsx('py-8 text-center', {
             'text-black': isDark,
             'text-[#8A92A6]': !isDark,
@@ -69,6 +76,7 @@ function renderBodyContent(
       </tr>
     );
   }
+
   return items.map((item: Product) => {
     const isDraft = item.status.toUpperCase() === PRODUCT_STATUS.DRAFT;
 
@@ -83,10 +91,14 @@ function renderBodyContent(
             <span>Image</span>
           </div>
         </td>
+
         <td>{item.title}</td>
         <td>{item.status}</td>
         <td>{item.price}</td>
-        <td>{item.description}</td>
+        <td>{item.description ?? '—'}</td>
+        <td>{item.createdAt ? formatDate(new Date(item.createdAt)) : '—'}</td>
+        <td>{item.purchaseCount ?? 0}</td>
+
         <td>
           <div className="flex justify-end pr-2">
             <ActionMenu
@@ -129,6 +141,9 @@ export function TableProducts({
   items,
   loading,
   error,
+  sort,
+  order,
+  onSortChange,
   onDelete,
   onDuplicate,
 }: TableProductsProps) {
@@ -146,17 +161,56 @@ export function TableProducts({
                 <span>Image</span>
               </div>
             </th>
-            <th>Name</th>
+
+            <th>
+              <TableSortControl
+                label="Name"
+                field="title"
+                currentSort={sort}
+                currentOrder={order}
+                onSortChange={onSortChange}
+              />
+            </th>
+
             <th>Status</th>
-            <th>Price</th>
+
+            <th>
+              <TableSortControl
+                label="Price"
+                field="price"
+                currentSort={sort}
+                currentOrder={order}
+                onSortChange={onSortChange}
+              />
+            </th>
+
             <th>Description</th>
+
+            <th>
+              <TableSortControl
+                label="Created Date"
+                field="createdAt"
+                currentSort={sort}
+                currentOrder={order}
+                onSortChange={onSortChange}
+              />
+            </th>
+
+            <th>
+              <TableSortControl
+                label="Units Purchased"
+                field="purchaseCount"
+                currentSort={sort}
+                currentOrder={order}
+                onSortChange={onSortChange}
+              />
+            </th>
+
             <th></th>
           </tr>
         </thead>
 
-        <tbody
-          className={`bg-[rgb(var(--color-bg-sec))] [&_td]:px-4 [&_td]:text-center`}
-        >
+        <tbody className="bg-[rgb(var(--color-bg-sec))] [&_td]:px-4 [&_td]:text-center">
           {renderBodyContent(
             loading,
             error ?? null,

--- a/src/components/TableSortControl/TableSortControl.test.tsx
+++ b/src/components/TableSortControl/TableSortControl.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TableSortControl } from './TableSortControl';
+
+vi.mock('@/components', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowUp: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="arrow-up" {...props} />
+  ),
+  ArrowDown: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="arrow-down" {...props} />
+  ),
+  ArrowUpDown: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="arrow-up-down" {...props} />
+  ),
+}));
+
+describe('TableSortControl', () => {
+  it('renders label', () => {
+    render(
+      <TableSortControl
+        label="Price"
+        field="price"
+        currentSort="title"
+        currentOrder="asc"
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /price/i })).toBeInTheDocument();
+  });
+
+  it('renders ArrowUpDown when column is not active', () => {
+    render(
+      <TableSortControl
+        label="Price"
+        field="price"
+        currentSort="title"
+        currentOrder="asc"
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('arrow-up-down')).toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-down')).not.toBeInTheDocument();
+  });
+
+  it('renders ArrowUp when active sort is asc', () => {
+    render(
+      <TableSortControl
+        label="Price"
+        field="price"
+        currentSort="price"
+        currentOrder="asc"
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('arrow-up')).toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-down')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-up-down')).not.toBeInTheDocument();
+  });
+
+  it('renders ArrowDown when active sort is desc', () => {
+    render(
+      <TableSortControl
+        label="Price"
+        field="price"
+        currentSort="price"
+        currentOrder="desc"
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('arrow-down')).toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('arrow-up-down')).not.toBeInTheDocument();
+  });
+
+  it('calls onSortChange with field on click', () => {
+    const onSortChange = vi.fn();
+
+    render(
+      <TableSortControl
+        label="Units Purchased"
+        field="purchaseCount"
+        currentSort="title"
+        currentOrder="asc"
+        onSortChange={onSortChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /units purchased/i }));
+
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+    expect(onSortChange).toHaveBeenCalledWith('purchaseCount');
+  });
+});

--- a/src/components/TableSortControl/TableSortControl.tsx
+++ b/src/components/TableSortControl/TableSortControl.tsx
@@ -1,0 +1,46 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+
+import { Button } from '@/components';
+
+type SortOrder = 'asc' | 'desc';
+
+interface TableSortControlProps<T extends string> {
+  label: string;
+  field: T;
+  currentSort: T;
+  currentOrder: SortOrder;
+  onSortChange: (field: T) => void;
+}
+
+export function TableSortControl<T extends string>({
+  label,
+  field,
+  currentSort,
+  currentOrder,
+  onSortChange,
+}: TableSortControlProps<T>) {
+  const renderSortIcon = () => {
+    if (currentSort !== field) {
+      return <ArrowUpDown className="h-4 w-4 opacity-60" strokeWidth={2.5} />;
+    }
+
+    return currentOrder === 'asc' ? (
+      <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+    ) : (
+      <ArrowDown className="h-4 w-4" strokeWidth={2.5} />
+    );
+  };
+
+  return (
+    <Button
+      type="button"
+      onClick={() => onSortChange(field)}
+      className="!h-auto !min-h-0 !rounded-none !border-0 !bg-transparent !p-0 !font-[700] !whitespace-nowrap !text-inherit !shadow-none hover:!border-transparent hover:!bg-transparent"
+    >
+      <span className="inline-flex items-center gap-1 whitespace-nowrap">
+        <span className="font-inherit">{label}</span>
+        {renderSortIcon()}
+      </span>
+    </Button>
+  );
+}

--- a/src/components/TableSortControl/index.ts
+++ b/src/components/TableSortControl/index.ts
@@ -1,0 +1,1 @@
+export { TableSortControl } from './TableSortControl';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,6 +38,7 @@ export { SortRadioItem } from './SortProducts/SortRadioItem/SortRadioItem';
 export { TableCategories } from './TableCategories/TableCategories';
 export { TableOrders } from './TableOrders/TableOrders';
 export { TableProducts } from './TableProducts/TableProducts';
+export { TableSortControl } from './TableSortControl/TableSortControl';
 export { TextArea } from './TextArea';
 export { UserAvatar } from './UserAvatar';
 export { UserForm } from './UserForm/UserForm';

--- a/src/hooks/useAdminOrders.ts
+++ b/src/hooks/useAdminOrders.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client/react';
 
-import { ORDER, PAGE, PAGE_LIMIT, SORT } from '@/constants/general';
+import { PAGE, PAGE_LIMIT } from '@/constants/general';
 import {
   GET_ORDERS,
   UPDATE_ORDER_STATUS,
@@ -11,15 +11,22 @@ import {
   type OrderStatus,
 } from '@/types/tableOrders.types';
 
-export function useAdminOrders(status?: string) {
+export type OrdersSortField = 'createdAt' | 'totalPrice';
+export type SortOrder = 'asc' | 'desc';
+
+export function useAdminOrders(
+  status?: string,
+  sort: OrdersSortField = 'createdAt',
+  order: SortOrder = 'desc',
+) {
   const filter =
     status && status !== ALL_STATUS ? { status: status.toUpperCase() } : {};
 
   const queryVariables = {
     page: PAGE,
     limit: PAGE_LIMIT,
-    sort: SORT,
-    order: ORDER,
+    sort,
+    order,
     filter,
   };
 

--- a/src/pages/Admin/Orders/AdminOrders.tsx
+++ b/src/pages/Admin/Orders/AdminOrders.tsx
@@ -1,24 +1,53 @@
-import { useNavigate } from 'react-router-dom';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Button, OrdersTopWidgets, OrderTabs, TableOrders } from '@/components';
 import { ROUTES } from '@/constants';
 import { DEFAULT_ORDER_STATUS_FILTER } from '@/constants/orders';
-import { useAdminOrders } from '@/hooks/useAdminOrders';
+import {
+  type OrdersSortField,
+  type SortOrder,
+  useAdminOrders,
+} from '@/hooks/useAdminOrders';
 import { useAdminOrdersCounts } from '@/hooks/useAdminOrdersCounts';
 import type { OrderItem } from '@/types/tableOrders.types';
 
+type DisplayOrdersSortField = OrdersSortField | null;
+
+const DEFAULT_SORT_BY: OrdersSortField = 'createdAt';
+const DEFAULT_ORDER: SortOrder = 'desc';
+
 export function AdminOrders() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   const currentStatus =
     searchParams.get('status') || DEFAULT_ORDER_STATUS_FILTER;
 
-  const { orders, loading, error, handleOrderStatusChange } =
-    useAdminOrders(currentStatus);
-  const { counts, loading: countsLoading } = useAdminOrdersCounts();
+  const sortParam = searchParams.get('sortBy');
+  const orderParam = searchParams.get('order');
 
-  const navigate = useNavigate();
+  const currentSort: OrdersSortField =
+    sortParam === 'createdAt' || sortParam === 'totalPrice'
+      ? sortParam
+      : DEFAULT_SORT_BY;
+
+  const currentOrder: SortOrder =
+    orderParam === 'asc' || orderParam === 'desc' ? orderParam : DEFAULT_ORDER;
+
+  const hasExplicitSortInUrl =
+    searchParams.has('sortBy') && searchParams.has('order');
+
+  const displaySort: DisplayOrdersSortField = hasExplicitSortInUrl
+    ? currentSort
+    : null;
+
+  const { orders, loading, error, handleOrderStatusChange } = useAdminOrders(
+    currentStatus,
+    currentSort,
+    currentOrder,
+  );
+
+  const { counts, loading: countsLoading } = useAdminOrdersCounts();
 
   const handleCreateOrder = () => {
     navigate(ROUTES.ADMIN_ORDER_CREATE);
@@ -28,6 +57,17 @@ export function AdminOrders() {
     navigate(ROUTES.ADMIN_ORDER_EDIT.replace(':id', order.orderId), {
       state: { order },
     });
+  };
+
+  const handleSortChange = (field: OrdersSortField) => {
+    const nextOrder: SortOrder =
+      currentSort === field && currentOrder === 'asc' ? 'desc' : 'asc';
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('sortBy', field);
+    nextParams.set('order', nextOrder);
+
+    setSearchParams(nextParams);
   };
 
   return (
@@ -54,6 +94,9 @@ export function AdminOrders() {
         items={orders}
         loading={loading}
         error={error}
+        sort={displaySort}
+        order={currentOrder}
+        onSortChange={handleSortChange}
         onEdit={handleEditOrder}
         onStatusChange={handleOrderStatusChange}
       />

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ListFilter } from 'lucide-react';
 
 import {
@@ -20,11 +20,26 @@ import { useDuplicate } from '@/hooks/useDuplicate';
 import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useAdminProductsStore } from '@/store/useAdminProductsStore';
 import { type ProductsFilters } from '@/types/filters';
-import type { SortValue } from '@/types/productsSort';
+import type {
+  ProductSortField,
+  SortOrder,
+  SortValue,
+} from '@/types/productsSort';
 import { buildSortValue, parseSortValue } from '@/utils/sorting';
+
+const VALID_SORT_FIELDS: ProductSortField[] = [
+  'updatedAt',
+  'createdAt',
+  'price',
+  'title',
+  'purchaseCount',
+];
+
+const VALID_SORT_ORDERS: SortOrder[] = ['asc', 'desc'];
 
 export function AdminProducts() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { openConfirmModal } = useConfirmModal();
 
   const { filters, search, sort, order, setFilters, setSearch, setSort } =
@@ -65,6 +80,40 @@ export function AdminProducts() {
     normalizeOutOfRangePage(totalPages);
   }, [loading, normalizeOutOfRangePage, totalPages]);
 
+  useEffect(() => {
+    const sortBy = searchParams.get('sortBy');
+    const orderParam = searchParams.get('order');
+
+    if (
+      sortBy &&
+      orderParam &&
+      VALID_SORT_FIELDS.includes(sortBy as ProductSortField) &&
+      VALID_SORT_ORDERS.includes(orderParam as SortOrder)
+    ) {
+      if (sort !== sortBy || order !== orderParam) {
+        setSort(sortBy as ProductSortField, orderParam as SortOrder);
+      }
+      return;
+    }
+
+    if (sort !== 'updatedAt' || order !== 'desc') {
+      setSort('updatedAt', 'desc');
+    }
+  }, [searchParams, sort, order, setSort]);
+
+  const updateSortParams = (
+    nextSort: ProductSortField,
+    nextOrder: SortOrder,
+  ) => {
+    const params = new URLSearchParams();
+
+    params.set('page', '1');
+    params.set('sortBy', nextSort);
+    params.set('order', nextOrder);
+
+    setSearchParams(params);
+  };
+
   const handleFiltersChange = (newFilters: ProductsFilters) => {
     setFilters(newFilters);
     resetPage();
@@ -77,8 +126,15 @@ export function AdminProducts() {
 
   const handleSortChange = (value: SortValue) => {
     const nextSort = parseSortValue(value);
-    setSort(nextSort.sort, nextSort.order);
-    resetPage();
+
+    updateSortParams(nextSort.sort, nextSort.order);
+  };
+
+  const handleTableSortChange = (field: ProductSortField) => {
+    const nextOrder: SortOrder =
+      sort === field && order === 'asc' ? 'desc' : 'asc';
+
+    updateSortParams(field, nextOrder);
   };
 
   const handlePageChange = (newPage: number) => {
@@ -144,6 +200,9 @@ export function AdminProducts() {
           items={items}
           loading={loading}
           error={error}
+          sort={sort}
+          order={order}
+          onSortChange={handleTableSortChange}
           onDelete={handleDeleteProduct}
           onDuplicate={duplicateProduct}
         />

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -30,6 +30,7 @@ export const GET_PRODUCTS_PAGE = gql`
         categories
         createdAt
         updatedAt
+        purchaseCount
       }
     }
   }

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -1,3 +1,4 @@
+import type { ProductSortField } from '@/types/productsSort';
 export const PRODUCT_STATUS = {
   ACTIVE: 'ACTIVE',
   INACTIVE: 'INACTIVE',
@@ -18,6 +19,7 @@ export interface Product {
   status: ProductStatus;
   tags?: string[];
   description?: string;
+  purchaseCount?: number;
 
   //it's a workaround to pass build, because there are no fields for createdAt/updatedAt in mock data and storybooks(probably?). Overall these 2 fields should not be optional
   createdAt?: string;
@@ -36,7 +38,7 @@ export interface ProductQueryParams {
   page: number;
   limit: number;
   search?: string;
-  sort?: 'price' | 'title' | 'createdAt';
+  sort?: ProductSortField;
   order?: 'asc' | 'desc';
   category?: string;
   minPrice?: number;

--- a/src/types/productsSort.ts
+++ b/src/types/productsSort.ts
@@ -3,13 +3,15 @@ export const PRODUCT_SORT_FIELDS = {
   CREATED_AT: 'createdAt',
   PRICE: 'price',
   TITLE: 'title',
+  PURCHASE_COUNT: 'purchaseCount',
 } as const;
 
 export type ProductSortField =
   | typeof PRODUCT_SORT_FIELDS.UPDATED_AT
   | typeof PRODUCT_SORT_FIELDS.CREATED_AT
   | typeof PRODUCT_SORT_FIELDS.PRICE
-  | typeof PRODUCT_SORT_FIELDS.TITLE;
+  | typeof PRODUCT_SORT_FIELDS.TITLE
+  | typeof PRODUCT_SORT_FIELDS.PURCHASE_COUNT;
 
 export type SortOrder = 'asc' | 'desc';
 
@@ -20,4 +22,6 @@ export type SortValue =
   | 'price-asc'
   | 'price-desc'
   | 'title-asc'
-  | 'title-desc';
+  | 'title-desc'
+  | 'purchaseCount-asc'
+  | 'purchaseCount-desc';

--- a/src/utils/sorting.test.ts
+++ b/src/utils/sorting.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSortValue, parseSortValue } from './sorting';
+
+describe('sorting utils', () => {
+  describe('buildSortValue', () => {
+    it('should build sort value for purchaseCount asc', () => {
+      expect(buildSortValue('purchaseCount', 'asc')).toBe('purchaseCount-asc');
+    });
+
+    it('should build sort value for purchaseCount desc', () => {
+      expect(buildSortValue('purchaseCount', 'desc')).toBe(
+        'purchaseCount-desc',
+      );
+    });
+
+    it('should build sort value for title desc', () => {
+      expect(buildSortValue('title', 'desc')).toBe('title-desc');
+    });
+
+    it('should return updated-desc as fallback for unsupported combination', () => {
+      expect(buildSortValue('updatedAt', 'asc')).toBe('updated-desc');
+    });
+  });
+
+  describe('parseSortValue', () => {
+    it('should parse purchaseCount-asc', () => {
+      expect(parseSortValue('purchaseCount-asc')).toEqual({
+        sort: 'purchaseCount',
+        order: 'asc',
+      });
+    });
+
+    it('should parse purchaseCount-desc', () => {
+      expect(parseSortValue('purchaseCount-desc')).toEqual({
+        sort: 'purchaseCount',
+        order: 'desc',
+      });
+    });
+
+    it('should parse updated-desc', () => {
+      expect(parseSortValue('updated-desc')).toEqual({
+        sort: 'updatedAt',
+        order: 'desc',
+      });
+    });
+  });
+});

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -4,7 +4,6 @@ import type {
   SortValue,
 } from '@/types/productsSort';
 
-// Builds a string sort value from sort field and order
 export function buildSortValue(
   sort: ProductSortField,
   order: SortOrder,
@@ -15,10 +14,13 @@ export function buildSortValue(
   if (sort === 'price' && order === 'asc') return 'price-asc';
   if (sort === 'price' && order === 'desc') return 'price-desc';
   if (sort === 'title' && order === 'asc') return 'title-asc';
-  return 'title-desc';
+  if (sort === 'title' && order === 'desc') return 'title-desc';
+  if (sort === 'purchaseCount' && order === 'asc') return 'purchaseCount-asc';
+  if (sort === 'purchaseCount' && order === 'desc') return 'purchaseCount-desc';
+
+  return 'updated-desc';
 }
 
-// Parses sort value string into structured sorting parameters
 export function parseSortValue(value: SortValue): {
   sort: ProductSortField;
   order: SortOrder;
@@ -38,5 +40,9 @@ export function parseSortValue(value: SortValue): {
       return { sort: 'title', order: 'asc' };
     case 'title-desc':
       return { sort: 'title', order: 'desc' };
+    case 'purchaseCount-asc':
+      return { sort: 'purchaseCount', order: 'asc' };
+    case 'purchaseCount-desc':
+      return { sort: 'purchaseCount', order: 'desc' };
   }
 }


### PR DESCRIPTION
Implemented sortable headers for Admin Products and Admin Orders tables.

Products
- Added sortable headers for Name, Price, Created Date, and Units Purchased
- Added Units Purchased column using purchaseCount from API
- Synced sort state with URL query params

Orders
- Added sortable headers for Date and Total Price
- Synced sort state with URL 

Added reusable TableSortControl component
Updated related tests