### PR TITLE
feat(390): add admin dashboard with templates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { AdminEditOrder } from './pages/Admin/AdminEditOrder/AdminEditOrder';
 import { AdminCategories } from './pages/Admin/Categories/AdminCategories';
 import { CreateProduct } from './pages/Admin/CreateProduct/CreateProduct';
 import { CreateUser } from './pages/Admin/CreateUser/CreateUser';
+import { Dashboard } from './pages/Admin/Dashboard/Dashboard';
 import { EditCategory } from './pages/Admin/EditCategory/EditCategory';
 import { EditProduct } from './pages/Admin/EditProduct/EditProduct';
 import { EditUser } from './pages/Admin/EditUser/EditUser';
@@ -60,6 +61,7 @@ function App() {
     ADMIN_PRODUCT_EDIT,
     ADMIN_ORDER_CREATE,
     ADMIN_ORDER_EDIT,
+    ADMIN_DASHBOARD,
     LOGIN,
     REGISTER,
     EMAIL_CONFIRMATION,
@@ -118,11 +120,12 @@ function App() {
           }
         >
           <Route path={ADMIN} element={<AdminLayout />}>
-            <Route index element={<Navigate to={ADMIN_PRODUCTS} replace />} />
+            <Route index element={<Navigate to={ADMIN_DASHBOARD} replace />} />
             <Route path={ADMIN_CATEGORIES} element={<AdminCategories />} />
             <Route path={ADMIN_CATEGORY_ADD} element={<AddCategory />} />
             <Route path={ADMIN_CATEGORY_EDIT} element={<EditCategory />} />
             <Route path={ADMIN_PRODUCTS} element={<AdminProducts />} />
+            <Route path={ADMIN_DASHBOARD} element={<Dashboard />} />
             <Route path={ADMIN_PRODUCT_CREATE} element={<CreateProduct />} />
             <Route path={ADMIN_PRODUCT_EDIT} element={<EditProduct />} />
             <Route path={ADMIN_ORDERS} element={<AdminOrders />} />

--- a/src/components/MobileSidebar/MobileSidebar.test.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.test.tsx
@@ -89,6 +89,7 @@ describe('UI Component: MobileSidebar', () => {
     expect(
       screen.getByRole('link', { name: 'Categories' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Products' })).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Settings' }),
@@ -148,9 +149,11 @@ describe('UI Component: MobileSidebar', () => {
   it('should render Products and Categories links with correct hrefs for admin', () => {
     renderWithTheme({ ...defaultProps, isSidebarOpen: true });
 
+    const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
     const categoriesLink = screen.getByRole('link', { name: 'Categories' });
     const productsLink = screen.getByRole('link', { name: 'Products' });
 
+    expect(dashboardLink).toHaveAttribute('href', ROUTES.ADMIN_DASHBOARD);
     expect(categoriesLink).toHaveAttribute('href', ROUTES.ADMIN_CATEGORIES);
     expect(productsLink).toHaveAttribute('href', ROUTES.ADMIN_PRODUCTS);
   });

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { canAccessAdminRoute } from '@/utils/permissions';
 
 const MOBILE_LINKS = [
+  { to: ROUTES.ADMIN_DASHBOARD, label: 'Dashboard' },
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products' },
   { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
   { to: ROUTES.ADMIN_USERS, label: 'Users' },

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -48,6 +48,7 @@ describe('UI Component: Sidebar', () => {
     vi.mocked(useAuth).mockReturnValue(defaultAuthMock);
     renderWithProviders(<Sidebar />);
 
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Categories')).toBeInTheDocument();
     expect(screen.getByText('Products')).toBeInTheDocument();
     expect(screen.queryByText('Users')).not.toBeInTheDocument();
@@ -67,6 +68,7 @@ describe('UI Component: Sidebar', () => {
 
     expect(screen.getByText('Users')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 
   it('should call logout when the user confirms in the modal', async () => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom';
 import {
   ChartBarStacked,
+  LayoutDashboard,
   LogOut,
   PackageIcon,
   SettingsIcon,
@@ -17,6 +18,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { canAccessAdminRoute } from '@/utils/permissions';
 
 const SIDEBAR_LINKS = [
+  { to: ROUTES.ADMIN_DASHBOARD, label: 'Dashboard', icon: <LayoutDashboard /> },
   { to: ROUTES.ADMIN_PRODUCTS, label: 'Products', icon: <PackageIcon /> },
   {
     to: ROUTES.ADMIN_CATEGORIES,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,6 +33,7 @@ export const ROUTES = {
   ADMIN_ORDERS: '/admin/orders',
   ADMIN_ORDER_CREATE: '/admin/orders/create',
   ADMIN_ORDER_EDIT: '/admin/orders/:id',
+  ADMIN_DASHBOARD: '/admin/dashboard',
   PROFILE: '/profile',
   MYORDERS: '/profile/myOrders',
   FORGOT_PASSWORD: '/forgot-password',

--- a/src/pages/Admin/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard/Dashboard.tsx
@@ -1,0 +1,55 @@
+type DashboardCardProps = {
+  title: string;
+  slotName: string;
+  className?: string;
+};
+
+function DashboardCard({ title, className = '' }: DashboardCardProps) {
+  return (
+    <section
+      className={`bg-background rounded-2xl border border-gray-300 p-4 ${className}`}
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <h2 className="text-text text-xs font-bold tracking-[0.08em] uppercase">
+          {title}
+        </h2>
+      </div>
+
+      <div className="bg-backgroundSec flex min-h-48 items-center justify-center rounded-2xl border border-gray-300 px-6 py-8 text-center"></div>
+    </section>
+  );
+}
+
+export function Dashboard() {
+  return (
+    <div>
+      <section className="bg-background text-text min-h-screen px-4 py-6 transition-colors duration-300 md:px-6">
+        <div className="mx-auto space-y-3">
+          <div className="grid gap-3 xl:grid-cols-2">
+            <DashboardCard
+              title="Status Orders"
+              slotName="<OrderStatusChart />"
+            />
+
+            <DashboardCard
+              title="Number of Clients"
+              slotName="<RegistrationsChart />"
+            />
+          </div>
+
+          <DashboardCard
+            title="Number of Sales"
+            slotName="<SalesChart />"
+            className="min-h-[320px]"
+          />
+
+          <DashboardCard
+            title="ABC Analysis"
+            slotName="<ABCTable />"
+            className="min-h-[300px]"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
Add admin dashboard page

- Added a new /admin/dashboard route
- Added a Dashboard link to the admin sidebar
- Created a simple dashboard template page with placeholder slots for future widgets
- Changed the default /admin redirect to open the dashboard instead of products

<img width="1892" height="886" alt="image" src="https://github.com/user-attachments/assets/9cebbc92-8a21-47a5-bddb-034780cf1dec" />
