### PR TITLE
feat(394): add customer name and order id sorting to admin orders

### DIFF
--- a/src/components/TableOrders/TableOrders.test.tsx
+++ b/src/components/TableOrders/TableOrders.test.tsx
@@ -80,10 +80,10 @@ describe('UI Component: TableOrders', () => {
       screen.getByRole('columnheader', { name: 'Product Name' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', { name: 'Customer name' }),
+      screen.getByRole('button', { name: /customer name/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', { name: 'Order ID' }),
+      screen.getByRole('button', { name: /order id/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /total price/i }),
@@ -120,6 +120,32 @@ describe('UI Component: TableOrders', () => {
     expect(
       screen.getByText(formatDate(new Date(orderItem.createdAt))),
     ).toBeInTheDocument();
+  });
+
+  it('should call onSortChange when customer name header is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderTable({
+      sort: null,
+    });
+
+    await user.click(screen.getByRole('button', { name: /customer name/i }));
+
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+    expect(onSortChange).toHaveBeenCalledWith('customerName');
+  });
+
+  it('should call onSortChange when order id header is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderTable({
+      sort: null,
+    });
+
+    await user.click(screen.getByRole('button', { name: /order id/i }));
+
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+    expect(onSortChange).toHaveBeenCalledWith('orderId');
   });
 
   it('should call onSortChange when total price header is clicked', async () => {

--- a/src/components/TableOrders/TableOrders.tsx
+++ b/src/components/TableOrders/TableOrders.tsx
@@ -55,8 +55,32 @@ export function TableOrders({
 
   const columns: Column[] = [
     { key: 'product', label: 'Product Name', className: '!min-w-[55%]' },
-    { key: 'customer', label: 'Customer name', className: 'min-w-[5%]' },
-    { key: 'orderId', label: 'Order ID', className: 'min-w-[6%]' },
+    {
+      key: 'customer',
+      label: (
+        <TableSortControl<OrdersSortField>
+          label="Customer name"
+          field="customerName"
+          currentSort={sort as OrdersSortField}
+          currentOrder={order}
+          onSortChange={onSortChange}
+        />
+      ),
+      className: 'min-w-[5%]',
+    },
+    {
+      key: 'orderId',
+      label: (
+        <TableSortControl<OrdersSortField>
+          label="Order ID"
+          field="orderId"
+          currentSort={sort as OrdersSortField}
+          currentOrder={order}
+          onSortChange={onSortChange}
+        />
+      ),
+      className: 'min-w-[6%]',
+    },
     {
       key: 'totalPrice',
       label: (

--- a/src/hooks/useAdminOrders.ts
+++ b/src/hooks/useAdminOrders.ts
@@ -11,7 +11,11 @@ import {
   type OrderStatus,
 } from '@/types/tableOrders.types';
 
-export type OrdersSortField = 'createdAt' | 'totalPrice';
+export type OrdersSortField =
+  | 'createdAt'
+  | 'totalPrice'
+  | 'customerName'
+  | 'orderId';
 export type SortOrder = 'asc' | 'desc';
 
 export function useAdminOrders(

--- a/src/pages/Admin/Orders/AdminOrders.tsx
+++ b/src/pages/Admin/Orders/AdminOrders.tsx
@@ -33,7 +33,10 @@ export function AdminOrders() {
   const orderParam = searchParams.get('order');
 
   const currentSort: OrdersSortField =
-    sortParam === 'createdAt' || sortParam === 'totalPrice'
+    sortParam === 'createdAt' ||
+    sortParam === 'totalPrice' ||
+    sortParam === 'orderId' ||
+    sortParam === 'customerName'
       ? sortParam
       : DEFAULT_SORT_BY;
 


### PR DESCRIPTION
Extended Admin Orders table sorting to support new backend fields:
- customerName
- orderId

This updates the frontend sorting flow so the Orders table now supports sorting by:
- Customer Name
- Order ID
- Total Price
- Date

Resolves https://github.com/UA-5399-React/docs/issues/394