### PR TITLE
fix: resolve 6 shop page bugs (#400 #401 #402 #404 #405 #406)

### DIFF
--- a/src/components/Dropdown/CategoryDropdown.tsx
+++ b/src/components/Dropdown/CategoryDropdown.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Field } from '@base-ui/react/field';
 import { Select } from '@base-ui/react/select';
 import clsx from 'clsx';
@@ -19,6 +20,8 @@ export const CategoryDropdown = ({
   multiple = true,
   disabled = false,
 }: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+
   const selectedOptions = selectedValues
     ? options.filter((option) => selectedValues.includes(option.value))
     : undefined;
@@ -34,13 +37,14 @@ export const CategoryDropdown = ({
   const handleValueChange = (value: string | string[] | null) => {
     if (!value) {
       onChange([]);
-      return;
+    } else {
+      const vals = Array.isArray(value) ? value : [value];
+      const selected = vals
+        .map((v) => options.find((o) => o.value === v))
+        .filter(Boolean) as DropdownProps['options'];
+      onChange(selected);
     }
-    const vals = Array.isArray(value) ? value : [value];
-    const selected = vals
-      .map((v) => options.find((o) => o.value === v))
-      .filter(Boolean) as DropdownProps['options'];
-    onChange(selected);
+    setOpen(false);
   };
 
   let content;
@@ -70,6 +74,8 @@ export const CategoryDropdown = ({
         onValueChange={handleValueChange}
         value={value}
         disabled={disabled}
+        open={open}
+        onOpenChange={setOpen}
       >
         <Select.Trigger
           className={clsx(styles.Select, selectClassName)}

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -53,7 +53,7 @@ export const ProductCard = ({ product }: ProductCardProps) => {
         </button>
       </a>
       <div className="flex flex-col">
-        <h3 className="text-sm font-medium text-[rgb(var(--color-text))]">
+        <h3 className="line-clamp-2 text-sm font-medium text-[rgb(var(--color-text))]">
           {title}
         </h3>
         <span className="text-sm font-semibold text-[rgb(var(--color-text))]">

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Heart, Image as ImageIcon } from 'lucide-react';
 
 import { useCartStore } from '@/store/useCartStore';
@@ -12,6 +13,7 @@ interface ProductCardProps {
 export const ProductCard = ({ product }: ProductCardProps) => {
   const { _id, title, price, imageUrl } = product;
   const addItem = useCartStore((state) => state.addItem);
+  const [imgError, setImgError] = useState(false);
 
   const handleAddToCart = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -26,10 +28,11 @@ export const ProductCard = ({ product }: ProductCardProps) => {
         className="relative mb-3 block overflow-hidden rounded-md"
         aria-label={title}
       >
-        {imageUrl ? (
+        {imageUrl && !imgError ? (
           <img
             src={imageUrl}
             alt={title}
+            onError={() => setImgError(true)}
             className="h-64 w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
         ) : (

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -20,8 +20,17 @@ const STATUS_OPTIONS: DropdownOption[] = [
   { label: 'Draft', value: 'DRAFT' },
 ];
 
+const HTML_TAG_REGEX = /<[^>]*>/;
+
 const productFormSchema = z.object({
-  name: z.string().trim().min(1, 'Product name is required'),
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Product name is required')
+    .refine(
+      (value) => !HTML_TAG_REGEX.test(value),
+      'HTML tags are not allowed',
+    ),
   price: z
     .string()
     .trim()
@@ -41,7 +50,12 @@ const productFormSchema = z.object({
       'Enter at least one category',
     ),
   status: z.enum(['ACTIVE', 'INACTIVE', 'DRAFT']),
-  description: z.string(),
+  description: z
+    .string()
+    .refine(
+      (value) => !HTML_TAG_REGEX.test(value),
+      'HTML tags are not allowed',
+    ),
   imagePreview: z.string().nullable(),
   imageFile: z.instanceof(File).optional(),
 });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -21,7 +21,12 @@ export const useAuth = () => {
 
     if (!token || !expires) return false;
 
-    return Date.now() < Number(expires);
+    if (Date.now() >= Number(expires)) {
+      useCartStore.getState().clearCart();
+      return false;
+    }
+
+    return true;
   });
 
   const logout = async () => {

--- a/src/pages/Checkout/Checkout.test.tsx
+++ b/src/pages/Checkout/Checkout.test.tsx
@@ -156,7 +156,7 @@ describe('Page: Checkout', () => {
   it('renders checkout sections, summary, total note, and autofill-friendly inputs', () => {
     render(<Checkout />);
 
-    expect(screen.getByText('Contact Infomation')).toBeInTheDocument();
+    expect(screen.getByText('Contact Information')).toBeInTheDocument();
     expect(screen.getByText('Shipping Address')).toBeInTheDocument();
     expect(screen.getByText('Payment method')).toBeInTheDocument();
     expect(screen.getAllByText('Order summary')).toHaveLength(2);

--- a/src/pages/Checkout/CheckoutSections.tsx
+++ b/src/pages/Checkout/CheckoutSections.tsx
@@ -38,7 +38,7 @@ export const ContactInformationSection = ({
   register,
 }: CheckoutSectionProps) => (
   <CheckoutSection
-    title="Contact Infomation"
+    title="Contact Information"
     isDark={isDark}
     className="md:px-[23px] md:pt-[39px] md:pb-10"
   >

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -15,9 +15,6 @@ test('user can browse, filter, add to cart', async ({ page }) => {
 
   await page.getByRole('combobox', { name: 'Categories' }).click();
   await page.getByText('Laptop', { exact: true }).click();
-  await page
-    .getByRole('combobox', { name: 'Categories' })
-    .click({ force: true });
 
   await page.getByRole('combobox', { name: 'Price' }).click();
   await page.getByText('Under $').click();


### PR DESCRIPTION
## Summary

- **#400** — Show placeholder image when `imageUrl` is `null`, empty, or fails to load (`onError` handler)
- **#401** — Reject HTML tags in product name and description fields (Zod `refine` with `/<[^>]*>/` regex)
- **#402** — Clamp product card title to 2 lines with ellipsis (`line-clamp-2`) to keep grid heights consistent
- **#404** — Fix typo: "Contact Infomation" → "Contact Information"
- **#405** — Clear cart when auth token is expired on page load; guest cart is preserved when no token exists
- **#406** — Close category filter dropdown immediately after selecting an option (controlled `open` state)

Closes UA-5399-React/docs#400
Closes UA-5399-React/docs#401
Closes UA-5399-React/docs#402
Closes UA-5399-React/docs#404
Closes UA-5399-React/docs#405
Closes UA-5399-React/docs#406