### PR TITLE
feat(386): add edit button for featured products items

### DIFF
--- a/src/pages/Admin/FeaturedProducts/FeaturedProducts.test.tsx
+++ b/src/pages/Admin/FeaturedProducts/FeaturedProducts.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
-import { NEW_ARRIVALS_LIMIT } from '@/constants';
+import { NEW_ARRIVALS_LIMIT, ROUTES } from '@/constants';
 import { apiClient } from '@/services/api';
 
 import { FeaturedProducts } from './FeaturedProducts';
@@ -47,9 +47,16 @@ describe('Page: FeaturedProducts', () => {
 
     return render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={['/admin/featured']}>
+        <MemoryRouter initialEntries={[ROUTES.ADMIN_FEATURED]}>
           <Routes>
-            <Route path="/admin/featured" element={<FeaturedProducts />} />
+            <Route
+              path={ROUTES.ADMIN_FEATURED}
+              element={<FeaturedProducts />}
+            />
+            <Route
+              path={ROUTES.ADMIN_PRODUCT_EDIT}
+              element={<div>Edit Product Page</div>}
+            />
           </Routes>
         </MemoryRouter>
       </QueryClientProvider>,
@@ -98,6 +105,17 @@ describe('Page: FeaturedProducts', () => {
     });
   });
 
+  it('navigates to product edit page from featured item', async () => {
+    renderPage();
+
+    await screen.findByText('AirPods');
+
+    const editButton = screen.getByRole('button', { name: /edit/i });
+    await user.click(editButton);
+
+    expect(await screen.findByText('Edit Product Page')).toBeInTheDocument();
+  });
+
   it('removes a product from the list', async () => {
     (apiClient.delete as Mock).mockResolvedValue({});
     renderPage();
@@ -107,7 +125,9 @@ describe('Page: FeaturedProducts', () => {
     const allButtons = screen.getAllByRole('button');
 
     const deleteBtn = allButtons.find(
-      (btn) => btn.innerHTML.includes('svg') || btn.className.includes('trash'),
+      (btn) =>
+        btn !== screen.queryByRole('button', { name: /edit/i }) &&
+        (btn.innerHTML.includes('svg') || btn.className.includes('trash')),
     );
 
     expect(deleteBtn).toBeTruthy();
@@ -171,8 +191,14 @@ describe('Page: FeaturedProducts', () => {
 
     await screen.findByText('AirPods');
 
-    const deleteButtons = screen.getAllByRole('button');
-    const deleteBtn = deleteButtons.find((btn) => btn.querySelector('svg'));
+    const allButtons = screen.getAllByRole('button');
+    const deleteBtn = allButtons.find(
+      (btn) =>
+        btn !== screen.queryByRole('button', { name: /edit/i }) &&
+        btn.querySelector('svg'),
+    );
+
+    expect(deleteBtn).toBeTruthy();
 
     await user.click(deleteBtn!);
 

--- a/src/pages/Admin/FeaturedProducts/FeaturedProducts.tsx
+++ b/src/pages/Admin/FeaturedProducts/FeaturedProducts.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
+import { generatePath, useNavigate } from 'react-router-dom';
 import { Check, Loader2, PackageSearch, Plus, Trash2 } from 'lucide-react';
 
 import { AdminPageHeader, Button, SearchInput } from '@/components';
-import { NEW_ARRIVALS_LIMIT } from '@/constants';
+import { NEW_ARRIVALS_LIMIT, ROUTES } from '@/constants';
 import { apiClient } from '@/services/api';
 import type { Product } from '@/types/product.types';
 
@@ -16,6 +17,8 @@ interface FeaturedResponse {
   position: number;
 }
 export function FeaturedProducts() {
+  const navigate = useNavigate();
+
   const [allProducts, setAllProducts] = useState<FeaturedProductItem[]>([]);
   const [featured, setFeatured] = useState<FeaturedProductItem[]>([]);
   const [search, setSearch] = useState('');
@@ -291,6 +294,20 @@ export function FeaturedProducts() {
                   </div>
 
                   <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        navigate(
+                          generatePath(ROUTES.ADMIN_PRODUCT_EDIT, {
+                            id: product._id,
+                          }),
+                        );
+                      }}
+                      className="border-fieldBorder text-muted hover:!border-fieldBorder hover:!text-muted bg-transparent px-3 py-1.5 text-xs font-bold tracking-wider uppercase transition-all"
+                    >
+                      Edit
+                    </Button>
+
                     {deleteConfirmId === product._id ? (
                       <button
                         type="button"


### PR DESCRIPTION
- added Edit button for each item on Featured Products admin page
- used existing shared Button component 
- navigates to product edit page using ROUTES.ADMIN_PRODUCT_EDIT
- added tests fir Feature Products page 

Resolves https://github.com/UA-5399-React/docs/issues/386