### PR TITLE
fix(416): multiply price by quantity in cart total display

### DIFF
--- a/src/components/FlyoutCart/FlyoutCart.test.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.test.tsx
@@ -129,10 +129,12 @@ describe('FlyoutCart component', () => {
 
   // Item rendering
   it('renders cart items with title, price and quantity', () => {
-    vi.mocked(useCartStore).mockReturnValue(baseStore({ items: [makeItem()] }));
+    vi.mocked(useCartStore).mockReturnValue(
+      baseStore({ items: [makeItem()], getCartTotal: vi.fn(() => 200) }),
+    );
     renderCart();
     expect(screen.getByText('Test Product')).toBeInTheDocument();
-    expect(screen.getByText('$50.00')).toBeInTheDocument();
+    expect(screen.getByText('$100.00')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
   });
 

--- a/src/components/FlyoutCart/FlyoutCart.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.tsx
@@ -133,7 +133,7 @@ export const FlyoutCart = () => {
                       </div>
                       <div className="flex flex-col items-end gap-1">
                         <span className="pl-2 font-semibold">
-                          ${item.product.price.toFixed(2)}
+                          ${(item.product.price * item.quantity).toFixed(2)}
                         </span>
                         <Button
                           onClick={() =>

--- a/src/pages/Cart/Cart.tsx
+++ b/src/pages/Cart/Cart.tsx
@@ -288,7 +288,7 @@ export const Cart = () => {
                               isDark ? 'text-white' : 'text-black',
                             )}
                           >
-                            ${item.product.price.toFixed(2)}
+                            ${(item.product.price * item.quantity).toFixed(2)}
                           </span>
                           <Button
                             onClick={() =>


### PR DESCRIPTION
## Summary

- FlyoutCart sidebar and Cart mobile view were displaying unit price instead of `price × quantity`
- Fixed both locations to show the correct line-item total
- Updated FlyoutCart test to assert the computed total (`price × qty`) and avoid collision with the cart grand total

## Changes

- `src/components/FlyoutCart/FlyoutCart.tsx` — line-item price: `price` → `price * quantity`
- `src/pages/Cart/Cart.tsx` — same fix for mobile view
- `src/components/FlyoutCart/FlyoutCart.test.tsx` — updated assertion to expect `$100.00` (50 × 2)

Closes UA-5399-React/docs#416