### PR TITLE
fix(408): remove awaitRefetchQueries to prevent false mutation error

### DIFF
--- a/src/hooks/useCreateAdminUser.test.ts
+++ b/src/hooks/useCreateAdminUser.test.ts
@@ -43,7 +43,6 @@ describe('useCreateAdminUser', () => {
 
     expect(ApolloClient.useMutation).toHaveBeenCalledWith(expect.anything(), {
       refetchQueries: [{ query: GET_USERS_LIST }],
-      awaitRefetchQueries: true,
     });
 
     await act(async () => {

--- a/src/hooks/useCreateAdminUser.ts
+++ b/src/hooks/useCreateAdminUser.ts
@@ -19,7 +19,6 @@ export function useCreateAdminUser() {
     { input: CreateAdminUserInput }
   >(CREATE_USER, {
     refetchQueries: [{ query: GET_USERS_LIST }],
-    awaitRefetchQueries: true,
   });
 
   const createUser = async (input: CreateAdminUserInput) => {


### PR DESCRIPTION
## Summary

- `awaitRefetchQueries: true` caused the `createUser` mutation promise to reject when the `GET_USERS_LIST` refetch failed (e.g. caching key mismatch), even though the server had already created the user successfully
- Removing it lets the refetch run in the background; failures no longer surface as a mutation error

## Changes

- `src/hooks/useCreateAdminUser.ts` — removed `awaitRefetchQueries: true`
- `src/hooks/useCreateAdminUser.test.ts` — removed assertion for that option

Closes UA-5399-React/docs#408