### PR TITLE
feat(414): add admin and storefront navigation links

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -78,7 +78,7 @@ describe('UI Component: Header', () => {
     vi.clearAllMocks();
     lightTheme();
 
-    mockUseAuth.mockReturnValue({ isAuth: false });
+    mockUseAuth.mockReturnValue({ isAuth: false, canAccessAdminPanel: false });
     mockUseMe.mockReturnValue({ data: undefined });
 
     useCartStore.setState({ items: [], isOpen: false });
@@ -140,6 +140,13 @@ describe('UI Component: Header', () => {
     expect(screen.getByRole('button', { name: 'User' })).toBeInTheDocument();
   });
 
+  it('should not render Admin panel button for non-admin users', () => {
+    render(<Header />);
+    expect(
+      screen.queryByRole('button', { name: 'Admin panel' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('should render the Theme toggle button', () => {
     render(<Header />);
     expect(screen.getByRole('button', { name: 'Theme' })).toBeInTheDocument();
@@ -169,7 +176,7 @@ describe('UI Component: Header', () => {
   it('should navigate to profile when authenticated user clicks User button', async () => {
     const user = userEvent.setup();
 
-    mockUseAuth.mockReturnValue({ isAuth: true });
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
     mockUseMe.mockReturnValue({
       data: {
         id: '1',
@@ -191,7 +198,7 @@ describe('UI Component: Header', () => {
   });
 
   it('should render user initials when authenticated user has no avatar', () => {
-    mockUseAuth.mockReturnValue({ isAuth: true });
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
     mockUseMe.mockReturnValue({
       data: {
         id: '1',
@@ -211,7 +218,7 @@ describe('UI Component: Header', () => {
   });
 
   it('should render first email letter when authenticated user has no avatar and no names', () => {
-    mockUseAuth.mockReturnValue({ isAuth: true });
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
     mockUseMe.mockReturnValue({
       data: {
         id: '1',
@@ -231,7 +238,7 @@ describe('UI Component: Header', () => {
   });
 
   it('should render user avatar when authenticated user has avatar', () => {
-    mockUseAuth.mockReturnValue({ isAuth: true });
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
     mockUseMe.mockReturnValue({
       data: {
         id: '1',
@@ -255,7 +262,7 @@ describe('UI Component: Header', () => {
   });
 
   it('should fall back to initials when avatar image fails to load', () => {
-    mockUseAuth.mockReturnValue({ isAuth: true });
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
     mockUseMe.mockReturnValue({
       data: {
         id: '1',
@@ -279,6 +286,18 @@ describe('UI Component: Header', () => {
     fireEvent.error(avatar as HTMLImageElement);
 
     expect(screen.getByText('SA')).toBeInTheDocument();
+  });
+
+  it('should render Admin panel button for admin users and navigate to dashboard', async () => {
+    const user = userEvent.setup();
+
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
+
+    render(<Header />);
+
+    await user.click(screen.getByRole('button', { name: 'Admin panel' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ADMIN_DASHBOARD);
   });
 
   // ── Theme icon ───────────────────────────────────────────────────────────────
@@ -458,6 +477,17 @@ describe('UI Component: Header', () => {
     render(<Header />);
     await user.click(screen.getByRole('button', { name: 'Open menu' }));
     expect(screen.getByRole('link', { name: 'Wishlist' })).toBeInTheDocument();
+  });
+
+  it('should render Admin Panel action in drawer for admin users', async () => {
+    const user = userEvent.setup();
+
+    mockUseAuth.mockReturnValue({ isAuth: true, canAccessAdminPanel: true });
+
+    render(<Header />);
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    expect(screen.getByText('Admin Panel')).toBeInTheDocument();
   });
 
   it('should render Change Theme button in drawer when open', async () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import {
   ShoppingBag,
   Sun,
   UserCircle,
+  UserStar,
   X,
 } from 'lucide-react';
 
@@ -73,7 +74,7 @@ export const Header = () => {
 
   const [prevUrlSearch, setPrevUrlSearch] = useState(initialSearch);
 
-  const { isAuth } = useAuth();
+  const { isAuth, canAccessAdminPanel } = useAuth();
 
   const { data: me } = useMe(isAuth);
 
@@ -87,6 +88,10 @@ export const Header = () => {
 
   const handleUserNavigate = () => {
     navigate(isAuth ? ROUTES.PROFILE : ROUTES.LOGIN);
+  };
+
+  const handleAdminNavigate = () => {
+    navigate(ROUTES.ADMIN_DASHBOARD);
   };
 
   if (initialSearch !== prevUrlSearch) {
@@ -225,6 +230,17 @@ export const Header = () => {
               </button>
             </div>
 
+            {canAccessAdminPanel && (
+              <button
+                onClick={handleAdminNavigate}
+                aria-label="Admin panel"
+                title="Admin panel"
+                className="cursor-pointer border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+              >
+                <UserStar className="h-6 w-6" />
+              </button>
+            )}
+
             <button
               onClick={handleUserNavigate}
               aria-label="User"
@@ -304,6 +320,19 @@ export const Header = () => {
             <div
               className={`mt-auto shrink-0 border-t px-6 ${isDark ? 'border-gray-700' : 'border-gray-200'}`}
             >
+              {canAccessAdminPanel && (
+                <button
+                  onClick={() => {
+                    closeMenu();
+                    handleAdminNavigate();
+                  }}
+                  className={`flex w-full cursor-pointer items-center justify-between border-x-0 border-t-0 border-b bg-transparent py-4 pr-0 pl-0 text-left font-[inherit] text-sm font-medium outline-none ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
+                >
+                  <span>Admin Panel</span>
+                  <UserStar className="h-5 w-5 shrink-0 text-gray-400" />
+                </button>
+              )}
+
               <button
                 onClick={handleToggleTheme}
                 className={`flex w-full cursor-pointer items-center justify-between border-x-0 border-t-0 border-b bg-transparent py-4 pr-0 pl-0 text-left font-[inherit] text-sm font-medium outline-none ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}

--- a/src/components/MobileSidebar/MobileSidebar.test.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.test.tsx
@@ -87,6 +87,9 @@ describe('UI Component: MobileSidebar', () => {
 
     expect(screen.getByText('ADMIN')).toBeInTheDocument();
     expect(
+      screen.getByRole('link', { name: 'View Store' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('link', { name: 'Categories' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
@@ -149,10 +152,12 @@ describe('UI Component: MobileSidebar', () => {
   it('should render Products and Categories links with correct hrefs for admin', () => {
     renderWithTheme({ ...defaultProps, isSidebarOpen: true });
 
+    const storefrontLink = screen.getByRole('link', { name: 'View Store' });
     const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
     const categoriesLink = screen.getByRole('link', { name: 'Categories' });
     const productsLink = screen.getByRole('link', { name: 'Products' });
 
+    expect(storefrontLink).toHaveAttribute('href', ROUTES.HOME);
     expect(dashboardLink).toHaveAttribute('href', ROUTES.ADMIN_DASHBOARD);
     expect(categoriesLink).toHaveAttribute('href', ROUTES.ADMIN_CATEGORIES);
     expect(productsLink).toHaveAttribute('href', ROUTES.ADMIN_PRODUCTS);

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom';
-import { LogOutIcon, MenuIcon, StoreIcon, XIcon } from 'lucide-react';
+import { LogOutIcon, MenuIcon, XIcon } from 'lucide-react';
 
 import { Button } from '@/components';
 import { ROUTES } from '@/constants';
@@ -70,7 +70,6 @@ export const MobileSidebar = ({
                         `flex h-[40px] items-center gap-2 ${isActive ? 'text-xl font-bold' : ''}`
                       }
                     >
-                      {to === ROUTES.HOME && <StoreIcon className="h-4 w-4" />}
                       {label}
                     </NavLink>
                   </li>

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -27,8 +27,8 @@ export const MobileSidebar = ({
 }: MobileSidebarProps) => {
   const { logout, role } = useAuth();
   const navigate = useNavigate();
-  const visibleLinks = MOBILE_LINKS.filter(
-    ({ to }) => to === ROUTES.HOME || canAccessAdminRoute(role, to),
+  const visibleLinks = MOBILE_LINKS.filter(({ to }) =>
+    canAccessAdminRoute(role, to),
   );
 
   const handleLogout = () => {
@@ -67,7 +67,7 @@ export const MobileSidebar = ({
                       to={to}
                       onClick={() => onSidebarChange(false)}
                       className={({ isActive }) =>
-                        `flex h-[40px] items-center gap-2 ${isActive ? 'text-xl font-bold' : ''}`
+                        `h-[40px] ${isActive ? 'text-xl font-bold' : ''}`
                       }
                     >
                       {label}

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom';
-import { LogOutIcon, MenuIcon, XIcon } from 'lucide-react';
+import { LogOutIcon, MenuIcon, StoreIcon, XIcon } from 'lucide-react';
 
 import { Button } from '@/components';
 import { ROUTES } from '@/constants';
@@ -13,6 +13,7 @@ const MOBILE_LINKS = [
   { to: ROUTES.ADMIN_USERS, label: 'Users' },
   { to: ROUTES.ADMIN_ORDERS, label: 'Orders' },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings' },
+  { to: ROUTES.HOME, label: 'View Store' },
 ];
 
 interface MobileSidebarProps {
@@ -26,8 +27,8 @@ export const MobileSidebar = ({
 }: MobileSidebarProps) => {
   const { logout, role } = useAuth();
   const navigate = useNavigate();
-  const visibleLinks = MOBILE_LINKS.filter(({ to }) =>
-    canAccessAdminRoute(role, to),
+  const visibleLinks = MOBILE_LINKS.filter(
+    ({ to }) => to === ROUTES.HOME || canAccessAdminRoute(role, to),
   );
 
   const handleLogout = () => {
@@ -66,9 +67,10 @@ export const MobileSidebar = ({
                       to={to}
                       onClick={() => onSidebarChange(false)}
                       className={({ isActive }) =>
-                        `h-[40px] ${isActive ? 'text-xl font-bold' : ''}`
+                        `flex h-[40px] items-center gap-2 ${isActive ? 'text-xl font-bold' : ''}`
                       }
                     >
+                      {to === ROUTES.HOME && <StoreIcon className="h-4 w-4" />}
                       {label}
                     </NavLink>
                   </li>

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -48,6 +48,7 @@ describe('UI Component: Sidebar', () => {
     vi.mocked(useAuth).mockReturnValue(defaultAuthMock);
     renderWithProviders(<Sidebar />);
 
+    expect(screen.getByText('View Store')).toBeInTheDocument();
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Categories')).toBeInTheDocument();
     expect(screen.getByText('Products')).toBeInTheDocument();
@@ -68,7 +69,19 @@ describe('UI Component: Sidebar', () => {
 
     expect(screen.getByText('Users')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('View Store')).toBeInTheDocument();
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('should link View Store to the client home page', () => {
+    vi.mocked(useAuth).mockReturnValue(defaultAuthMock);
+
+    renderWithProviders(<Sidebar />);
+
+    expect(screen.getByRole('link', { name: 'View Store' })).toHaveAttribute(
+      'href',
+      '/',
+    );
   });
 
   it('should call logout when the user confirms in the modal', async () => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -40,8 +40,8 @@ export const Sidebar = () => {
   const { logout, role } = useAuth();
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModal();
-  const visibleLinks = SIDEBAR_LINKS.filter(
-    ({ to }) => to === ROUTES.HOME || canAccessAdminRoute(role, to),
+  const visibleLinks = SIDEBAR_LINKS.filter(({ to }) =>
+    canAccessAdminRoute(role, to),
   );
 
   const handleLogout = () => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   SettingsIcon,
   ShoppingCartIcon,
   Sparkles,
+  Store,
   UsersIcon,
 } from 'lucide-react';
 
@@ -31,6 +32,7 @@ const SIDEBAR_LINKS = [
   { to: ROUTES.ADMIN_MAILER, label: 'Mailer', icon: <Mail /> },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings', icon: <SettingsIcon /> },
   { to: ROUTES.ADMIN_FEATURED, label: 'Featured Products', icon: <Sparkles /> },
+  { to: ROUTES.HOME, label: 'View Store', icon: <Store /> },
 ];
 
 export const Sidebar = () => {
@@ -38,8 +40,8 @@ export const Sidebar = () => {
   const { logout, role } = useAuth();
   const navigate = useNavigate();
   const { openConfirmModal } = useConfirmModal();
-  const visibleLinks = SIDEBAR_LINKS.filter(({ to }) =>
-    canAccessAdminRoute(role, to),
+  const visibleLinks = SIDEBAR_LINKS.filter(
+    ({ to }) => to === ROUTES.HOME || canAccessAdminRoute(role, to),
   );
 
   const handleLogout = () => {


### PR DESCRIPTION
## Summary
Added quick navigation between the client and admin sides of the app.

## Changes
- added an `Admin Panel` icon button to the client header for admin and super admin users
- added an `Admin Panel` action to the mobile burger menu on the client side
- added a `View Store` link to the admin sidebar
- added a `View Store` link to the admin mobile sidebar
- updated tests for the new navigation behavior
