### PR TITLE
feat(420): add clear all button to flyout cart

### DIFF
--- a/src/components/FlyoutCart/FlyoutCart.test.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.test.tsx
@@ -26,10 +26,16 @@ vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({ isDark: mockIsDark }),
 }));
 
+// ─── Toast ─────────────────────────────────────────────────────────────────────
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
 // ─── Cart store ────────────────────────────────────────────────────────────────
 const mockCloseCart = vi.fn();
 const mockUpdateQuantity = vi.fn();
 const mockRemoveItem = vi.fn();
+const mockClearCart = vi.fn();
 const mockGetCartTotal = vi.fn(() => 100);
 
 vi.mock('@/store/useCartStore', () => ({
@@ -40,6 +46,7 @@ vi.mock('@/store/useCartStore', () => ({
 const baseStore = (overrides = {}) => ({
   items: [],
   isOpen: true,
+  clearCart: mockClearCart,
   closeCart: mockCloseCart,
   updateQuantity: mockUpdateQuantity,
   removeItem: mockRemoveItem,
@@ -304,5 +311,26 @@ describe('FlyoutCart component', () => {
     // The text is a direct child of the div that holds the dark-mode class
     const wrapper = emptyMsg.closest('[class*="text-gray"]');
     expect(wrapper).toHaveClass('text-gray-400');
+  });
+
+  // Clear all button
+  it('does not render the "Clear all" button when cart is empty', () => {
+    renderCart();
+    expect(screen.queryByRole('button', { name: /clear all/i })).toBeNull();
+  });
+
+  it('renders the "Clear all" button when cart has items', () => {
+    vi.mocked(useCartStore).mockReturnValue(baseStore({ items: [makeItem()] }));
+    renderCart();
+    expect(
+      screen.getByRole('button', { name: /clear all/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls clearCart when "Clear all" is clicked', () => {
+    vi.mocked(useCartStore).mockReturnValue(baseStore({ items: [makeItem()] }));
+    renderCart();
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    expect(mockClearCart).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/FlyoutCart/FlyoutCart.test.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.test.tsx
@@ -26,9 +26,13 @@ vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({ isDark: mockIsDark }),
 }));
 
-// ─── Toast ─────────────────────────────────────────────────────────────────────
-vi.mock('react-hot-toast', () => ({
-  default: { success: vi.fn(), error: vi.fn() },
+// ─── Error store ───────────────────────────────────────────────────────────────
+const mockShowMessage = vi.fn();
+vi.mock('@/store/errorStore', () => ({
+  useErrorStore: vi.fn(
+    (selector: (s: { show: typeof mockShowMessage }) => unknown) =>
+      selector({ show: mockShowMessage }),
+  ),
 }));
 
 // ─── Cart store ────────────────────────────────────────────────────────────────

--- a/src/components/FlyoutCart/FlyoutCart.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.tsx
@@ -1,3 +1,4 @@
+import toast from 'react-hot-toast';
 import { Link, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { Minus, Plus, X } from 'lucide-react';
@@ -9,8 +10,15 @@ import { useTheme } from '@/hooks/useTheme';
 import { useCartStore } from '@/store/useCartStore';
 
 export const FlyoutCart = () => {
-  const { items, isOpen, closeCart, updateQuantity, removeItem, getCartTotal } =
-    useCartStore();
+  const {
+    items,
+    isOpen,
+    closeCart,
+    updateQuantity,
+    removeItem,
+    clearCart,
+    getCartTotal,
+  } = useCartStore();
   const { isAuth } = useAuth();
   const { isDark } = useTheme();
   const navigate = useNavigate();
@@ -31,6 +39,11 @@ export const FlyoutCart = () => {
   const handleViewCart = () => {
     closeCart();
     navigate(ROUTES.CART);
+  };
+
+  const handleClearAll = () => {
+    clearCart();
+    toast.success('Cart cleared');
   };
 
   // @TODO: Check and implement dynamic data for the places it needed.
@@ -63,17 +76,32 @@ export const FlyoutCart = () => {
           >
             Cart
           </h2>
-          <Button
-            onClick={closeCart}
-            className={clsx(
-              'h-fit w-fit border-none bg-transparent !p-0 transition-colors hover:border-transparent',
-              isDark
-                ? 'text-gray-400 hover:text-white'
-                : 'text-gray-500 hover:text-black',
+          <div className="flex items-center gap-2">
+            {items.length > 0 && (
+              <Button
+                onClick={handleClearAll}
+                className={clsx(
+                  'h-fit w-fit rounded border px-3 py-1 text-sm transition-colors hover:border-transparent',
+                  isDark
+                    ? 'border-gray-600 bg-transparent text-gray-300 hover:bg-gray-700 hover:text-white'
+                    : 'border-gray-300 bg-transparent text-gray-600 hover:bg-gray-100 hover:text-black',
+                )}
+              >
+                Clear all
+              </Button>
             )}
-          >
-            <X className="h-6 w-6" />
-          </Button>
+            <Button
+              onClick={closeCart}
+              className={clsx(
+                'h-fit w-fit border-none bg-transparent !p-0 transition-colors hover:border-transparent',
+                isDark
+                  ? 'text-gray-400 hover:text-white'
+                  : 'text-gray-500 hover:text-black',
+              )}
+            >
+              <X className="h-6 w-6" />
+            </Button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto px-6 py-4">

--- a/src/components/FlyoutCart/FlyoutCart.tsx
+++ b/src/components/FlyoutCart/FlyoutCart.tsx
@@ -1,4 +1,3 @@
-import toast from 'react-hot-toast';
 import { Link, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { Minus, Plus, X } from 'lucide-react';
@@ -7,6 +6,7 @@ import { Button } from '@/components/Button';
 import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
+import { useErrorStore } from '@/store/errorStore';
 import { useCartStore } from '@/store/useCartStore';
 
 export const FlyoutCart = () => {
@@ -22,6 +22,7 @@ export const FlyoutCart = () => {
   const { isAuth } = useAuth();
   const { isDark } = useTheme();
   const navigate = useNavigate();
+  const showMessage = useErrorStore((s) => s.show);
 
   const total = getCartTotal();
 
@@ -43,7 +44,7 @@ export const FlyoutCart = () => {
 
   const handleClearAll = () => {
     clearCart();
-    toast.success('Cart cleared');
+    showMessage('success', 'Success!', 'Cart cleared');
   };
 
   // @TODO: Check and implement dynamic data for the places it needed.


### PR DESCRIPTION
## Summary
- Added **Clear all** button to the FlyoutCart header (visible only when cart has items)
- Calls `clearCart()` from the cart store and shows a success toast
- Button adapts to dark/light theme

## Tests
- Added 3 new unit tests: renders Clear all when items present, hides it when empty, calls `clearCart` on click
- All 288 existing tests pass

Closes UA-5399-React/docs#420