### PR TITLE
feat(411): add product SKU on ProductDetails and TableProducts

### DIFF
--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -100,7 +100,12 @@ function renderBodyContent(
           </div>
         </td>
 
-        <td>{item.title}</td>
+        <td>
+          <div className="flex flex-col">
+            <span>{item.title}</span>
+            <span>SKU: {item.productCode ?? '—'}</span>
+          </div>
+        </td>
         <td>{item.status}</td>
         <td>{item.price}</td>
         <td>{item.description ?? '—'}</td>

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -101,7 +101,7 @@ export const ProductDetails = () => {
                 <Link
                   key={category.id}
                   to={`${ROUTES.SHOP}?category=${category.id}`}
-                  className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-200 hover:text-black"
+                  className="border-fieldBorder bg-backgroundSec text-text hover:bg-background flex items-center rounded-full border px-3 py-1 text-sm transition-colors"
                 >
                   {category.title}
                 </Link>
@@ -109,6 +109,16 @@ export const ProductDetails = () => {
             </div>
           )}
           <div className="mb-8 text-2xl font-bold">${product.price}</div>
+          <div className="border-fieldBorder mb-6 border-t pt-4">
+            <div className="flex items-center">
+              <span className="text-muted w-24 shrink-0 text-sm font-medium uppercase">
+                SKU
+              </span>
+              <span className="text-text text-sm">
+                {product.productCode ?? '—'}
+              </span>
+            </div>
+          </div>
           <div className="mt-auto flex flex-col gap-4">
             <div className="flex h-[52px] gap-4">
               <div className="flex w-[120px] items-center justify-between rounded-lg bg-[#F3F5F7] px-2">

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -23,6 +23,7 @@ export const GET_PRODUCTS_PAGE = gql`
       limit
       items {
         id
+        productCode
         title
         price
         status
@@ -41,13 +42,13 @@ export const GET_PRODUCT = gql`
   query GetProduct($id: ID!) {
     product(id: $id) {
       id
+      productCode
       title
       price
       updatedAt
       status
       description
       categories
-      productCode
       imageUrl
       imagePublicId
     }
@@ -58,6 +59,7 @@ export const CREATE_PRODUCT = gql`
   mutation CreateProduct($input: CreateProductInput!) {
     createProduct(input: $input) {
       id
+      productCode
       title
       price
       status
@@ -73,6 +75,7 @@ export const UPDATE_PRODUCT = gql`
   mutation UpdateProduct($id: ID!, $input: UpdateProductInput!) {
     updateProduct(id: $id, input: $input) {
       id
+      productCode
       title
       price
       status

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -20,6 +20,7 @@ export interface Product {
   tags?: string[];
   description?: string;
   purchaseCount?: number;
+  productCode?: string;
 
   //it's a workaround to pass build, because there are no fields for createdAt/updatedAt in mock data and storybooks(probably?). Overall these 2 fields should not be optional
   createdAt?: string;


### PR DESCRIPTION
- added productCode to the frontend Product type
- requested productCode in product-related GraphQL queries and mutations
- displayed SKU on the Product Details page
- displayed SKU under the product name in TableProducts