### PR TITLE
fix: add missing mailer and featured products links to mobile sidebar

### DIFF
--- a/src/components/MobileSidebar/MobileSidebar.test.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.test.tsx
@@ -94,6 +94,10 @@ describe('UI Component: MobileSidebar', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Products' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Mailer' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Featured Products' }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Settings' }),
     ).not.toBeInTheDocument();
@@ -156,11 +160,17 @@ describe('UI Component: MobileSidebar', () => {
     const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
     const categoriesLink = screen.getByRole('link', { name: 'Categories' });
     const productsLink = screen.getByRole('link', { name: 'Products' });
+    const mailerLink = screen.getByRole('link', { name: 'Mailer' });
+    const featuredLink = screen.getByRole('link', {
+      name: 'Featured Products',
+    });
 
     expect(storefrontLink).toHaveAttribute('href', ROUTES.HOME);
     expect(dashboardLink).toHaveAttribute('href', ROUTES.ADMIN_DASHBOARD);
     expect(categoriesLink).toHaveAttribute('href', ROUTES.ADMIN_CATEGORIES);
     expect(productsLink).toHaveAttribute('href', ROUTES.ADMIN_PRODUCTS);
+    expect(mailerLink).toHaveAttribute('href', ROUTES.ADMIN_MAILER);
+    expect(featuredLink).toHaveAttribute('href', ROUTES.ADMIN_FEATURED);
   });
 
   it('should render super admin links when role is super_admin', () => {

--- a/src/components/MobileSidebar/MobileSidebar.tsx
+++ b/src/components/MobileSidebar/MobileSidebar.tsx
@@ -12,7 +12,9 @@ const MOBILE_LINKS = [
   { to: ROUTES.ADMIN_CATEGORIES, label: 'Categories' },
   { to: ROUTES.ADMIN_USERS, label: 'Users' },
   { to: ROUTES.ADMIN_ORDERS, label: 'Orders' },
+  { to: ROUTES.ADMIN_MAILER, label: 'Mailer' },
   { to: ROUTES.ADMIN_SETTING, label: 'Settings' },
+  { to: ROUTES.ADMIN_FEATURED, label: 'Featured Products' },
   { to: ROUTES.HOME, label: 'View Store' },
 ];
 


### PR DESCRIPTION
## Summary
- Added `Mailer` and `Featured Products` to the `MOBILE_LINKS` array in `MobileSidebar`
- Links were present in the desktop `Sidebar` but missing from the mobile counterpart
- Updated `MobileSidebar.test.tsx` to assert both links are rendered and have correct `href`s

## Test plan
- [x] Unit tests updated and passing (742 tests pass)
- [x] Verified in browser at 390px — mobile sidebar now shows all admin links matching desktop

Closes UA-5399-React/docs#429