### PR TITLE
feat: add image slider to product details page

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,2 @@
 # Send the commit message file path to the verification script
-node scripts/verify-commit.js $1
+node scripts/verify-commit.js "$1"

--- a/src/components/ImageSlider/ImageSlider.test.tsx
+++ b/src/components/ImageSlider/ImageSlider.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ImageSlider } from './ImageSlider';
+
+const images = [
+  'https://example.com/img1.png',
+  'https://example.com/img2.png',
+  'https://example.com/img3.png',
+];
+
+describe('ImageSlider', () => {
+  it('renders the placeholder icon when images array is empty', () => {
+    const { container } = render(<ImageSlider images={[]} alt="product" />);
+    expect(container.querySelector('.lucide-image')).toBeInTheDocument();
+  });
+
+  it('renders the first image on mount', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    const img = screen.getByRole('img', { name: 'product 1' });
+    expect(img).toHaveAttribute('src', images[0]);
+  });
+
+  it('does not render prev/next buttons for a single image', () => {
+    render(<ImageSlider images={[images[0]]} alt="product" />);
+    expect(
+      screen.queryByRole('button', { name: /previous image/i }),
+    ).toBeNull();
+    expect(screen.queryByRole('button', { name: /next image/i })).toBeNull();
+  });
+
+  it('does not render dot indicators for a single image', () => {
+    render(<ImageSlider images={[images[0]]} alt="product" />);
+    expect(screen.queryByRole('button', { name: /go to image/i })).toBeNull();
+  });
+
+  it('renders prev/next buttons and dots for multiple images', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    expect(
+      screen.getByRole('button', { name: /previous image/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /next image/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /go to image/i }),
+    ).toHaveLength(images.length);
+  });
+
+  it('advances to the next image when Next is clicked', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    fireEvent.click(screen.getByRole('button', { name: /next image/i }));
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[1]);
+  });
+
+  it('goes back to the previous image when Prev is clicked', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    fireEvent.click(screen.getByRole('button', { name: /next image/i }));
+    fireEvent.click(screen.getByRole('button', { name: /previous image/i }));
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[0]);
+  });
+
+  it('wraps around from last to first on Next click', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    const next = screen.getByRole('button', { name: /next image/i });
+    fireEvent.click(next);
+    fireEvent.click(next);
+    fireEvent.click(next);
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[0]);
+  });
+
+  it('wraps around from first to last on Prev click', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    fireEvent.click(screen.getByRole('button', { name: /previous image/i }));
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[2]);
+  });
+
+  it('jumps to the correct image when a dot is clicked', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go to image 3' }));
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[2]);
+  });
+
+  it('swipes to the next image on left swipe', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    const container = screen
+      .getByRole('img')
+      .closest('[class*="relative"]') as HTMLElement;
+    fireEvent.touchStart(container, {
+      touches: [{ clientX: 200 }],
+    });
+    fireEvent.touchEnd(container, {
+      changedTouches: [{ clientX: 100 }],
+    });
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[1]);
+  });
+
+  it('swipes to the previous image on right swipe', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    const container = screen
+      .getByRole('img')
+      .closest('[class*="relative"]') as HTMLElement;
+    fireEvent.touchStart(container, { touches: [{ clientX: 100 }] });
+    fireEvent.touchEnd(container, { changedTouches: [{ clientX: 200 }] });
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[2]);
+  });
+
+  it('ignores swipes shorter than 40px', () => {
+    render(<ImageSlider images={images} alt="product" />);
+    const container = screen
+      .getByRole('img')
+      .closest('[class*="relative"]') as HTMLElement;
+    fireEvent.touchStart(container, { touches: [{ clientX: 100 }] });
+    fireEvent.touchEnd(container, { changedTouches: [{ clientX: 90 }] });
+    expect(screen.getByRole('img')).toHaveAttribute('src', images[0]);
+  });
+});

--- a/src/components/ImageSlider/ImageSlider.tsx
+++ b/src/components/ImageSlider/ImageSlider.tsx
@@ -1,0 +1,97 @@
+import { useRef, useState } from 'react';
+import clsx from 'clsx';
+import { ChevronLeft, ChevronRight, Image as ImageIcon } from 'lucide-react';
+
+interface ImageSliderProps {
+  images: string[];
+  alt: string;
+}
+
+export const ImageSlider = ({ images, alt }: ImageSliderProps) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const touchStartX = useRef<number | null>(null);
+
+  const hasMultiple = images.length > 1;
+
+  const prev = () =>
+    setCurrentIndex((i) => (i - 1 + images.length) % images.length);
+
+  const next = () => setCurrentIndex((i) => (i + 1) % images.length);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const diff = touchStartX.current - e.changedTouches[0].clientX;
+    if (Math.abs(diff) > 40) {
+      if (diff > 0) next();
+      else prev();
+    }
+    touchStartX.current = null;
+  };
+
+  if (images.length === 0) {
+    return (
+      <div className="flex h-[500px] items-center justify-center rounded-lg bg-gray-200">
+        <ImageIcon className="h-24 w-24 text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        className="relative h-[500px] overflow-hidden rounded-lg bg-gray-200 select-none"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        <img
+          src={images[currentIndex]}
+          alt={`${alt} ${currentIndex + 1}`}
+          className="h-full w-full object-cover"
+          draggable={false}
+        />
+
+        {hasMultiple && (
+          <>
+            <button
+              onClick={prev}
+              aria-label="Previous image"
+              className="absolute top-1/2 left-3 flex h-10 w-10 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border-none bg-white/90 shadow-md transition-all hover:scale-105 hover:bg-white"
+            >
+              <ChevronLeft className="h-5 w-5 text-gray-800" />
+            </button>
+
+            <button
+              onClick={next}
+              aria-label="Next image"
+              className="absolute top-1/2 right-3 flex h-10 w-10 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border-none bg-white/90 shadow-md transition-all hover:scale-105 hover:bg-white"
+            >
+              <ChevronRight className="h-5 w-5 text-gray-800" />
+            </button>
+          </>
+        )}
+      </div>
+
+      {hasMultiple && (
+        <div className="flex justify-center gap-2">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setCurrentIndex(i)}
+              aria-label={`Go to image ${i + 1}`}
+              className={clsx(
+                'h-2 cursor-pointer rounded-full border-none transition-all',
+                i === currentIndex
+                  ? 'w-6 bg-gray-800'
+                  : 'w-2 bg-gray-300 hover:bg-gray-400',
+              )}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ export { ExportButton } from './ExportButton/ExportButton';
 export { Features } from './Features';
 export { FlyoutCart } from './FlyoutCart';
 export { Header } from './Header';
+export { ImageSlider } from './ImageSlider/ImageSlider';
 export { ImportProductsModal } from './ImportProductsModal/ImportProductsModal';
 export { Input } from './Input';
 export { LoginForm } from './LoginForm/LoginForm';

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Heart, Image as ImageIcon, Minus, Plus } from 'lucide-react';
+import { Heart, Minus, Plus } from 'lucide-react';
 
+import { ImageSlider } from '@/components';
 import { ROUTES } from '@/constants';
 import { useShopCategories } from '@/hooks/useShopCategories';
 import { productService } from '@/services/productService';
@@ -74,21 +75,13 @@ export const ProductDetails = () => {
     addItem(product, quantity);
   };
 
+  const images = product.imageUrl ? [product.imageUrl] : [];
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="grid grid-cols-1 gap-12 md:grid-cols-2">
         <div className="flex flex-col gap-4">
-          <div className="flex h-[500px] items-center justify-center overflow-hidden rounded-lg bg-gray-200">
-            {product.imageUrl ? (
-              <img
-                src={product.imageUrl}
-                alt={product.title}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <ImageIcon className="h-24 w-24 text-gray-400" />
-            )}
-          </div>
+          <ImageSlider images={images} alt={product.title} />
         </div>
         <div className="flex flex-col">
           <h1 className="mb-4 text-4xl font-bold">{product.title}</h1>


### PR DESCRIPTION
## Summary
- Added `ImageSlider` component with prev/next buttons, dot indicators, and touch/swipe support
- Integrated slider into `ProductDetails` page (derives image array from existing `imageUrl` field)
- Shows a placeholder icon when product has no image
- Ready for multi-image support once backend issue #423 ships `images[]`

## Test plan
- [x] 13 unit tests added (empty state, single image, navigation, wrap-around, dots, swipe, short-swipe threshold)
- [x] All 755 tests pass
- [x] Verified in browser — desktop and mobile (390px)

Closes UA-5399-React/docs#422