### PR TITLE
fix: hide number of clients widget data and show all button for admin role

### DIFF
--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -8,7 +8,7 @@ import {
   resolvePeriod,
 } from '@/utils';
 
-export function useUserStats(period?: string) {
+export function useUserStats(period?: string, enabled = true) {
   const today = new Date();
   const { year, month } = resolvePeriod(period);
 
@@ -16,6 +16,7 @@ export function useUserStats(period?: string) {
     GET_USER_STATS,
     {
       variables: { year, month },
+      skip: !enabled,
     },
   );
 

--- a/src/pages/Admin/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { StatusOrdersWidget } from '@/components';
 import { ROUTES } from '@/constants';
+import { useAuth } from '@/hooks/useAuth';
 import { useUserStats } from '@/hooks/useUserStats';
 import { getCurrentMonthPeriod } from '@/utils';
 
@@ -34,11 +35,8 @@ function DashboardCard({
 }
 export function Dashboard() {
   const navigate = useNavigate();
+  const { isSuperAdmin } = useAuth();
   const [selectedPeriod, setSelectedPeriod] = useState(getCurrentMonthPeriod());
-
-  const handleShowAll = () => {
-    navigate(ROUTES.ADMIN_USERS);
-  };
 
   const {
     dailyCounts,
@@ -47,7 +45,7 @@ export function Dashboard() {
     dateLabel,
     loading: periodLoading,
     error: periodError,
-  } = useUserStats(selectedPeriod);
+  } = useUserStats(selectedPeriod, isSuperAdmin);
 
   return (
     <div>
@@ -67,7 +65,9 @@ export function Dashboard() {
               onPeriodChange={setSelectedPeriod}
               loading={periodLoading}
               error={periodError}
-              onShowAll={handleShowAll}
+              onShowAll={
+                isSuperAdmin ? () => navigate(ROUTES.ADMIN_USERS) : undefined
+              }
             />
           </div>
 

--- a/src/pages/Admin/UsersChart/UsersChart.tsx
+++ b/src/pages/Admin/UsersChart/UsersChart.tsx
@@ -187,12 +187,14 @@ export function UsersChart({
 
         <p className="text-muted text-center text-sm">{dateLabel}</p>
 
-        <Button
-          onClick={onShowAll}
-          className="rounded-full border! border-blue-500! bg-transparent p-2 text-sm font-medium text-blue-500 transition-colors hover:bg-blue-500/10"
-        >
-          Show all
-        </Button>
+        {onShowAll && (
+          <Button
+            onClick={onShowAll}
+            className="rounded-full border! border-blue-500! bg-transparent p-2 text-sm font-medium text-blue-500 transition-colors hover:bg-blue-500/10"
+          >
+            Show all
+          </Button>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- `admin` role was getting an "Access denied" error on the dashboard because the `userStats` GraphQL query is restricted to `super_admin`
- The "Show all" button linked to `/admin/users` which is also `super_admin`-only

## Changes
- `useUserStats.ts` — added `enabled` flag; passes `skip: !enabled` to Apollo so the query is never fired when disabled
- `Dashboard.tsx` — reads `isSuperAdmin` from `useAuth`, skips query for admin, passes `onShowAll` only for super_admin
- `UsersChart.tsx` — renders "Show all" button only when `onShowAll` prop is provided

## Result
- `admin` — sees the widget with zero counts, no error, no "Show all" button
- `super_admin` — unchanged: full data + "Show all" button

Closes UA-5399-React/docs#428