### PR TITLE
feat(433): add clear all button to shop filters

### DIFF
--- a/src/components/ShopFilters/ShopFilters.test.tsx
+++ b/src/components/ShopFilters/ShopFilters.test.tsx
@@ -89,4 +89,39 @@ describe('ShopFilters', () => {
     expect(search).toContain('category=cat-2');
     expect(search).toContain('page=1');
   });
+
+  it('clears category and price filters and resets page to 1', () => {
+    useShopCategoriesMock.mockReturnValue({
+      data: [
+        { id: 'cat-1', title: 'Phones' },
+        { id: 'cat-2', title: 'Tablets' },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/shop?category=cat-1&minPrice=500&maxPrice=1000&page=3&sort=price&search=iphone',
+        ]}
+      >
+        <ShopFilters />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+
+    const search = screen.getByTestId('location-search').textContent ?? '';
+    const params = new URLSearchParams(search);
+
+    expect(params.get('category')).toBeNull();
+    expect(params.get('minPrice')).toBeNull();
+    expect(params.get('maxPrice')).toBeNull();
+    expect(params.get('page')).toBe('1');
+
+    expect(params.get('sort')).toBe('price');
+    expect(params.get('search')).toBe('iphone');
+  });
 });

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from 'react-router-dom';
 
+import { Button } from '@/components/Button';
 import { CategoryDropdown, Dropdown } from '@/components/Dropdown';
 import { useShopCategories } from '@/hooks/useShopCategories';
 
@@ -103,8 +104,21 @@ export function ShopFilters() {
     });
   };
 
+  const handleClearAll = () => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+
+      next.delete('category');
+      next.delete('minPrice');
+      next.delete('maxPrice');
+      next.set('page', '1');
+
+      return next;
+    });
+  };
+
   return (
-    <div className="flex flex-col gap-4 sm:flex-row">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
       <CategoryDropdown
         label="Categories"
         options={categoryOptions}
@@ -114,14 +128,23 @@ export function ShopFilters() {
         selectedValues={currentCategory}
         disabled={isCategoryDisabled}
       />
-      <Dropdown
-        label="Price"
-        options={PRICE_OPTIONS}
-        multiple={true}
-        onChange={handlePriceChange}
-        placeholder={priceLabel}
-        selectedValues={currentPriceValue ? [currentPriceValue] : []}
-      />
+      <div className="[&_[data-placeholder]]:!text-text w-full sm:w-auto [&_[data-placeholder]]:!opacity-100">
+        <Dropdown
+          label="Price"
+          options={PRICE_OPTIONS}
+          multiple={false}
+          onChange={handlePriceChange}
+          placeholder={priceLabel}
+          selectedValues={currentPriceValue ? [currentPriceValue] : []}
+        />
+      </div>
+      <Button
+        type="button"
+        onClick={handleClearAll}
+        className="!bg-background !text-text hover:!bg-backgroundSec !box-border !h-[32px] !w-full !rounded-md !border !border-gray-300 !px-[15px] !py-0 !text-sm !leading-5 !font-normal hover:!border-gray-300 sm:!w-[120px]"
+      >
+        Clear all
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
- Added a Clear all button to the shopping filters
- Clear all removes category and price filters from URL params
- Reset page to 1 after filters are cleared
- Added a border to the dropdown/filter controls to match the design
- Added test coverage for the new behavior

Resolves https://github.com/UA-5399-React/docs/issues/433