### PR TITLE
refactor(437): replace category dropdown with shared dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -82,7 +82,8 @@
 .Popup {
   box-sizing: border-box;
   padding-block: 0.25rem;
-  border-radius: 0.375rem;
+  border: 1px solid rgb(var(--default-border));
+  border-radius: 0.5rem;
   background-color: rgb(var(--color-bg));
   background-clip: padding-box;
   color: var(--color-text);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Field } from '@base-ui/react/field';
 import { Select } from '@base-ui/react/select';
 import clsx from 'clsx';
@@ -19,7 +20,10 @@ export const Dropdown = ({
   multiple = true,
   disabled = false,
   required = false,
+  closeOnSelect = false,
 }: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+
   const selectedOptions = selectedValues
     ? options.filter((option) => selectedValues.includes(option.value))
     : undefined;
@@ -33,6 +37,11 @@ export const Dropdown = ({
   const handleValueChange = (value: string | string[] | null) => {
     if (!value) {
       onChange([]);
+
+      if (closeOnSelect) {
+        setOpen(false);
+      }
+
       return;
     }
 
@@ -67,6 +76,8 @@ export const Dropdown = ({
         value={value}
         items={options}
         disabled={disabled}
+        open={open}
+        onOpenChange={setOpen}
       >
         <Select.Trigger
           className={clsx(styles.Select, selectClassName)}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -54,6 +54,10 @@ export const Dropdown = ({
       .filter(Boolean) as DropdownProps['options'];
 
     onChange(selected);
+
+    if (closeOnSelect) {
+      setOpen(false);
+    }
   };
 
   return (
@@ -103,6 +107,11 @@ export const Dropdown = ({
                   key={option.value}
                   value={option.value}
                   className={styles.Item}
+                  onClick={() => {
+                    if (closeOnSelect) {
+                      setTimeout(() => setOpen(false), 0);
+                    }
+                  }}
                 >
                   <Select.ItemText className={styles.ItemText}>
                     {option.label}

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -15,4 +15,5 @@ export interface DropdownProps {
   multiple?: boolean;
   disabled?: boolean;
   required?: boolean;
+  closeOnSelect?: boolean;
 }

--- a/src/components/ShopFilters/ShopFilters.test.tsx
+++ b/src/components/ShopFilters/ShopFilters.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useShopCategoriesMock = vi.fn();
 
@@ -9,31 +9,38 @@ vi.mock('@/hooks/useShopCategories', () => ({
 }));
 
 vi.mock('@/components/Dropdown', () => ({
-  CategoryDropdown: ({
+  Dropdown: ({
+    label,
     placeholder,
     disabled,
     onChange,
     options,
     selectedValues,
   }: {
+    label: string;
     placeholder: string;
     disabled?: boolean;
     onChange: (values: { label: string; value: string }[]) => void;
     options: { label: string; value: string }[];
     selectedValues?: string[];
-  }) => (
-    <div>
-      <div data-testid="category-placeholder">{placeholder}</div>
-      <div data-testid="category-disabled">{String(Boolean(disabled))}</div>
-      <div data-testid="category-selected">
-        {selectedValues?.join(',') ?? ''}
-      </div>
-      <button type="button" onClick={() => onChange(options.slice(0, 2))}>
-        Select categories
-      </button>
-    </div>
-  ),
-  Dropdown: () => <div data-testid="price-dropdown" />,
+  }) => {
+    if (label === 'Categories') {
+      return (
+        <div>
+          <div data-testid="category-placeholder">{placeholder}</div>
+          <div data-testid="category-disabled">{String(Boolean(disabled))}</div>
+          <div data-testid="category-selected">
+            {selectedValues?.join(',') ?? ''}
+          </div>
+          <button type="button" onClick={() => onChange(options.slice(0, 2))}>
+            Select categories
+          </button>
+        </div>
+      );
+    }
+
+    return <div data-testid="price-dropdown" />;
+  },
 }));
 
 import { ShopFilters } from './ShopFilters';
@@ -43,6 +50,10 @@ const LocationDisplay = () => {
 
   return <div data-testid="location-search">{location.search}</div>;
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('ShopFilters', () => {
   it('shows a disabled loading state while categories are loading', () => {

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -133,7 +133,7 @@ export function ShopFilters() {
         <Dropdown
           label="Price"
           options={PRICE_OPTIONS}
-          multiple={false}
+          multiple={true}
           onChange={handlePriceChange}
           placeholder={priceLabel}
           selectedValues={currentPriceValue ? [currentPriceValue] : []}

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components/Button';
-import { CategoryDropdown, Dropdown } from '@/components/Dropdown';
+import { Dropdown } from '@/components/Dropdown';
 import { useShopCategories } from '@/hooks/useShopCategories';
 
 const PRICE_OPTIONS = [
@@ -10,6 +10,9 @@ const PRICE_OPTIONS = [
   { label: '$1000 - $2000', value: '1000-2000' },
   { label: 'Over $2000', value: '2000+' },
 ];
+
+const DROPDOWN_WRAPPER_CLASS =
+  'w-full sm:w-auto [&_[data-placeholder]]:!text-text [&_[data-placeholder]]:!opacity-100';
 
 const getSelectedCategories = (searchParams: URLSearchParams) => {
   const categories = searchParams
@@ -51,11 +54,6 @@ export function ShopFilters() {
       : categoryOptions.length === 0
         ? 'No categories available'
         : 'All Electronics';
-  const selectedCategoryLabels = currentCategory
-    .map((v) => categoryOptions.find((o) => o.value === v)?.label)
-    .filter(Boolean)
-    .join(', ');
-  const categoryLabel = selectedCategoryLabels || categoryPlaceholder;
 
   const handleCategoryChange = (values: { value: string }[]) => {
     const filtered = values.map((v) => v.value).filter(Boolean);
@@ -116,19 +114,21 @@ export function ShopFilters() {
       return next;
     });
   };
-
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
-      <CategoryDropdown
-        label="Categories"
-        options={categoryOptions}
-        multiple={true}
-        onChange={handleCategoryChange}
-        placeholder={categoryLabel}
-        selectedValues={currentCategory}
-        disabled={isCategoryDisabled}
-      />
-      <div className="[&_[data-placeholder]]:!text-text w-full sm:w-auto [&_[data-placeholder]]:!opacity-100">
+      <div className={DROPDOWN_WRAPPER_CLASS}>
+        <Dropdown
+          label="Categories"
+          options={categoryOptions}
+          multiple={true}
+          onChange={handleCategoryChange}
+          placeholder={categoryPlaceholder}
+          selectedValues={currentCategory}
+          disabled={isCategoryDisabled}
+        />
+      </div>
+
+      <div className={DROPDOWN_WRAPPER_CLASS}>
         <Dropdown
           label="Price"
           options={PRICE_OPTIONS}
@@ -138,6 +138,7 @@ export function ShopFilters() {
           selectedValues={currentPriceValue ? [currentPriceValue] : []}
         />
       </div>
+
       <Button
         type="button"
         onClick={handleClearAll}

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -125,6 +125,7 @@ export function ShopFilters() {
           placeholder={categoryPlaceholder}
           selectedValues={currentCategory}
           disabled={isCategoryDisabled}
+          closeOnSelect
         />
       </div>
 


### PR DESCRIPTION
- Replaced CategoryDropdown with the shared Dropdown component in ShopFilters
- Preserved multiple category selection and URL query params behavior
- Updated ShopFilters tests
- Added border styling for the dropdown popup

Resolves https://github.com/UA-5399-React/docs/issues/437
