### PR TITLE
Feat/410 input close

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -66,6 +66,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       inputClassName = '',
       id,
       required = false,
+      onChange,
+      value,
+      defaultValue,
       ...props
     },
     ref,
@@ -73,8 +76,43 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const reactId = React.useId();
     const inputId = id || reactId;
     const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
+
+    const isControlled = value !== undefined;
+    const [uncontrolledHasValue, setUncontrolledHasValue] = React.useState(() =>
+      Boolean(defaultValue ?? ''),
+    );
+    const hasValue = isControlled ? Boolean(value) : uncontrolledHasValue;
+
+    const internalRef = React.useRef<HTMLInputElement>(null);
+    const resolvedRef =
+      (ref as React.RefObject<HTMLInputElement>) ?? internalRef;
+
     const isPassword = type === 'password';
     const inputType = isPassword && isPasswordVisible ? 'text' : type;
+
+    const handleChange: NonNullable<typeof onChange> = (e) => {
+      if (!isControlled) setUncontrolledHasValue(Boolean(e.target.value));
+      onChange?.(e);
+    };
+
+    const handleClear = () => {
+      const input = resolvedRef.current;
+      if (!input) return;
+
+      // Use the native setter + dispatch so React's synthetic event system
+      // picks it up and calls our handleChange — no manual onChange call needed
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      nativeInputValueSetter?.call(input, '');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      if (!isControlled) setUncontrolledHasValue(false);
+      input.focus();
+    };
+
+    const hasRightSlot = isPassword || rightElement || hasValue;
 
     const paddingClasses = clsx({
       'pl-10': leftIcon,
@@ -111,8 +149,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <BaseInput
             {...props}
             id={inputId}
-            ref={ref}
+            ref={resolvedRef}
             type={inputType}
+            value={value}
+            defaultValue={defaultValue}
+            onChange={handleChange}
             className={clsx(
               BASE_INPUT_CLASSES,
               VARIANT_STYLES[variant],
@@ -122,7 +163,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             )}
           />
 
-          {(isPassword || rightElement) && (
+          {hasRightSlot && (
             <div
               className={clsx(
                 RIGHT_ELEMENT_CLASSES,
@@ -143,6 +184,15 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   ) : (
                     <EyeSlashIcon className="h-5 w-5" />
                   )}
+                </button>
+              ) : hasValue ? (
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="flex items-center justify-center border-none bg-transparent p-0 text-[rgb(var(--color-icon))] transition-colors hover:cursor-pointer hover:text-[rgb(var(--color-icon-hover))] focus:outline-none"
+                  aria-label="Clear input"
+                >
+                  <XCircleIcon className="h-5 w-5" />
                 </button>
               ) : (
                 <div className="text-icon hover:text-icon-hover flex cursor-pointer items-center transition-colors">
@@ -208,6 +258,25 @@ function EyeSlashIcon({ className, ...props }: React.ComponentProps<'svg'>) {
         strokeLinecap="round"
         strokeLinejoin="round"
         d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+      />
+    </svg>
+  );
+}
+
+function XCircleIcon({ className, ...props }: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
       />
     </svg>
   );

--- a/src/pages/Cart/Cart.test.tsx
+++ b/src/pages/Cart/Cart.test.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ROUTES } from '@/constants';
@@ -256,7 +257,7 @@ describe('Cart Page', () => {
     expect(screen.getAllByText('$100.00').length).toBeGreaterThanOrEqual(2);
   });
 
-  it('handles coupon application', () => {
+  it('handles coupon application', async () => {
     setupWithItems();
     render(
       <BrowserRouter>
@@ -264,13 +265,15 @@ describe('Cart Page', () => {
       </BrowserRouter>,
     );
 
+    const user = userEvent.setup();
+
     const input = screen.getByPlaceholderText(/Coupon Code/i);
-    fireEvent.change(input, { target: { value: 'SAVE10' } });
+    await user.type(input, 'SAVE10');
 
-    const applyBtn = screen.getByRole('button', { name: /apply/i });
-    fireEvent.click(applyBtn);
+    // Apply button is hidden while input has value (clear button takes its place),
+    // so we submit the form by pressing Enter instead
+    await user.keyboard('{Enter}');
 
-    // Input should be cleared after application (based on Cart.tsx logic)
     expect(input).toHaveValue('');
   });
 


### PR DESCRIPTION

Adds an inline clear (✕) button to all `Input` components without introducing new props.

**What changed:**
- Clear button appears automatically when the input has a value
- For `type="password"` — only the eye toggle is shown, no clear button
- When `rightElement` is provided — it's visible while the field is empty; once the user starts typing, the clear button replaces it
- No changes to the public API — fully backward compatible

**Implementation notes:**
- Controlled inputs (`value` prop) derive `hasValue` directly from the prop — no `useEffect`
- Uncontrolled inputs track value via internal `useState` updated in `onChange`/`handleClear`
- `onChange` type inferred via `NonNullable<typeof onChange>` to stay compatible with `BaseUIEvent` from `@base-ui/react`

**Tests:**
- Updated `Cart` coupon test to submit via `Enter` since `rightElement` (Apply button) is intentionally hidden while the input has a value

**Screenshots:**

#### Figma
<img width="363" height="67" alt="image" src="https://github.com/user-attachments/assets/b2915ad2-e283-43e6-b00c-edede198f532" />

#### Code
<img width="909" height="186" alt="image" src="https://github.com/user-attachments/assets/8637ad5f-8e07-43e5-b520-e6c95a3df6e0" />
