### PR TITLE
feat(426): rewrite order status service, hook, add logic for percentage

### DIFF
--- a/src/components/AdminDashboard/StatusOrdersWidget/StatusOrdersWidget.tsx
+++ b/src/components/AdminDashboard/StatusOrdersWidget/StatusOrdersWidget.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useOrdersStatusStats } from '@/hooks/useOrdersStatusStats';
@@ -40,14 +41,23 @@ export const StatusOrdersWidget = () => {
   const navigate = useNavigate();
   const { data, isLoading, error } = useOrdersStatusStats();
 
+  const statusesWithPercentage = useMemo(() => {
+    if (!data) return [];
+
+    return data.statuses.map((s) => ({
+      ...s,
+      percentage: data.total > 0 ? Math.round((s.count / data.total) * 100) : 0,
+    }));
+  }, [data]);
+
   if (isLoading) return <StatusOrdersSkeleton />;
   if (error || !data)
     return <div className="text-sm text-red-400">Error loading data</div>;
 
   return (
     <div className="flex flex-col items-center gap-6 py-2">
-      <StatusOrdersChart data={data} />
-      <StatusOrdersLegend statuses={data.statuses} />
+      <StatusOrdersChart data={{ ...data, statuses: statusesWithPercentage }} />
+      <StatusOrdersLegend statuses={statusesWithPercentage} />
 
       <button
         onClick={() => navigate('/admin/orders')}

--- a/src/hooks/useOrdersStatusStats.ts
+++ b/src/hooks/useOrdersStatusStats.ts
@@ -1,20 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@apollo/client/react';
 
-import { dashboardService } from '@/services/dashboardService';
+import { GET_ORDERS_STATUS_STATS } from '@/services/graphql/dashboardAdminService';
 import type { OrdersStatusStats } from '@/types';
 
 export const useOrdersStatusStats = () => {
-  const [data, setData] = useState<OrdersStatusStats | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, loading, error } = useQuery<{
+    ordersStatusStats: OrdersStatusStats;
+  }>(GET_ORDERS_STATUS_STATS);
 
-  useEffect(() => {
-    dashboardService
-      .getOrderStatusStats()
-      .then(setData)
-      .catch((e: Error) => setError(e.message))
-      .finally(() => setIsLoading(false));
-  }, []);
-
-  return { data, isLoading, error };
+  return {
+    data: data?.ordersStatusStats ?? null,
+    isLoading: loading,
+    error: error?.message ?? null,
+  };
 };

--- a/src/services/graphql/dashboardAdminService.ts
+++ b/src/services/graphql/dashboardAdminService.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const GET_ORDERS_STATUS_STATS = gql`
+  query GetOrdersStatusStats {
+    ordersStatusStats {
+      total
+      statuses {
+        status
+        count
+      }
+    }
+  }
+`;

--- a/src/types/dashboard.types.ts
+++ b/src/types/dashboard.types.ts
@@ -6,6 +6,5 @@ export interface OrderStatusSegment {
 
 export interface OrdersStatusStats {
   total: number;
-  largestSegment: OrderStatusSegment;
   statuses: OrderStatusSegment[];
 }


### PR DESCRIPTION
Rewrite orders status stats fetching from REST to GraphQL

Migrated orders status stats data fetching from REST to GraphQL.

- Added `GET_ORDERS_STATUS_STATS` query in `dashboardAdminService.ts`
- Removed old `dashboardService.ts` (REST)
- Refactored `useOrdersStatusStats` hook
- Moved `percentage` calculation from backend to `StatusOrdersWidget`