### PR TITLE
feat(436): add the ability to add additional images to products in admin

### DIFF
--- a/src/components/ProductForm/ProductForm.test.tsx
+++ b/src/components/ProductForm/ProductForm.test.tsx
@@ -60,6 +60,12 @@ describe('Component: ProductForm', () => {
           status: 'ACTIVE',
           description: 'Laptop for work',
           imagePreview: 'https://example.com/product.png',
+          additionalImages: [
+            {
+              imageUrl: 'https://example.com/product-detail.png',
+              imagePublicId: 'products/product-detail',
+            },
+          ],
         }}
         onSubmit={vi.fn()}
         onCancel={vi.fn()}
@@ -78,6 +84,10 @@ describe('Component: ProductForm', () => {
     expect(screen.getByAltText('Preview')).toHaveAttribute(
       'src',
       'https://example.com/product.png',
+    );
+    expect(screen.getByAltText('Existing gallery photo 1')).toHaveAttribute(
+      'src',
+      'https://example.com/product-detail.png',
     );
 
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
@@ -145,6 +155,8 @@ describe('Component: ProductForm', () => {
         description: 'Flagship phone',
         imagePreview: null,
         imageFile: undefined,
+        additionalImages: [],
+        additionalImageFiles: undefined,
       });
     });
   }, 10000);
@@ -197,6 +209,84 @@ describe('Component: ProductForm', () => {
     expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:preview');
   }, 10000);
 
+  it('should preview and remove selected gallery photos', async () => {
+    const user = userEvent.setup();
+    const createObjectURLMock = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation((file) => `blob:${(file as File).name}`);
+    const revokeObjectURLMock = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined);
+
+    const { container } = render(
+      <ProductForm onSubmit={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    const fileInputs = container.querySelectorAll('input[type="file"]');
+    const galleryInput = fileInputs[1] as HTMLInputElement;
+    const galleryFile = new File(['gallery'], 'gallery.png', {
+      type: 'image/png',
+    });
+
+    fireEvent.change(galleryInput, { target: { files: [galleryFile] } });
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(galleryFile);
+    expect(screen.getByAltText('Gallery preview 1')).toHaveAttribute(
+      'src',
+      'blob:gallery.png',
+    );
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove gallery photo 1' }),
+    );
+
+    expect(screen.queryByAltText('Gallery preview 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:gallery.png');
+  }, 10000);
+
+  it('should remove existing gallery photos from submit data', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+
+    render(
+      <ProductForm
+        isEditMode={true}
+        updatedAt="2025-10-10T12:00:00Z"
+        initialData={{
+          name: 'MacBook Pro',
+          price: '2499',
+          categories: 'laptop, electronics',
+          status: 'ACTIVE',
+          description: 'Laptop for work',
+          imagePreview: null,
+          additionalImages: [
+            {
+              imageUrl: 'https://example.com/product-detail.png',
+              imagePublicId: 'products/product-detail',
+            },
+          ],
+        }}
+        onSubmit={handleSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove existing gallery photo 1' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalImages: [],
+        }),
+      );
+    });
+  }, 10000);
+
   it('should update product status in edit mode', async () => {
     const user = userEvent.setup();
     const handleSubmit = vi.fn();
@@ -219,7 +309,7 @@ describe('Component: ProductForm', () => {
     );
 
     await user.click(screen.getByRole('combobox', { name: 'Status' }));
-    await user.click(screen.getByRole('option', { name: 'Inactive' }));
+    await user.click(await screen.findByRole('option', { name: 'Inactive' }));
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(
@@ -232,6 +322,8 @@ describe('Component: ProductForm', () => {
           description: 'Laptop for work',
           imagePreview: null,
           imageFile: undefined,
+          additionalImages: [],
+          additionalImageFiles: undefined,
         });
       },
       { timeout: 10000 },

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Image as ImageIcon } from 'lucide-react';
+import { Image as ImageIcon, X } from 'lucide-react';
 import { z } from 'zod';
 
 import { CategoryDropdown, Dropdown, Input, TextArea } from '@/components';
@@ -58,6 +58,15 @@ const productFormSchema = z.object({
     ),
   imagePreview: z.string().nullable(),
   imageFile: z.instanceof(File).optional(),
+  additionalImages: z
+    .array(
+      z.object({
+        imageUrl: z.string(),
+        imagePublicId: z.string(),
+      }),
+    )
+    .optional(),
+  additionalImageFiles: z.array(z.instanceof(File)).optional(),
 });
 
 interface ProductFormProps {
@@ -78,7 +87,12 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   updatedAt,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const additionalFileInputRef = useRef<HTMLInputElement>(null);
   const previewUrlRef = useRef<string | null>(null);
+  const additionalPreviewUrlsRef = useRef<Set<string>>(new Set());
+  const [additionalImagePreviews, setAdditionalImagePreviews] = useState<
+    string[]
+  >([]);
   const { categories } = useAdminCategories();
   const categoryOptions = categories.map((c) => ({
     label: c.title,
@@ -108,10 +122,17 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
+      additionalImages: initialData?.additionalImages || [],
     },
   });
 
   const imagePreview = useWatch({ control, name: 'imagePreview' });
+  const existingAdditionalImages =
+    useWatch({ control, name: 'additionalImages' }) || [];
+  const additionalImageFiles = useWatch({
+    control,
+    name: 'additionalImageFiles',
+  });
 
   useEffect(() => {
     register('imagePreview');
@@ -119,6 +140,9 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   }, [register]);
 
   useEffect(() => {
+    additionalPreviewUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    additionalPreviewUrlsRef.current.clear();
+
     reset({
       name: initialData?.name || '',
       price: initialData?.price || '',
@@ -131,6 +155,8 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       description: initialData?.description || '',
       imagePreview: initialData?.imagePreview || null,
       imageFile: undefined,
+      additionalImages: initialData?.additionalImages || [],
+      additionalImageFiles: undefined,
     });
   }, [initialData, reset]);
 
@@ -139,6 +165,10 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
       }
+      additionalPreviewUrlsRef.current.forEach((url) =>
+        URL.revokeObjectURL(url),
+      );
+      additionalPreviewUrlsRef.current.clear();
     };
   }, []);
 
@@ -159,6 +189,60 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       shouldDirty: true,
       shouldValidate: true,
     });
+  };
+
+  const handleAdditionalImagesChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+
+    const previewUrls = files.map((file) => {
+      const previewUrl = URL.createObjectURL(file);
+      additionalPreviewUrlsRef.current.add(previewUrl);
+      return previewUrl;
+    });
+
+    setAdditionalImagePreviews((previews) => [...previews, ...previewUrls]);
+    setValue(
+      'additionalImageFiles',
+      [...(additionalImageFiles || []), ...files],
+      {
+        shouldDirty: true,
+        shouldValidate: true,
+      },
+    );
+    e.target.value = '';
+  };
+
+  const handleRemoveAdditionalImage = (index: number) => {
+    const previewToRemove = additionalImagePreviews[index];
+    if (previewToRemove) {
+      URL.revokeObjectURL(previewToRemove);
+      additionalPreviewUrlsRef.current.delete(previewToRemove);
+    }
+
+    const nextFiles = (additionalImageFiles || []).filter(
+      (_, fileIndex) => fileIndex !== index,
+    );
+    setAdditionalImagePreviews((previews) =>
+      previews.filter((_, previewIndex) => previewIndex !== index),
+    );
+    setValue('additionalImageFiles', nextFiles.length ? nextFiles : undefined, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
+  const handleRemoveExistingAdditionalImage = (index: number) => {
+    setValue(
+      'additionalImages',
+      existingAdditionalImages.filter((_, imageIndex) => imageIndex !== index),
+      {
+        shouldDirty: true,
+        shouldValidate: true,
+      },
+    );
   };
 
   const handleSave = async (data: ProductFormData) => {
@@ -209,6 +293,76 @@ export const ProductForm: React.FC<ProductFormProps> = ({
           >
             Choose File
           </button>
+          <input
+            type="file"
+            ref={additionalFileInputRef}
+            onChange={handleAdditionalImagesChange}
+            accept="image/*"
+            multiple
+            className="hidden"
+          />
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button
+              type="button"
+              onClick={() => additionalFileInputRef.current?.click()}
+              className="cursor-pointer rounded-md border border-green-500 bg-transparent px-5 py-1.5 text-green-500 hover:border hover:border-green-500/60 dark:hover:bg-green-900/20"
+            >
+              Add Gallery Photos
+            </button>
+            {!!additionalImageFiles?.length && (
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                {additionalImageFiles.length} selected
+              </span>
+            )}
+          </div>
+          {existingAdditionalImages.length > 0 && (
+            <div className="flex max-w-xs flex-wrap justify-center gap-2">
+              {existingAdditionalImages.map((image, index) => (
+                <div
+                  key={image.imagePublicId}
+                  className="relative h-20 w-20 overflow-hidden rounded-lg bg-gray-200 dark:bg-gray-800"
+                >
+                  <img
+                    src={image.imageUrl}
+                    alt={`Existing gallery photo ${index + 1}`}
+                    className="h-full w-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    aria-label={`Remove existing gallery photo ${index + 1}`}
+                    onClick={() => handleRemoveExistingAdditionalImage(index)}
+                    className="absolute top-1 right-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border border-white/70 bg-black/60 text-white hover:bg-black/80"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {additionalImagePreviews.length > 0 && (
+            <div className="flex max-w-xs flex-wrap justify-center gap-2">
+              {additionalImagePreviews.map((previewUrl, index) => (
+                <div
+                  key={previewUrl}
+                  className="group relative h-20 w-20 overflow-hidden rounded-lg bg-gray-200 dark:bg-gray-800"
+                >
+                  <img
+                    src={previewUrl}
+                    alt={`Gallery preview ${index + 1}`}
+                    className="h-full w-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    aria-label={`Remove gallery photo ${index + 1}`}
+                    onClick={() => handleRemoveAdditionalImage(index)}
+                    className="absolute top-1 right-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border border-white/70 bg-black/60 text-white hover:bg-black/80"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/src/hooks/useGetAdminProduct.ts
+++ b/src/hooks/useGetAdminProduct.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client/react';
 
 import { GET_PRODUCT } from '@/services/graphql/productAdminService';
-import type { ProductStatusUpperCase } from '@/types';
+import type { ProductImage, ProductStatusUpperCase } from '@/types';
 
 interface GetProductData {
   product: {
@@ -13,6 +13,7 @@ interface GetProductData {
     description: string;
     categories: string[];
     imageUrl?: string;
+    additionalImages?: ProductImage[];
   };
 }
 

--- a/src/pages/Admin/CreateProduct/CreateProduct.tsx
+++ b/src/pages/Admin/CreateProduct/CreateProduct.tsx
@@ -24,6 +24,12 @@ export const CreateProduct = () => {
         uploadedImage = await uploadImage(formData.imageFile);
       }
 
+      const uploadedAdditionalImages = formData.additionalImageFiles?.length
+        ? await Promise.all(
+            formData.additionalImageFiles.map((file) => uploadImage(file)),
+          )
+        : [];
+
       const input = {
         title: formData.name,
         price: parseFloat(formData.price),
@@ -38,6 +44,9 @@ export const CreateProduct = () => {
           imageUrl: uploadedImage.imageUrl,
           imagePublicId: uploadedImage.imagePublicId,
         }),
+        ...(uploadedAdditionalImages.length
+          ? { additionalImages: uploadedAdditionalImages }
+          : {}),
       };
 
       await createProduct(input);

--- a/src/pages/Admin/EditProduct/EditProduct.tsx
+++ b/src/pages/Admin/EditProduct/EditProduct.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { AdminPageHeader } from '@/components';
@@ -31,17 +32,22 @@ export const EditProduct = () => {
   const { updateProduct, loading: isUpdating } = useUpdateAdminProduct();
   const { uploadImage, loading: isUploading } = useUploadProductImage();
 
-  const initialData = product
-    ? {
-        name: product.title,
-        price: String(product.price),
-        description: product.description || '',
-        categories: product.categories?.join(', ') || '',
-        status: product.status,
-        imagePreview: product.imageUrl || null,
-        updatedAt: product.updatedAt,
-      }
-    : null;
+  const initialData = useMemo(
+    () =>
+      product
+        ? {
+            name: product.title,
+            price: String(product.price),
+            description: product.description || '',
+            categories: product.categories?.join(', ') || '',
+            status: product.status,
+            imagePreview: product.imageUrl || null,
+            additionalImages: product.additionalImages || [],
+            updatedAt: product.updatedAt,
+          }
+        : null,
+    [product],
+  );
 
   if (!id) return <Navigate to={ROUTES.ADMIN_PRODUCTS} replace />;
 
@@ -80,12 +86,22 @@ export const EditProduct = () => {
         uploadedImage = await uploadImage(formData.imageFile);
       }
 
+      const uploadedAdditionalImages = formData.additionalImageFiles?.length
+        ? await Promise.all(
+            formData.additionalImageFiles.map((file) => uploadImage(file)),
+          )
+        : [];
+
       await updateProduct(id, {
         title: formData.name,
         price: Number(formData.price),
         status: formData.status as ProductStatus,
         description: formData.description,
         categories: formData.categories.split(',').map((c) => c.trim()),
+        additionalImages: [
+          ...(formData.additionalImages || []),
+          ...uploadedAdditionalImages,
+        ],
         ...(uploadedImage && {
           imageUrl: uploadedImage.imageUrl,
           imagePublicId: uploadedImage.imagePublicId,

--- a/src/pages/ProductDetails/ProductDetails.tsx
+++ b/src/pages/ProductDetails/ProductDetails.tsx
@@ -75,7 +75,10 @@ export const ProductDetails = () => {
     addItem(product, quantity);
   };
 
-  const images = product.imageUrl ? [product.imageUrl] : [];
+  const images = [
+    ...(product.imageUrl ? [product.imageUrl] : []),
+    ...(product.additionalImages || []).map((image) => image.imageUrl),
+  ];
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/services/graphql/productAdminService.ts
+++ b/src/services/graphql/productAdminService.ts
@@ -51,6 +51,10 @@ export const GET_PRODUCT = gql`
       categories
       imageUrl
       imagePublicId
+      additionalImages {
+        imageUrl
+        imagePublicId
+      }
     }
   }
 `;
@@ -67,6 +71,10 @@ export const CREATE_PRODUCT = gql`
       categories
       imageUrl
       imagePublicId
+      additionalImages {
+        imageUrl
+        imagePublicId
+      }
     }
   }
 `;
@@ -83,6 +91,10 @@ export const UPDATE_PRODUCT = gql`
       categories
       imageUrl
       imagePublicId
+      additionalImages {
+        imageUrl
+        imagePublicId
+      }
     }
   }
 `;

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -8,12 +8,18 @@ export const PRODUCT_STATUS = {
 export type ProductStatus = 'active' | 'inactive' | 'draft';
 export type ProductStatusUpperCase = Uppercase<ProductStatus>;
 
+export interface ProductImage {
+  imageUrl: string;
+  imagePublicId: string;
+}
+
 export interface Product {
   _id?: string;
   id: string;
   categories?: string[];
   imageUrl?: string;
   imagePublicId?: string;
+  additionalImages?: ProductImage[];
   price: number;
   title: string;
   status: ProductStatus;
@@ -62,9 +68,8 @@ export interface ProductFormData {
   description: string;
   imagePreview: string | null;
   imageFile?: File;
+  additionalImages?: ProductImage[];
+  additionalImageFiles?: File[];
 }
 
-export interface UploadProductImageResponse {
-  imageUrl: string;
-  imagePublicId: string;
-}
+export type UploadProductImageResponse = ProductImage;


### PR DESCRIPTION
Add product gallery images

- upload multiple additional product photos
- preview and remove gallery photos in admin form
- save gallery images on create/edit
- show gallery images on product details page

