### PR TITLE
feat(454): enhance ABCAnalysisTable with pagination and total count display

### DIFF
--- a/src/components/ABCAnalysisTable/ABCAnalysisTable.test.tsx
+++ b/src/components/ABCAnalysisTable/ABCAnalysisTable.test.tsx
@@ -33,6 +33,7 @@ describe('UI Component: ABCAnalysisTable', () => {
         metric: 'REVENUE',
         totalValue: 1200.5,
       },
+      total: 1,
       loading: false,
       error: undefined,
       refetch: vi.fn(),
@@ -68,6 +69,7 @@ describe('UI Component: ABCAnalysisTable', () => {
         },
       ],
       summary: null,
+      total: 1,
       loading: false,
       error: undefined,
       refetch: vi.fn(),
@@ -101,6 +103,7 @@ describe('UI Component: ABCAnalysisTable', () => {
     mockUseAbcAnalysis.mockReturnValue({
       items: [],
       summary: null,
+      total: 1,
       loading: false,
       error: undefined,
       refetch: vi.fn(),

--- a/src/components/ABCAnalysisTable/ABCAnalysisTable.tsx
+++ b/src/components/ABCAnalysisTable/ABCAnalysisTable.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react';
 
-import { MainTable, Switcher } from '@/components';
+import { MainTable, Pagination, Switcher } from '@/components';
 import { ThresholdRange } from '@/components';
+import { ADMIN_PAGE_LIMIT } from '@/constants';
 import {
   COLOR_MIN,
   COLOR_RANGE,
   LEFT_MAX,
   LEFT_MIN,
+  PAGE,
   QUANTITY,
   REVENUE,
   RIGHT_MAX,
@@ -55,19 +57,24 @@ export function ABCAnalysisTable() {
   const [metricMode, setMetricMode] = useState<MetricMode>(REVENUE);
   const [redThreshold, setRedThreshold] = useState(LEFT_MIN);
   const [greenThreshold, setGreenThreshold] = useState(RIGHT_MAX);
+  const [currentPage, setCurrentPage] = useState(PAGE);
 
-  const { items, summary, loading, error } = useAbcAnalysis({
+  const { items, summary, total, loading, error } = useAbcAnalysis({
     metric: toMetricEnum(metricMode),
+    page: currentPage,
+    limit: ADMIN_PAGE_LIMIT,
     aThreshold: redThreshold,
     bThreshold: greenThreshold,
   });
 
   const handleRedThresholdChange = (value: number) => {
     setRedThreshold(Math.max(LEFT_MIN, Math.min(value, LEFT_MAX)));
+    setCurrentPage(PAGE);
   };
 
   const handleGreenThresholdChange = (value: number) => {
     setGreenThreshold(Math.min(RIGHT_MAX, Math.max(value, RIGHT_MIN)));
+    setCurrentPage(PAGE);
   };
 
   const columns = useMemo<Column[]>(
@@ -140,11 +147,12 @@ export function ABCAnalysisTable() {
           isRightActive={metricMode === REVENUE}
           leftLabel="Count"
           rightLabel="Revenue"
-          onToggle={() =>
+          onToggle={() => {
             setMetricMode((prevMode) =>
               prevMode === REVENUE ? QUANTITY : REVENUE,
-            )
-          }
+            );
+            setCurrentPage(PAGE);
+          }}
           ariaLabel="Toggle between quantity and revenue"
         />
 
@@ -170,6 +178,12 @@ export function ABCAnalysisTable() {
         emptyMessage="No ABC analysis data found"
         renderRow={(item) => renderRow(item)}
         summary={summary ? renderSummary(summary) : null}
+      />
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={total}
+        onPageChange={setCurrentPage}
       />
     </div>
   );

--- a/src/hooks/useAbcAnalysis.test.ts
+++ b/src/hooks/useAbcAnalysis.test.ts
@@ -1,0 +1,139 @@
+import * as ApolloClient from '@apollo/client/react';
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ADMIN_PAGE_LIMIT } from '@/constants';
+import { PAGE, REVENUE } from '@/constants/general';
+import { GET_ABC_ANALYSIS } from '@/services/graphql/statisticsAdminService';
+
+import { useAbcAnalysis } from './useAbcAnalysis';
+
+vi.mock('@apollo/client/react', () => ({
+  useQuery: vi.fn(),
+}));
+
+describe('useAbcAnalysis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:30:45.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls query with default variables and computed date range', () => {
+    const refetch = vi.fn();
+
+    vi.mocked(ApolloClient.useQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+      refetch,
+    } as unknown as ReturnType<typeof ApolloClient.useQuery>);
+
+    renderHook(() => useAbcAnalysis());
+
+    expect(ApolloClient.useQuery).toHaveBeenCalledWith(GET_ABC_ANALYSIS, {
+      variables: {
+        metric: REVENUE.toUpperCase(),
+        page: PAGE,
+        limit: ADMIN_PAGE_LIMIT,
+        dateFrom: '2026-05-01T00:00:00.000Z',
+        dateTo: '2026-05-15T12:30:45.000Z',
+        aThreshold: 80,
+        bThreshold: 95,
+        categoryId: null,
+      },
+    });
+  });
+
+  it('returns mapped data and respects custom params', () => {
+    const refetch = vi.fn();
+    const items = [
+      {
+        productName: 'Phone',
+        productCode: 'P-1001',
+        value: 15,
+        cumulativeValue: 15,
+        totalValue: 100,
+        cumulativePercentage: 15,
+        percentageByTotal: 15,
+        bucket: 'A' as const,
+      },
+    ];
+    const summary = {
+      aCount: 2,
+      bCount: 3,
+      cCount: 4,
+      metric: 'UNITS' as const,
+      totalValue: 100,
+    };
+
+    vi.mocked(ApolloClient.useQuery).mockReturnValue({
+      data: {
+        getAbcAnalysis: {
+          items,
+          summary,
+          total: 9,
+        },
+      },
+      loading: true,
+      error: undefined,
+      refetch,
+    } as unknown as ReturnType<typeof ApolloClient.useQuery>);
+
+    const { result } = renderHook(() =>
+      useAbcAnalysis({
+        metric: 'UNITS',
+        page: 2,
+        limit: 25,
+        dateFrom: '2026-05-10T00:00:00.000Z',
+        dateTo: '2026-05-12T00:00:00.000Z',
+        aThreshold: 70,
+        bThreshold: 90,
+        categoryId: 'cat-1',
+      }),
+    );
+
+    expect(ApolloClient.useQuery).toHaveBeenCalledWith(GET_ABC_ANALYSIS, {
+      variables: {
+        metric: 'UNITS',
+        page: 2,
+        limit: 25,
+        dateFrom: '2026-05-10T00:00:00.000Z',
+        dateTo: '2026-05-12T00:00:00.000Z',
+        aThreshold: 70,
+        bThreshold: 90,
+        categoryId: 'cat-1',
+      },
+    });
+    expect(result.current.items).toEqual(items);
+    expect(result.current.summary).toEqual(summary);
+    expect(result.current.total).toBe(9);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.refetch).toBe(refetch);
+  });
+
+  it('returns fallback values when query data is missing', () => {
+    const queryError = new Error('Network error');
+    const refetch = vi.fn();
+
+    vi.mocked(ApolloClient.useQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: queryError,
+      refetch,
+    } as unknown as ReturnType<typeof ApolloClient.useQuery>);
+
+    const { result } = renderHook(() => useAbcAnalysis({ page: 3 }));
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.summary).toBeNull();
+    expect(result.current.total).toBe(PAGE);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(queryError);
+    expect(result.current.refetch).toBe(refetch);
+  });
+});

--- a/src/hooks/useAbcAnalysis.ts
+++ b/src/hooks/useAbcAnalysis.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useQuery } from '@apollo/client/react';
 
+import { ADMIN_PAGE_LIMIT } from '@/constants';
+import { PAGE } from '@/constants/general';
 import { REVENUE } from '@/constants/general';
 import { GET_ABC_ANALYSIS } from '@/services/graphql/statisticsAdminService';
 import type {
@@ -23,6 +25,8 @@ function getDefaultRange() {
 
 interface UseAbcAnalysisParams {
   metric?: AbcMetricEnum;
+  page?: number;
+  limit?: number;
   dateFrom?: string;
   dateTo?: string;
   aThreshold?: number;
@@ -32,6 +36,8 @@ interface UseAbcAnalysisParams {
 
 export function useAbcAnalysis({
   metric = REVENUE.toUpperCase() as AbcMetricEnum,
+  page = PAGE,
+  limit = ADMIN_PAGE_LIMIT,
   dateFrom,
   dateTo,
   aThreshold = 80,
@@ -42,6 +48,8 @@ export function useAbcAnalysis({
 
   const variables: AbcAnalysisQueryVariables = {
     metric,
+    page,
+    limit,
     dateFrom: dateFrom ?? defaults.dateFrom,
     dateTo: dateTo ?? defaults.dateTo,
     aThreshold,
@@ -57,6 +65,7 @@ export function useAbcAnalysis({
   return {
     items: data?.getAbcAnalysis?.items ?? [],
     summary: data?.getAbcAnalysis?.summary ?? null,
+    total: data?.getAbcAnalysis?.total ?? PAGE,
     loading,
     error,
     refetch,

--- a/src/hooks/useGetAdminCategory.test.ts
+++ b/src/hooks/useGetAdminCategory.test.ts
@@ -1,0 +1,65 @@
+import * as ApolloClient from '@apollo/client/react';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET_CATEGORY } from '@/services/graphql/categoryAdminService';
+
+import { useGetAdminCategory } from './useGetAdminCategory';
+
+vi.mock('@apollo/client/react', () => ({
+  useQuery: vi.fn(),
+}));
+
+describe('useGetAdminCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns category data when id is provided', () => {
+    const category = {
+      id: 'category-1',
+      title: 'Phones',
+      imageUrl: 'https://example.com/phone.jpg',
+      description: 'Smartphones and accessories',
+      parent: null,
+      depth: 1,
+      createdAt: '2026-03-20T10:00:00.000Z',
+      updatedAt: '2026-03-20T10:00:00.000Z',
+    };
+
+    vi.mocked(ApolloClient.useQuery).mockReturnValue({
+      data: { category },
+      loading: false,
+      error: undefined,
+    } as unknown as ReturnType<typeof ApolloClient.useQuery>);
+
+    const { result } = renderHook(() => useGetAdminCategory('category-1'));
+
+    expect(ApolloClient.useQuery).toHaveBeenCalledWith(GET_CATEGORY, {
+      variables: { id: 'category-1' },
+      skip: false,
+    });
+    expect(result.current.category).toEqual(category);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('skips query when id is missing and exposes undefined category', () => {
+    const queryError = new Error('Missing id');
+
+    vi.mocked(ApolloClient.useQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: queryError,
+    } as unknown as ReturnType<typeof ApolloClient.useQuery>);
+
+    const { result } = renderHook(() => useGetAdminCategory());
+
+    expect(ApolloClient.useQuery).toHaveBeenCalledWith(GET_CATEGORY, {
+      variables: { id: undefined },
+      skip: true,
+    });
+    expect(result.current.category).toBeUndefined();
+    expect(result.current.error).toBe(queryError);
+  });
+});

--- a/src/pages/NotFound/NotFound.test.tsx
+++ b/src/pages/NotFound/NotFound.test.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { NotFound } from './NotFound';
@@ -22,5 +22,20 @@ describe('NotFound page', () => {
     expect(
       screen.getByRole('link', { name: /browse shop/i }),
     ).toBeInTheDocument();
+  });
+
+  it('navigates to home when Go to Home button is clicked', () => {
+    const originalLocation = window.location;
+
+    delete (window as Partial<Window>).location;
+    window.location = { ...originalLocation, href: '/not-found' } as Location;
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /go to home/i }));
+
+    expect(window.location.href).toBe('/');
+
+    window.location = originalLocation;
   });
 });

--- a/src/services/graphql/statisticsAdminService.ts
+++ b/src/services/graphql/statisticsAdminService.ts
@@ -88,6 +88,8 @@ export const GET_ABC_ANALYSIS = gql`
     $dateFrom: DateTime!
     $dateTo: DateTime!
     $metric: AbcMetricEnum!
+    $page: Int!
+    $limit: Int!
     $aThreshold: Int
     $bThreshold: Int
     $categoryId: ID
@@ -96,10 +98,15 @@ export const GET_ABC_ANALYSIS = gql`
       dateFrom: $dateFrom
       dateTo: $dateTo
       metric: $metric
+      page: $page
+      limit: $limit
       aThreshold: $aThreshold
       bThreshold: $bThreshold
       categoryId: $categoryId
     ) {
+      total
+      page
+      limit
       items {
         productName
         productCode

--- a/src/types/statistic.types.ts
+++ b/src/types/statistic.types.ts
@@ -110,6 +110,7 @@ export interface AbcAnalysisQueryData {
   getAbcAnalysis: {
     items: AbcAnalysisItem[];
     summary: AbcAnalysisSummary;
+    total: number;
   };
 }
 
@@ -117,6 +118,8 @@ export interface AbcAnalysisQueryVariables {
   dateFrom: string;
   dateTo: string;
   metric: AbcMetricEnum;
+  page: number;
+  limit: number;
   aThreshold?: number;
   bThreshold?: number;
   categoryId?: string | null;


### PR DESCRIPTION
- Added pagination component to ABCAnalysisTable for improved navigation.
- Integrated total count of items into the table's state and UI.
- Updated useAbcAnalysis hook to fetch pagination data and total pages.
- Adjusted tests to reflect changes in data structure and UI components.