### PR TITLE
feat(450): add pagination to group table

### DIFF
--- a/src/hooks/useGroupByTable.ts
+++ b/src/hooks/useGroupByTable.ts
@@ -32,12 +32,13 @@ function getDefaultRange() {
     dateTo: now.toISOString(),
   };
 }
-
-interface UseSalesByProductParams {
+interface UseGroupByTableParams {
   groupBy?: GroupByEnum;
   dateFrom?: string;
   dateTo?: string;
   categoryId?: string | null;
+  page?: number;
+  limit?: number;
 }
 
 export function useGroupByTable({
@@ -45,7 +46,9 @@ export function useGroupByTable({
   dateFrom,
   dateTo,
   categoryId = null,
-}: UseSalesByProductParams = {}) {
+  page = 1,
+  limit = 10,
+}: UseGroupByTableParams = {}) {
   const defaults = useMemo(() => getDefaultRange(), []);
 
   const variables: SalesByProductQueryVariables = {
@@ -53,6 +56,8 @@ export function useGroupByTable({
     dateFrom: dateFrom ?? defaults.dateFrom,
     dateTo: dateTo ?? defaults.dateTo,
     categoryId,
+    page,
+    limit,
   };
 
   const query =
@@ -69,24 +74,19 @@ export function useGroupByTable({
     variables,
   });
 
-  const items =
+  const response =
     groupBy === DAY
-      ? ((data as SalesByDayQueryData | undefined)?.getSalesByDay?.items ?? [])
+      ? (data as SalesByDayQueryData | undefined)?.getSalesByDay
       : groupBy === CATEGORY
-        ? ((data as SalesByCategoryQueryData | undefined)?.getSalesByCategory
-            ?.items ?? [])
-        : ((data as SalesByProductQueryData | undefined)?.getSalesByProduct
-            ?.items ?? []);
+        ? (data as SalesByCategoryQueryData | undefined)?.getSalesByCategory
+        : (data as SalesByProductQueryData | undefined)?.getSalesByProduct;
 
-  const summary =
-    groupBy === DAY
-      ? ((data as SalesByDayQueryData | undefined)?.getSalesByDay?.summary ??
-        null)
-      : groupBy === CATEGORY
-        ? ((data as SalesByCategoryQueryData | undefined)?.getSalesByCategory
-            ?.summary ?? null)
-        : ((data as SalesByProductQueryData | undefined)?.getSalesByProduct
-            ?.summary ?? null);
+  const items = response?.items ?? [];
+  const summary = response?.summary ?? null;
+  const total = response?.total ?? 0;
+  const currentPage = response?.page ?? page;
+  const currentLimit = response?.limit ?? limit;
+  const totalPages = total > 0 ? Math.ceil(total / currentLimit) : 0;
 
   return {
     items: items as
@@ -98,6 +98,10 @@ export function useGroupByTable({
       | SalesByDaySummary
       | SalesByCategorySummary
       | null,
+    total,
+    page: currentPage,
+    limit: currentLimit,
+    totalPages,
     groupBy,
     loading,
     error,

--- a/src/pages/Admin/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard/Dashboard.tsx
@@ -6,6 +6,7 @@ import {
   Dropdown,
   type DropdownOption,
   GroupTable,
+  Pagination,
   SalesDynamicsWidget,
   StatusOrdersWidget,
 } from '@/components';
@@ -31,6 +32,8 @@ const GROUP_BY_OPTIONS = [
   { label: 'Category', value: CATEGORY },
 ];
 
+const GROUP_TABLE_LIMIT = 10;
+
 function DashboardCard({
   title,
   className = '',
@@ -55,6 +58,7 @@ export function Dashboard() {
   const { isSuperAdmin } = useAuth();
   const [selectedPeriod, setSelectedPeriod] = useState(getCurrentMonthPeriod());
   const [selectedGroupBy, setSelectedGroupBy] = useState<GroupByEnum>(DAY);
+  const [groupTablePage, setGroupTablePage] = useState(1);
 
   const {
     dailyCounts,
@@ -70,14 +74,20 @@ export function Dashboard() {
     summary: groupSummary,
     loading,
     error,
+    page,
+    totalPages,
   } = useGroupByTable({
     groupBy: selectedGroupBy,
+    page: groupTablePage,
+    limit: GROUP_TABLE_LIMIT,
   });
 
   const handleGroupByChange = (selected: DropdownOption[]) => {
     const nextGroupBy = selected[0]?.value as GroupByEnum | undefined;
     if (!nextGroupBy) return;
+
     setSelectedGroupBy(nextGroupBy);
+    setGroupTablePage(1);
   };
 
   return (
@@ -132,6 +142,16 @@ export function Dashboard() {
               loading={loading}
               error={error}
             />
+
+            {totalPages > 1 && (
+              <div className="flex justify-center px-4 py-4">
+                <Pagination
+                  currentPage={page}
+                  totalPages={totalPages}
+                  onPageChange={setGroupTablePage}
+                />
+              </div>
+            )}
           </DashboardCard>
         </div>
       </section>

--- a/src/services/graphql/statisticsAdminService.ts
+++ b/src/services/graphql/statisticsAdminService.ts
@@ -6,12 +6,16 @@ export const GET_SALES_BY_PRODUCT = gql`
     $dateTo: DateTime!
     $groupBy: GroupByEnum!
     $categoryId: ID
+    $page: Int
+    $limit: Int
   ) {
     getSalesByProduct(
       dateFrom: $dateFrom
       dateTo: $dateTo
       groupBy: $groupBy
       categoryId: $categoryId
+      page: $page
+      limit: $limit
     ) {
       items {
         productName
@@ -19,6 +23,9 @@ export const GET_SALES_BY_PRODUCT = gql`
         revenue
         productCode
       }
+      total
+      page
+      limit
       summary {
         totalUnitsSold
         totalRevenue
@@ -33,12 +40,16 @@ export const GET_SALES_BY_DAY = gql`
     $dateTo: DateTime!
     $groupBy: GroupByEnum!
     $categoryId: ID
+    $page: Int
+    $limit: Int
   ) {
     getSalesByDay(
       dateFrom: $dateFrom
       dateTo: $dateTo
       groupBy: $groupBy
       categoryId: $categoryId
+      page: $page
+      limit: $limit
     ) {
       items {
         date
@@ -47,6 +58,9 @@ export const GET_SALES_BY_DAY = gql`
         revenue
         averageCheck
       }
+      total
+      page
+      limit
       summary {
         totalOrdersCount
         totalUnitsSold
@@ -63,18 +77,25 @@ export const GET_SALES_BY_CATEGORY = gql`
     $dateTo: DateTime!
     $groupBy: GroupByEnum!
     $categoryId: ID
+    $page: Int
+    $limit: Int
   ) {
     getSalesByCategory(
       dateFrom: $dateFrom
       dateTo: $dateTo
       groupBy: $groupBy
       categoryId: $categoryId
+      page: $page
+      limit: $limit
     ) {
       items {
         category
         unitsSold
         revenue
       }
+      total
+      page
+      limit
       summary {
         totalUnitsSold
         totalRevenue

--- a/src/types/statistic.types.ts
+++ b/src/types/statistic.types.ts
@@ -56,25 +56,30 @@ export interface SalesByCategorySummary {
   totalRevenue: number;
 }
 
+export interface PaginatedSalesResponse<TItem, TSummary> {
+  items: TItem[];
+  total: number;
+  page: number;
+  limit: number;
+  summary: TSummary;
+}
+
 export interface SalesByProductQueryData {
-  getSalesByProduct: {
-    items: SalesByProductItem[];
-    summary: SalesByProductSummary;
-  };
+  getSalesByProduct: PaginatedSalesResponse<
+    SalesByProductItem,
+    SalesByProductSummary
+  >;
 }
 
 export interface SalesByDayQueryData {
-  getSalesByDay: {
-    items: SalesByDayItem[];
-    summary: SalesByDaySummary;
-  };
+  getSalesByDay: PaginatedSalesResponse<SalesByDayItem, SalesByDaySummary>;
 }
 
 export interface SalesByCategoryQueryData {
-  getSalesByCategory: {
-    items: SalesByCategoryItem[];
-    summary: SalesByCategorySummary;
-  };
+  getSalesByCategory: PaginatedSalesResponse<
+    SalesByCategoryItem,
+    SalesByCategorySummary
+  >;
 }
 
 export interface SalesByProductQueryVariables {
@@ -82,6 +87,8 @@ export interface SalesByProductQueryVariables {
   dateTo: string;
   groupBy: GroupByEnum;
   categoryId?: string | null;
+  page?: number;
+  limit?: number;
 }
 
 export type AbcMetricEnum = 'UNITS' | 'REVENUE';


### PR DESCRIPTION
- Added page and limit variables to grouped sales GraphQL queries.
- Updated grouped sales response types to support paginated backend response fields: total, page, and limit.
- Updated useGroupByTable to pass pagination variables and calculate totalPages.
- Added pagination controls below the Group table on the Dashboard.
- Reset Group table page to 1 when the selected group type changes.