### PR TITLE
Feat/452 add filter to table abc

### DIFF
--- a/src/components/ABCAnalysisTable/ABCAnalysisTable.tsx
+++ b/src/components/ABCAnalysisTable/ABCAnalysisTable.tsx
@@ -1,7 +1,13 @@
 import { useMemo, useState } from 'react';
+import { ListFilter } from 'lucide-react';
 
-import { MainTable, Switcher } from '@/components';
-import { ThresholdRange } from '@/components';
+import {
+  Button,
+  MainTable,
+  SalesDynamicsFilter,
+  Switcher,
+  ThresholdRange,
+} from '@/components';
 import {
   COLOR_MIN,
   COLOR_RANGE,
@@ -22,6 +28,10 @@ import type {
   AbcBucket,
   AbcMetricEnum,
 } from '@/types/statistic.types';
+import {
+  getDefaultDateCurrentMonthForInput,
+  toIsoDateRange,
+} from '@/utils/date.utils';
 
 type MetricMode = typeof QUANTITY | typeof REVENUE;
 
@@ -51,15 +61,38 @@ const formatPercent = (value: number) => `${value.toFixed(1)}%`;
 const toMetricEnum = (mode: MetricMode): AbcMetricEnum =>
   mode === QUANTITY ? 'UNITS' : 'REVENUE';
 
+interface FilterState {
+  dateFrom: string;
+  dateTo: string;
+  categoryId: string;
+}
+
+function defaultFilter() {
+  return {
+    ...getDefaultDateCurrentMonthForInput(),
+    categoryId: '',
+  };
+}
+
 export function ABCAnalysisTable() {
   const [metricMode, setMetricMode] = useState<MetricMode>(REVENUE);
   const [redThreshold, setRedThreshold] = useState(LEFT_MIN);
   const [greenThreshold, setGreenThreshold] = useState(RIGHT_MAX);
+  const [showFilters, setShowFilters] = useState(false);
+  const [appliedFilter, setAppliedFilter] =
+    useState<FilterState>(defaultFilter);
+  const queryDateRange = useMemo(
+    () => toIsoDateRange(appliedFilter.dateFrom, appliedFilter.dateTo),
+    [appliedFilter.dateFrom, appliedFilter.dateTo],
+  );
 
   const { items, summary, loading, error } = useAbcAnalysis({
     metric: toMetricEnum(metricMode),
     aThreshold: redThreshold,
     bThreshold: greenThreshold,
+    dateFrom: queryDateRange.dateFrom,
+    dateTo: queryDateRange.dateTo,
+    categoryId: appliedFilter.categoryId || null,
   });
 
   const handleRedThresholdChange = (value: number) => {
@@ -134,20 +167,8 @@ export function ABCAnalysisTable() {
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center justify-end gap-4 px-5">
-        <Switcher
-          isRightActive={metricMode === REVENUE}
-          leftLabel="Count"
-          rightLabel="Revenue"
-          onToggle={() =>
-            setMetricMode((prevMode) =>
-              prevMode === REVENUE ? QUANTITY : REVENUE,
-            )
-          }
-          ariaLabel="Toggle between quantity and revenue"
-        />
-
+    <div className="flex flex-col gap-4 space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-4 px-5">
         <ThresholdRange
           redThreshold={redThreshold}
           greenThreshold={greenThreshold}
@@ -160,6 +181,42 @@ export function ABCAnalysisTable() {
           onRedThresholdChange={handleRedThresholdChange}
           onGreenThresholdChange={handleGreenThresholdChange}
         />
+
+        <div className="flex gap-4">
+          <Switcher
+            isRightActive={metricMode === REVENUE}
+            leftLabel="Count"
+            rightLabel="Revenue"
+            onToggle={() =>
+              setMetricMode((prevMode) =>
+                prevMode === REVENUE ? QUANTITY : REVENUE,
+              )
+            }
+            ariaLabel="Toggle between quantity and revenue"
+          />
+
+          <div className="relative">
+            <Button
+              variant="outline"
+              onClick={() => setShowFilters((prev) => !prev)}
+              className="flex items-center gap-2 border-gray-300! bg-white text-gray-700 shadow-sm transition hover:bg-gray-50"
+            >
+              <ListFilter className="h-5 w-5" />
+              Filters
+            </Button>
+
+            {showFilters && (
+              <SalesDynamicsFilter
+                isOpen={true}
+                onClose={() => setShowFilters(false)}
+                onApply={(filter) => setAppliedFilter(filter as FilterState)}
+                initial={appliedFilter}
+                isRequired={false}
+                isShowProduct={false}
+              />
+            )}
+          </div>
+        </div>
       </div>
 
       <MainTable

--- a/src/components/SalesDynamicsFilter/SalesDynamicsFilter.tsx
+++ b/src/components/SalesDynamicsFilter/SalesDynamicsFilter.tsx
@@ -10,12 +10,14 @@ export interface FilterState {
   dateFrom: string;
   dateTo: string;
   categoryId: string;
-  productId: string;
-  productName: string;
+  productId?: string;
+  productName?: string;
 }
 
 export interface SalesDynamicsFilterProps {
   isOpen: boolean;
+  isRequired?: boolean;
+  isShowProduct?: boolean;
   onClose: () => void;
   onApply: (filter: FilterState) => void;
   initial: FilterState;
@@ -44,6 +46,8 @@ const emptyFilter = (): FilterState => {
 export function SalesDynamicsFilter({
   isOpen,
   onClose,
+  isRequired = true,
+  isShowProduct = true,
   onApply,
   initial,
 }: SalesDynamicsFilterProps) {
@@ -183,44 +187,46 @@ export function SalesDynamicsFilter({
             </div>
           </div>
 
-          <div>
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-[13px] font-semibold text-blue-500">
-                Product
-              </span>
-              <button
-                onClick={() =>
-                  setDraft((p) => ({ ...p, productId: '', productName: '' }))
-                }
-                className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-slate-400 transition-colors outline-none hover:bg-slate-100 hover:text-blue-500 focus:outline-none"
-                title="Reset product"
-              >
-                <RotateCcw size={14} strokeWidth={1.5} />
-              </button>
-            </div>
-            <div className="relative">
-              <select
-                value={draft.productId}
-                onChange={(e) => handleProductChange(e.target.value)}
-                disabled={!draft.categoryId || prodLoading}
-                className="h-10 w-full cursor-pointer appearance-none rounded-lg border border-slate-200 bg-white px-3 pr-8 text-[13px] text-slate-700 transition-colors outline-none focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <option value="">
-                  {!draft.categoryId ? 'Select category first' : 'Product'}
-                </option>
-                {products.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.title}
+          {isShowProduct && (
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-[13px] font-semibold text-blue-500">
+                  Product
+                </span>
+                <button
+                  onClick={() =>
+                    setDraft((p) => ({ ...p, productId: '', productName: '' }))
+                  }
+                  className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-slate-400 transition-colors outline-none hover:bg-slate-100 hover:text-blue-500 focus:outline-none"
+                  title="Reset product"
+                >
+                  <RotateCcw size={14} strokeWidth={1.5} />
+                </button>
+              </div>
+              <div className="relative">
+                <select
+                  value={draft.productId}
+                  onChange={(e) => handleProductChange(e.target.value)}
+                  disabled={!draft.categoryId || prodLoading}
+                  className="h-10 w-full cursor-pointer appearance-none rounded-lg border border-slate-200 bg-white px-3 pr-8 text-[13px] text-slate-700 transition-colors outline-none focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <option value="">
+                    {!draft.categoryId ? 'Select category first' : 'Product'}
                   </option>
-                ))}
-              </select>
-              <ChevronDown
-                size={14}
-                strokeWidth={1.5}
-                className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-slate-400"
-              />
+                  {products.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.title}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  size={14}
+                  strokeWidth={1.5}
+                  className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-slate-400"
+                />
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         <div className="flex gap-3 border-t border-slate-100 px-5 py-4">
@@ -236,7 +242,7 @@ export function SalesDynamicsFilter({
           <Button
             variant="primary"
             onClick={handleApply}
-            disabled={!draft.productId}
+            disabled={!draft.productId && isRequired}
             className="flex flex-1 items-center justify-center gap-2"
           >
             <Check size={14} strokeWidth={1.5} />

--- a/src/hooks/useAbcAnalysis.test.ts
+++ b/src/hooks/useAbcAnalysis.test.ts
@@ -131,7 +131,8 @@ describe('useAbcAnalysis', () => {
 
     expect(result.current.items).toEqual([]);
     expect(result.current.summary).toBeNull();
-    expect(result.current.total).toBe(PAGE);
+    expect(result.current.total).toBe(0);
+    expect(result.current.totalPages).toBe(1);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(queryError);
     expect(result.current.refetch).toBe(refetch);

--- a/src/hooks/useAbcAnalysis.ts
+++ b/src/hooks/useAbcAnalysis.ts
@@ -8,18 +8,7 @@ import type {
   AbcAnalysisQueryVariables,
   AbcMetricEnum,
 } from '@/types/statistic.types';
-
-function getDefaultRange() {
-  const now = new Date();
-  const startOfMonth = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0),
-  );
-
-  return {
-    dateFrom: startOfMonth.toISOString(),
-    dateTo: now.toISOString(),
-  };
-}
+import { getDefaultDateCurrentMonth } from '@/utils/date.utils';
 
 interface UseAbcAnalysisParams {
   metric?: AbcMetricEnum;
@@ -38,7 +27,7 @@ export function useAbcAnalysis({
   bThreshold = 95,
   categoryId = null,
 }: UseAbcAnalysisParams = {}) {
-  const defaults = useMemo(() => getDefaultRange(), []);
+  const defaults = useMemo(() => getDefaultDateCurrentMonth(), []);
 
   const variables: AbcAnalysisQueryVariables = {
     metric,
@@ -57,7 +46,10 @@ export function useAbcAnalysis({
   return {
     items: data?.getAbcAnalysis?.items ?? [],
     summary: data?.getAbcAnalysis?.summary ?? null,
+    categoryId,
     loading,
+    dateFrom,
+    dateTo,
     error,
     refetch,
   };

--- a/src/types/statistic.types.ts
+++ b/src/types/statistic.types.ts
@@ -111,6 +111,8 @@ export interface AbcAnalysisQueryData {
     items: AbcAnalysisItem[];
     summary: AbcAnalysisSummary;
     total: number;
+    page: number;
+    limit: number;
   };
 }
 

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -5,6 +5,11 @@ import type { RegistrationByDayRow } from '@/types/statistic.types';
 /**
  * Format a date to a readable string
  */
+
+export function toDateInputValue(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
 export const formatDate = (date: Date): string => {
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
@@ -46,6 +51,35 @@ export function buildDailyCountsFromRegistrations(
 export function getCurrentMonthPeriod() {
   const now = new Date();
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function getDefaultDateCurrentMonth() {
+  const now = new Date();
+  const startOfMonth = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0),
+  );
+
+  return {
+    dateFrom: startOfMonth.toISOString(),
+    dateTo: now.toISOString(),
+  };
+}
+
+export function getDefaultDateCurrentMonthForInput() {
+  const to = new Date();
+  const from = new Date(to.getFullYear(), to.getMonth(), 1);
+
+  return {
+    dateFrom: toDateInputValue(from),
+    dateTo: toDateInputValue(to),
+  };
+}
+
+export function toIsoDateRange(dateFrom: string, dateTo: string) {
+  return {
+    dateFrom: new Date(dateFrom).toISOString(),
+    dateTo: new Date(`${dateTo}T23:59:59`).toISOString(),
+  };
 }
 
 export function resolvePeriod(period?: string) {


### PR DESCRIPTION
- Added filtering capabilities to the ABC Analysis table, including date-range handling and category-based filtering via the Sales Dynamics filter panel.
- Updated useAbcAnalysis to support pagination-related data (total / totalPages) and aligned the hook response with backend pagination fields.
- Extended ABC analysis GraphQL-related typing (AbcAnalysisQueryData) and adjusted tests to reflect the updated pagination behavior.
- Introduced date utility helpers to normalize and reuse date-range conversions across the ABC analysis flow.