### PR TITLE
fix(458): export respects active filters

### DIFF
--- a/src/components/ExportButton/ExportButton.tsx
+++ b/src/components/ExportButton/ExportButton.tsx
@@ -3,14 +3,29 @@ import { Download } from 'lucide-react';
 
 import { Button } from '@/components';
 import { EXPORT_TYPES, type ExportType } from '@/constants';
-import { exportService } from '@/services/exportService';
+import {
+  type ExportOrdersParams,
+  type ExportProductsParams,
+  exportService,
+} from '@/services/exportService';
 import { useErrorStore } from '@/store/errorStore';
+import type { ProductsFilters } from '@/types/filters';
 
-interface ExportButtonProps {
-  type: ExportType;
+interface ExportButtonProductsProps {
+  type: Extract<ExportType, 'products'>;
+  filters?: ProductsFilters;
+  search?: string;
 }
 
-export function ExportButton({ type }: ExportButtonProps) {
+interface ExportButtonOrdersProps {
+  type: Extract<ExportType, 'orders'>;
+  status?: string;
+}
+
+type ExportButtonProps = ExportButtonProductsProps | ExportButtonOrdersProps;
+
+export function ExportButton(props: ExportButtonProps) {
+  const { type } = props;
   const [isLoading, setIsLoading] = useState(false);
   const showMessage = useErrorStore((s) => s.show);
 
@@ -19,11 +34,29 @@ export function ExportButton({ type }: ExportButtonProps) {
     try {
       const isProducts = type === EXPORT_TYPES.PRODUCTS;
       const fileName = isProducts ? 'products_export' : 'orders_export';
-      const onExport = isProducts
-        ? exportService.exportProducts
-        : exportService.exportOrders;
 
-      const blob = await onExport();
+      let blob: Blob;
+      if (isProducts) {
+        const p = props as ExportButtonProductsProps;
+        const params: ExportProductsParams = {};
+        if (p.filters) {
+          if (p.filters.status) params.status = p.filters.status;
+          if (p.filters.categories.length > 0)
+            params.category = p.filters.categories;
+          if (p.filters.minPrice) params.minPrice = p.filters.minPrice;
+          if (p.filters.maxPrice) params.maxPrice = p.filters.maxPrice;
+          if (p.filters.dateFrom) params.dateFrom = p.filters.dateFrom;
+          if (p.filters.dateTo) params.dateTo = p.filters.dateTo;
+          if (p.filters.dateField) params.dateField = p.filters.dateField;
+        }
+        if (p.search) params.search = p.search;
+        blob = await exportService.exportProducts(params);
+      } else {
+        const p = props as ExportButtonOrdersProps;
+        const params: ExportOrdersParams = {};
+        if (p.status) params.status = p.status;
+        blob = await exportService.exportOrders(params);
+      }
 
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');

--- a/src/pages/Admin/Orders/AdminOrders.tsx
+++ b/src/pages/Admin/Orders/AdminOrders.tsx
@@ -124,7 +124,7 @@ export function AdminOrders() {
           + Create Order
         </Button>
 
-        <ExportButton type={EXPORT_TYPES.ORDERS} />
+        <ExportButton type={EXPORT_TYPES.ORDERS} status={currentStatus} />
       </div>
 
       <OrderTabs />

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -199,7 +199,11 @@ export function AdminProducts() {
           >
             Import
           </Button>
-          <ExportButton type={EXPORT_TYPES.PRODUCTS} />{' '}
+          <ExportButton
+            type={EXPORT_TYPES.PRODUCTS}
+            filters={filters}
+            search={search}
+          />{' '}
         </div>
 
         <div className="flex items-center justify-end gap-4 p-4">

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,14 +1,42 @@
 import { API_BASE_URL, API_ENDPOINTS } from '@/constants';
 
+export interface ExportProductsParams {
+  status?: string;
+  search?: string;
+  category?: string[];
+  minPrice?: string;
+  maxPrice?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  dateField?: 'createdAt' | 'updatedAt';
+}
+
+export interface ExportOrdersParams {
+  status?: string;
+  search?: string;
+}
+
 export const exportService = {
-  exportProducts: async (): Promise<Blob> => {
-    const response = await fetch(
-      `${API_BASE_URL}${API_ENDPOINTS.EXPORT_PRODUCTS}`,
-      {
-        method: 'GET',
-        credentials: 'include',
-      },
-    );
+  exportProducts: async (params?: ExportProductsParams): Promise<Blob> => {
+    const query = new URLSearchParams();
+    if (params) {
+      if (params.status) query.append('status', params.status);
+      if (params.search) query.append('search', params.search);
+      if (params.category && params.category.length > 0) {
+        params.category.forEach((c) => query.append('category', c));
+      }
+      if (params.minPrice) query.append('minPrice', params.minPrice);
+      if (params.maxPrice) query.append('maxPrice', params.maxPrice);
+      if (params.dateFrom) query.append('dateFrom', params.dateFrom);
+      if (params.dateTo) query.append('dateTo', params.dateTo);
+      if (params.dateField) query.append('dateField', params.dateField);
+    }
+    const queryString = query.toString();
+    const url = `${API_BASE_URL}${API_ENDPOINTS.EXPORT_PRODUCTS}${queryString ? `?${queryString}` : ''}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+    });
 
     if (!response.ok) {
       throw new Error('Failed to export products');
@@ -41,14 +69,18 @@ export const exportService = {
     return await response.blob();
   },
 
-  exportOrders: async (): Promise<Blob> => {
-    const response = await fetch(
-      `${API_BASE_URL}${API_ENDPOINTS.EXPORT_ORDERS}`,
-      {
-        method: 'GET',
-        credentials: 'include',
-      },
-    );
+  exportOrders: async (params?: ExportOrdersParams): Promise<Blob> => {
+    const query = new URLSearchParams();
+    if (params) {
+      if (params.status) query.append('status', params.status);
+      if (params.search) query.append('search', params.search);
+    }
+    const queryString = query.toString();
+    const url = `${API_BASE_URL}${API_ENDPOINTS.EXPORT_ORDERS}${queryString ? `?${queryString}` : ''}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+    });
 
     if (!response.ok) {
       throw new Error('Failed to export orders');


### PR DESCRIPTION
## Summary
- Export Products and Export Orders now apply the same filters that are active in the admin panel
- Previously, clicking Export always downloaded all records regardless of what filters were set

Closes UA-5399-React/docs#458