### PR TITLE
feat(459): add bulk select, duplicate and delete for admin products table

### DIFF
--- a/src/components/TableProducts/TableProducts.test.tsx
+++ b/src/components/TableProducts/TableProducts.test.tsx
@@ -9,6 +9,8 @@ const mockNavigate = vi.fn();
 const mockDuplicate = vi.fn();
 const mockDelete = vi.fn();
 const mockSortChange = vi.fn();
+const mockToggleSelect = vi.fn();
+const mockSelectAll = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -48,9 +50,12 @@ const defaultProps = {
   error: undefined,
   sort: 'title' as const,
   order: 'asc' as const,
+  selectedIds: [] as string[],
   onSortChange: mockSortChange,
   onDelete: mockDelete,
   onDuplicate: mockDuplicate,
+  onToggleSelect: mockToggleSelect,
+  onSelectAll: mockSelectAll,
 };
 
 const renderTable = (
@@ -209,9 +214,12 @@ describe('UI Component: TableProducts', () => {
         loading={false}
         sort="updatedAt"
         order="desc"
+        selectedIds={[]}
         onSortChange={vi.fn()}
         onDelete={mockDelete}
         onDuplicate={mockDuplicate}
+        onToggleSelect={mockToggleSelect}
+        onSelectAll={mockSelectAll}
       />,
     );
     const img = screen.getByRole('img', { name: mockProducts[0].title });
@@ -229,9 +237,12 @@ describe('UI Component: TableProducts', () => {
         loading={false}
         sort="updatedAt"
         order="desc"
+        selectedIds={[]}
         onSortChange={vi.fn()}
         onDelete={mockDelete}
         onDuplicate={mockDuplicate}
+        onToggleSelect={mockToggleSelect}
+        onSelectAll={mockSelectAll}
       />,
     );
     expect(screen.queryByRole('img')).not.toBeInTheDocument();

--- a/src/components/TableProducts/TableProducts.tsx
+++ b/src/components/TableProducts/TableProducts.tsx
@@ -15,9 +15,12 @@ interface TableProductsProps {
   error?: Error | null;
   sort: ProductSortField;
   order: SortOrder;
+  selectedIds: string[];
   onSortChange: (field: ProductSortField) => void;
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
+  onToggleSelect: (id: string) => void;
+  onSelectAll: (ids: string[]) => void;
 }
 
 function renderBodyContent(
@@ -28,6 +31,8 @@ function renderBodyContent(
   navigate: ReturnType<typeof useNavigate>,
   onDelete: (id: string) => void,
   onDuplicate: (id: string) => void,
+  selectedIds: string[],
+  onToggleSelect: (id: string) => void,
 ) {
   if (loading) {
     return (
@@ -87,7 +92,11 @@ function renderBodyContent(
       >
         <td>
           <div className="flex items-center gap-2">
-            <Checkbox className="h-[20px] w-[20px]" />
+            <Checkbox
+              className="h-[20px] w-[20px]"
+              checked={selectedIds.includes(item.id)}
+              onCheckedChange={() => onToggleSelect(item.id)}
+            />
             {item.imageUrl ? (
               <img
                 src={item.imageUrl}
@@ -156,12 +165,20 @@ export function TableProducts({
   error,
   sort,
   order,
+  selectedIds,
   onSortChange,
   onDelete,
   onDuplicate,
+  onToggleSelect,
+  onSelectAll,
 }: TableProductsProps) {
   const { isDark } = useTheme();
   const navigate = useNavigate();
+
+  const pageIds = items.map((i) => i.id);
+  const allSelected =
+    pageIds.length > 0 && pageIds.every((id) => selectedIds.includes(id));
+  const someSelected = pageIds.some((id) => selectedIds.includes(id));
 
   return (
     <div className="mx-5 mt-5 overflow-x-auto rounded-l-lg rounded-r-lg border border-[#e5e7eb] shadow-md">
@@ -170,7 +187,14 @@ export function TableProducts({
           <tr>
             <th>
               <div className="flex items-center gap-2">
-                <Checkbox className="h-[20px] w-[20px]" />
+                <Checkbox
+                  className="h-[20px] w-[20px]"
+                  checked={allSelected}
+                  indeterminate={!allSelected && someSelected}
+                  onCheckedChange={(checked) =>
+                    onSelectAll(checked ? pageIds : [])
+                  }
+                />
                 <span>Image</span>
               </div>
             </th>
@@ -232,6 +256,8 @@ export function TableProducts({
             navigate,
             onDelete,
             onDuplicate,
+            selectedIds,
+            onToggleSelect,
           )}
         </tbody>
       </table>

--- a/src/pages/Admin/Products/AdminProducts.tsx
+++ b/src/pages/Admin/Products/AdminProducts.tsx
@@ -22,6 +22,7 @@ import { useDuplicate } from '@/hooks/useDuplicate';
 import { useErrorMessage } from '@/hooks/useErrorMessage';
 import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useAdminProductsStore } from '@/store/useAdminProductsStore';
+import { PRODUCT_STATUS } from '@/types';
 import { type ProductsFilters } from '@/types/filters';
 import type {
   ProductSortField,
@@ -47,8 +48,19 @@ export function AdminProducts() {
 
   useErrorMessage();
 
-  const { filters, search, sort, order, setFilters, setSearch, setSort } =
-    useAdminProductsStore();
+  const {
+    filters,
+    search,
+    sort,
+    order,
+    selectedIds,
+    setFilters,
+    setSearch,
+    setSort,
+    toggleSelect,
+    selectAll,
+    clearSelection,
+  } = useAdminProductsStore();
 
   const {
     currentPage,
@@ -75,6 +87,10 @@ export function AdminProducts() {
   });
 
   const selectedSortValue = buildSortValue(sort, order);
+
+  useEffect(() => {
+    return () => clearSelection();
+  }, []);
 
   useEffect(() => {
     normalizeInvalidPageParam();
@@ -145,6 +161,7 @@ export function AdminProducts() {
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
+    clearSelection();
   };
 
   const handleCreateProduct = () => {
@@ -152,20 +169,62 @@ export function AdminProducts() {
   };
 
   const handleDeleteProduct = (id: string) => {
+    const isBulk = selectedIds.includes(id) && selectedIds.length > 1;
+    const draftIds = isBulk
+      ? items
+          .filter(
+            (item) =>
+              selectedIds.includes(item.id) &&
+              item.status.toUpperCase() === PRODUCT_STATUS.DRAFT,
+          )
+          .map((item) => item.id)
+      : [id];
+
+    if (isBulk && draftIds.length === 0) return;
+
+    const description = isBulk
+      ? `Delete ${draftIds.length} draft product${draftIds.length !== 1 ? 's' : ''}?${
+          selectedIds.length > draftIds.length
+            ? ` (${selectedIds.length - draftIds.length} non-draft will be skipped)`
+            : ''
+        }`
+      : 'Are you sure you want to delete this product?';
+
     openConfirmModal({
-      title: 'Delete Product',
-      description: 'Are you sure you want to delete this product?',
+      title: isBulk ? 'Delete Selected' : 'Delete Product',
+      description,
       isCritical: true,
       confirmText: 'Delete',
       onConfirm: async () => {
-        await deleteProduct(id);
-        navigate('.', {
-          state: {
-            successMessage: 'Product deleted successfully!',
-          },
-        });
+        if (isBulk) {
+          await Promise.all(draftIds.map((draftId) => deleteProduct(draftId)));
+          clearSelection();
+        } else {
+          await deleteProduct(id);
+          navigate('.', {
+            state: { successMessage: 'Product deleted successfully!' },
+          });
+        }
       },
     });
+  };
+
+  const handleDuplicate = async (id: string) => {
+    if (selectedIds.includes(id) && selectedIds.length > 1) {
+      openConfirmModal({
+        title: 'Duplicate Selected',
+        description: `Duplicate ${selectedIds.length} products?`,
+        confirmText: 'Duplicate',
+        onConfirm: async () => {
+          await Promise.all(
+            selectedIds.map((selectedId) => duplicateProduct(selectedId)),
+          );
+          clearSelection();
+        },
+      });
+    } else {
+      await duplicateProduct(id);
+    }
   };
 
   return (
@@ -199,7 +258,7 @@ export function AdminProducts() {
           >
             Import
           </Button>
-          <ExportButton type={EXPORT_TYPES.PRODUCTS} />{' '}
+          <ExportButton type={EXPORT_TYPES.PRODUCTS} />
         </div>
 
         <div className="flex items-center justify-end gap-4 p-4">
@@ -225,9 +284,12 @@ export function AdminProducts() {
           error={error}
           sort={sort}
           order={order}
+          selectedIds={selectedIds}
           onSortChange={handleTableSortChange}
           onDelete={handleDeleteProduct}
-          onDuplicate={duplicateProduct}
+          onDuplicate={handleDuplicate}
+          onToggleSelect={toggleSelect}
+          onSelectAll={selectAll}
         />
 
         <Pagination

--- a/src/store/useAdminProductsStore.ts
+++ b/src/store/useAdminProductsStore.ts
@@ -10,11 +10,15 @@ interface AdminProductsStore {
   page: number;
   sort: ProductSortField;
   order: SortOrder;
+  selectedIds: string[];
   setFilters: (filters: ProductsFilters) => void;
   setSearch: (serach: string) => void;
   setPage: (page: number) => void;
   setSort: (sort: ProductSortField, order: SortOrder) => void;
   reset: () => void;
+  toggleSelect: (id: string) => void;
+  selectAll: (ids: string[]) => void;
+  clearSelection: () => void;
 }
 
 export const useAdminProductsStore = create<AdminProductsStore>((set) => ({
@@ -23,6 +27,7 @@ export const useAdminProductsStore = create<AdminProductsStore>((set) => ({
   page: 1,
   sort: 'updatedAt',
   order: 'desc',
+  selectedIds: [],
   setFilters: (filters) => set({ filters, page: 1 }),
   setSearch: (search) =>
     set({
@@ -39,4 +44,12 @@ export const useAdminProductsStore = create<AdminProductsStore>((set) => ({
       sort: 'updatedAt',
       order: 'desc',
     }),
+  toggleSelect: (id) =>
+    set((state) => ({
+      selectedIds: state.selectedIds.includes(id)
+        ? state.selectedIds.filter((s) => s !== id)
+        : [...state.selectedIds, id],
+    })),
+  selectAll: (ids) => set({ selectedIds: ids }),
+  clearSelection: () => set({ selectedIds: [] }),
 }));


### PR DESCRIPTION
## Summary

- Added checkboxes to the products table (header with indeterminate state + per-row)
- Bulk duplicate: selecting 2+ items and clicking Duplicate on any selected row opens a confirmation modal and runs all duplications in parallel
- Bulk delete: filters to DRAFT-only items in selection, shows count of skipped non-drafts, runs all deletions in parallel
- Selection clears on page change and on leaving the products page

Closes UA-5399-React/docs#459