### PR TITLE
fix(462): reflect group table pagination in URL search params on Admin Dashboard

### DIFF
--- a/src/pages/Admin/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard/Dashboard.tsx
@@ -20,6 +20,7 @@ import { ROUTES } from '@/constants';
 import { CATEGORY, DAY, PRODUCT } from '@/constants/general';
 import { useAuth } from '@/hooks/useAuth';
 import { useGroupByTable } from '@/hooks/useGroupByTable';
+import { usePaginationPageParam } from '@/hooks/usePaginationPageParam';
 import { useUserStats } from '@/hooks/useUserStats';
 import type { GroupByEnum } from '@/types/statistic.types';
 import { getCurrentMonthPeriod } from '@/utils';
@@ -66,7 +67,11 @@ export function Dashboard() {
   const { isSuperAdmin } = useAuth();
   const [selectedPeriod, setSelectedPeriod] = useState(getCurrentMonthPeriod());
   const [selectedGroupBy, setSelectedGroupBy] = useState<GroupByEnum>(DAY);
-  const [groupTablePage, setGroupTablePage] = useState(1);
+  const {
+    currentPage: groupTablePage,
+    setPage: setGroupTablePage,
+    resetPage: resetGroupTablePage,
+  } = usePaginationPageParam({ paramName: 'page' });
 
   const [filterOpen, setFilterOpen] = useState(false);
   const [groupFilter, setGroupFilter] =
@@ -106,7 +111,7 @@ export function Dashboard() {
     if (!nextGroupBy) return;
 
     setSelectedGroupBy(nextGroupBy);
-    setGroupTablePage(1);
+    resetGroupTablePage();
   };
 
   return (
@@ -162,7 +167,10 @@ export function Dashboard() {
                 <GroupTableFilter
                   isOpen={filterOpen}
                   onClose={() => setFilterOpen(false)}
-                  onApply={setGroupFilter}
+                  onApply={(filter) => {
+                    setGroupFilter(filter);
+                    resetGroupTablePage();
+                  }}
                   initial={groupFilter}
                 />
               </div>


### PR DESCRIPTION
## Summary

- Replaced `useState` with `usePaginationPageParam` on Admin Dashboard so the Group table page number is reflected in the URL (`?page=N`), consistent with all other admin pages (Products, Users, Categories, Orders)
- Page now resets to 1 when the Group-by dropdown changes or a date filter is applied

Closes UA-5399-React/docs#462