### PR TITLE
feat(465): added drag and drop icon to featured products

### DIFF
--- a/src/pages/Admin/FeaturedProducts/FeaturedProducts.test.tsx
+++ b/src/pages/Admin/FeaturedProducts/FeaturedProducts.test.tsx
@@ -124,7 +124,7 @@ describe('Page: FeaturedProducts', () => {
     const menuTrigger = screen.getByLabelText(/actions for airpods/i);
     await user.click(menuTrigger);
 
-    const editButton = screen.getByText(/^edit$/i);
+    const editButton = await screen.findByText(/^edit$/i);
     await user.click(editButton);
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.stringContaining('prod-3'),
@@ -264,5 +264,58 @@ describe('Page: FeaturedProducts', () => {
     });
 
     expect(apiClient.patch).toHaveBeenCalled();
+  });
+
+  it('resets confirm button when search text changes', async () => {
+    renderPage();
+    const searchInput = await screen.findByRole('textbox');
+
+    await user.type(searchInput, 'iPhone');
+
+    const addButton = await screen.findByRole('button', {
+      name: /add iphone 15/i,
+    });
+    await user.click(addButton);
+
+    const confirmBtn = await screen.findByRole('button', { name: /confirm/i });
+    expect(confirmBtn).toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'Mac');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /confirm/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes previous menu when a new one is opened', async () => {
+    (apiClient.get as Mock).mockImplementation((url: string) => {
+      if (url.includes('/featured-products'))
+        return Promise.resolve([
+          ...mockFeatured,
+          {
+            productId: { _id: 'prod-4', title: 'iPhone Case', price: 20 },
+            type: 'new_arrival',
+            position: 1,
+          },
+        ]);
+      return Promise.resolve(mockProducts);
+    });
+
+    renderPage();
+
+    const triggers = await screen.findAllByLabelText(/actions for/i);
+
+    await user.click(triggers[0]);
+    expect(await screen.findByText(/^edit$/i)).toBeInTheDocument();
+
+    await user.click(triggers[1]);
+
+    await waitFor(() => {
+      const editButtons = screen.getAllByText(/^edit$/i);
+      expect(editButtons).toHaveLength(1);
+    });
   });
 });

--- a/src/pages/Admin/FeaturedProducts/FeaturedProducts.tsx
+++ b/src/pages/Admin/FeaturedProducts/FeaturedProducts.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useEffect, useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 import type { DragEndEvent } from '@dnd-kit/core';
@@ -9,7 +10,13 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Check, Loader2, PackageSearch, Plus } from 'lucide-react';
+import {
+  Check,
+  GripVertical,
+  Loader2,
+  PackageSearch,
+  Plus,
+} from 'lucide-react';
 import { Pencil, Trash } from 'lucide-react';
 
 import { AdminPageHeader, SearchInput } from '@/components';
@@ -43,24 +50,37 @@ function SortableItem({ product, children }: SortableItemProps) {
     isDragging,
   } = useSortable({ id: product._id });
 
-  const style = {
+  const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    position: isDragging ? 'relative' : undefined,
     zIndex: isDragging ? 50 : 1,
   };
+
+  const childrenArray = React.Children.toArray(children);
+  const content = childrenArray[0];
+  const actionMenu = childrenArray[1];
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      {...attributes}
-      {...listeners}
-      tabIndex={0}
       className={`hover:bg-backgroundSec/50 bg-background flex items-center justify-between px-6 py-4 transition-colors ${
         isDragging ? 'z-50 opacity-80 shadow-2xl ring-2 ring-blue-500/20' : ''
-      } cursor-grab active:cursor-grabbing`}
+      }`}
     >
-      {children}
+      <div className="flex flex-1 flex-grow items-center gap-4">
+        <div
+          {...attributes}
+          {...listeners}
+          className="text-muted hover:text-text cursor-grab p-1 transition-colors active:cursor-grabbing"
+        >
+          <GripVertical size={20} aria-label="Drag handle" />
+        </div>
+
+        {content}
+      </div>
+      {actionMenu}
     </div>
   );
 }
@@ -235,6 +255,7 @@ export function FeaturedProducts() {
                 onChange={(val) => {
                   setSearch(val);
                   setSelectedProductId(null);
+                  setConfirmId(null);
                 }}
                 className={`[&_input]:bg-backgroundSec [&_input]:text-text [&_input]:border-fieldBorder [&_button]:hover:!bg-background/50 [&_button]:right-3 [&_button]:!border-none [&_button]:!bg-transparent [&_button]:!shadow-none ${
                   featured.length >= NEW_ARRIVALS_LIMIT
@@ -288,6 +309,7 @@ export function FeaturedProducts() {
                         ) : confirmId === product._id ? (
                           <button
                             type="button"
+                            aria-label="Confirm"
                             onClick={(e) => {
                               e.stopPropagation();
                               handleAddProduct(product);
@@ -301,6 +323,7 @@ export function FeaturedProducts() {
                         ) : (
                           <button
                             type="button"
+                            aria-label={`Add ${product.title}`}
                             onClick={(e) => {
                               e.stopPropagation();
                               setConfirmId(product._id);
@@ -374,7 +397,7 @@ export function FeaturedProducts() {
                         </div>
                       </div>
 
-                      <div onPointerDown={(e) => e.stopPropagation()}>
+                      <div className="ml-4 flex-shrink-0">
                         <ActionMenu
                           triggerAriaLabel={`Actions for ${product.title}`}
                           actions={[


### PR DESCRIPTION
Introduced a dedicated drag handle (GripVertical) to each item. Dragging is now restricted to this icon only, preventing accidental triggers and improving control

Fixed Z-index layering: The active item now stays on top of all other elements during transit by applying dynamic z-index and relative positioning

Opening a new action menu now automatically closes any previously opened one, ensuring a cleaner interface

Removed e.stopPropagation() to allow the menus to correctly handle "click-away" events for better overall behavior