### PR TITLE
feat(473): add wishlist item counter to navbar

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ROUTES } from '@/constants';
 import { useCartStore } from '@/store/useCartStore';
+import { useWishlistStore } from '@/store/useWishlistStore';
 import { act, fireEvent, render, screen, userEvent } from '@/utils/test-utils';
 
 import { Header } from './Header';
@@ -30,6 +31,10 @@ vi.mock('@/hooks/useAuth', () => ({
 
 vi.mock('@/hooks/useMe', () => ({
   useMe: (enabled: boolean) => mockUseMe(enabled),
+}));
+
+vi.mock('@/hooks/useWishlistProducts', () => ({
+  useWishlistProducts: vi.fn(),
 }));
 
 // ─── SearchInput stub ─────────────────────────────────────────────────────────
@@ -82,6 +87,7 @@ describe('UI Component: Header', () => {
     mockUseMe.mockReturnValue({ data: undefined });
 
     useCartStore.setState({ items: [], isOpen: false });
+    useWishlistStore.setState({ items: [] });
   });
 
   // ── Static structure ────────────────────────────────────────────────────────
@@ -397,6 +403,36 @@ describe('UI Component: Header', () => {
     expect(badges[0]).toBeInTheDocument();
   });
 
+  // ── Wishlist badge ────────────────────────────────────────────────────────────
+  it('should display wishlist item count badge when wishlist has items', () => {
+    useWishlistStore.setState({
+      items: [
+        {
+          productId: 'p1',
+          title: 'Product 1',
+          price: 100,
+        },
+        {
+          productId: 'p2',
+          title: 'Product 2',
+          price: 200,
+        },
+      ],
+    });
+
+    render(<Header />);
+
+    const badges = screen.getAllByText('2');
+
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should not display wishlist badge when wishlist is empty', () => {
+    render(<Header />);
+
+    expect(screen.queryByText('0')).toBeNull();
+  });
+
   // ── Drawer open/close ────────────────────────────────────────────────────────
   it('should not render drawer by default', () => {
     render(<Header />);
@@ -435,6 +471,38 @@ describe('UI Component: Header', () => {
     expect(
       screen.queryByRole('button', { name: 'Close menu' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('should display wishlist badge in drawer when wishlist has items', async () => {
+    const user = userEvent.setup();
+
+    useWishlistStore.setState({
+      items: [
+        {
+          productId: 'p1',
+          title: 'Product 1',
+          price: 100,
+        },
+        {
+          productId: 'p2',
+          title: 'Product 2',
+          price: 200,
+        },
+        {
+          productId: 'p3',
+          title: 'Product 3',
+          price: 300,
+        },
+      ],
+    });
+
+    render(<Header />);
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const badges = screen.getAllByText('3');
+
+    expect(badges.length).toBeGreaterThanOrEqual(1);
   });
 
   // ── Body scroll lock ─────────────────────────────────────────────────────────

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,7 +14,13 @@ import {
 
 import logoDark from '@/assets/logo/dark_theme_logo.png';
 import logoLight from '@/assets/logo/light_theme_logo.png';
-import { Button, CartCounter, FlyoutCart, SearchInput } from '@/components';
+import {
+  Button,
+  CartCounter,
+  FlyoutCart,
+  SearchInput,
+  WishlistCounter,
+} from '@/components';
 import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks/useAuth';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
@@ -244,9 +250,10 @@ export const Header = () => {
             <Link
               to={ROUTES.WISHLIST}
               aria-label="Wishlist"
-              className="flex cursor-pointer items-center justify-center border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
+              className="flex cursor-pointer items-center justify-center gap-1.5 border-none bg-transparent p-0 text-inherit transition-opacity hover:opacity-70"
             >
               <Heart className="h-6 w-6" />
+              <WishlistCounter />
             </Link>
 
             <button
@@ -375,7 +382,10 @@ export const Header = () => {
                 className={`flex items-center justify-between border-b py-4 text-sm font-medium no-underline ${isDark ? 'border-gray-700 text-white' : 'border-gray-200 text-black'}`}
               >
                 <span>Wishlist</span>
-                <Heart className="h-5 w-5 shrink-0 text-gray-400" />
+                <div className="flex items-center gap-2">
+                  <Heart className="h-5 w-5 shrink-0 text-gray-400" />
+                  <WishlistCounter />
+                </div>
               </Link>
             </div>
             <div className="shrink-0 px-6 pt-2 pb-6">

--- a/src/components/HeartButton/HeartButton.test.tsx
+++ b/src/components/HeartButton/HeartButton.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ROUTES } from '@/constants';
 import { wishlistService } from '@/services/wishlist.service';
+import { useWishlistStore } from '@/store/useWishlistStore';
 
 import { HeartButton } from './HeartButton';
 
@@ -44,6 +45,7 @@ describe('HeartButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAuth = true;
+    useWishlistStore.setState({ items: [] });
   });
 
   it('renders with correct styles when isFavorite is true', () => {
@@ -79,6 +81,44 @@ describe('HeartButton', () => {
       'Added',
       'Product added to wishlist',
     );
+  });
+
+  it('updates wishlist store when adding product to wishlist', () => {
+    render(<HeartButton product={mockProduct} isFavorite={false} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+
+    expect(useWishlistStore.getState().items).toEqual([
+      {
+        productId: mockProduct.id,
+        title: mockProduct.title,
+        price: mockProduct.price,
+        image: mockProduct.image,
+      },
+    ]);
+  });
+
+  it('updates wishlist store when removing product from wishlist', () => {
+    useWishlistStore.setState({
+      items: [
+        {
+          productId: mockProduct.id,
+          title: mockProduct.title,
+          price: mockProduct.price,
+          image: mockProduct.image,
+        },
+      ],
+    });
+
+    render(<HeartButton product={mockProduct} isFavorite={true} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+
+    expect(useWishlistStore.getState().items).toEqual([]);
   });
 
   it('calls removeFromWishlist when clicked and is favorite', async () => {
@@ -126,6 +166,22 @@ describe('HeartButton', () => {
       'Wishlist Error',
       'Wishlist unavailable',
     );
+  });
+
+  it('rolls back wishlist store on add failure', async () => {
+    vi.mocked(wishlistService.addToWishlist).mockRejectedValueOnce(
+      new Error('Wishlist unavailable'),
+    );
+
+    render(<HeartButton product={mockProduct} isFavorite={false} />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(useWishlistStore.getState().items).toEqual([]);
+    });
   });
 
   it('navigates to login on failure when guest', async () => {

--- a/src/components/HeartButton/HeartButton.tsx
+++ b/src/components/HeartButton/HeartButton.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@/constants';
 import { useAuth } from '@/hooks';
 import { wishlistService } from '@/services/wishlist.service';
 import { useErrorStore } from '@/store/errorStore';
+import { useWishlistStore } from '@/store/useWishlistStore';
 
 interface HeartButtonProps {
   product: {
@@ -28,6 +29,8 @@ export const HeartButton = ({
   const { isAuth } = useAuth();
 
   const showMessage = useErrorStore((s) => s.show);
+  const addWishlistItem = useWishlistStore((state) => state.addItem);
+  const removeWishlistItem = useWishlistStore((state) => state.removeItem);
 
   useEffect(() => {
     setIsFavorite(initialIsFavorite);
@@ -40,8 +43,22 @@ export const HeartButton = ({
     if (isLoading) return;
 
     const previousState = isFavorite;
+
     setIsFavorite(!previousState);
     setIsLoading(true);
+
+    const wishlistItem = {
+      productId: product.id,
+      title: product.title,
+      price: product.price,
+      image: product.image,
+    };
+
+    if (previousState) {
+      removeWishlistItem(product.id);
+    } else {
+      addWishlistItem(wishlistItem);
+    }
 
     try {
       if (previousState) {
@@ -49,12 +66,7 @@ export const HeartButton = ({
 
         showMessage('success', 'Removed', 'Product removed from wishlist');
       } else {
-        await wishlistService.addToWishlist({
-          productId: product.id,
-          title: product.title,
-          price: product.price,
-          image: product.image,
-        });
+        await wishlistService.addToWishlist(wishlistItem);
 
         showMessage('success', 'Added', 'Product added to wishlist');
       }
@@ -64,6 +76,12 @@ export const HeartButton = ({
       }
 
       setIsFavorite(previousState);
+
+      if (previousState) {
+        addWishlistItem(wishlistItem);
+      } else {
+        removeWishlistItem(product.id);
+      }
 
       showMessage(
         'error',

--- a/src/components/WishlistCounter/WishlistCounter.test.tsx
+++ b/src/components/WishlistCounter/WishlistCounter.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTheme } from '@/hooks/useTheme';
+import { useWishlistStore } from '@/store/useWishlistStore';
+
+import { WishlistCounter } from './WishlistCounter';
+
+vi.mock('@/hooks/useWishlistProducts', () => ({
+  useWishlistProducts: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('WishlistCounter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useWishlistStore.setState({ items: [] });
+
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: false,
+    } as never);
+  });
+
+  it('does not render when wishlist is empty', () => {
+    const { container } = render(<WishlistCounter />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders wishlist item count for light theme', () => {
+    useWishlistStore.setState({
+      items: [
+        {
+          productId: 'p1',
+          title: 'Product 1',
+          price: 100,
+        },
+        {
+          productId: 'p2',
+          title: 'Product 2',
+          price: 200,
+        },
+      ],
+    });
+
+    render(<WishlistCounter />);
+
+    const counter = screen.getByText('2');
+
+    expect(counter).toBeInTheDocument();
+    expect(counter).toHaveClass('bg-black', 'text-white');
+  });
+
+  it('renders wishlist item count for dark theme', () => {
+    vi.mocked(useTheme).mockReturnValue({
+      isDark: true,
+    } as never);
+
+    useWishlistStore.setState({
+      items: [
+        {
+          productId: 'p1',
+          title: 'Product 1',
+          price: 100,
+        },
+      ],
+    });
+
+    render(<WishlistCounter />);
+
+    const counter = screen.getByText('1');
+
+    expect(counter).toBeInTheDocument();
+    expect(counter).toHaveClass('bg-white', 'text-black');
+  });
+});

--- a/src/components/WishlistCounter/WishlistCounter.tsx
+++ b/src/components/WishlistCounter/WishlistCounter.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from '@/hooks/useTheme';
+import { useWishlistProducts } from '@/hooks/useWishlistProducts';
+import { useWishlistStore } from '@/store/useWishlistStore';
+
+export const WishlistCounter = () => {
+  useWishlistProducts();
+
+  const { isDark } = useTheme();
+  const wishlistItemCount = useWishlistStore((state) => state.items.length);
+
+  if (wishlistItemCount <= 0) return null;
+
+  return (
+    <span
+      className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
+        isDark ? 'bg-white text-black' : 'bg-black text-white'
+      }`}
+    >
+      {wishlistItemCount}
+    </span>
+  );
+};

--- a/src/components/WishlistCounter/index.ts
+++ b/src/components/WishlistCounter/index.ts
@@ -1,0 +1,1 @@
+export { WishlistCounter } from './WishlistCounter';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -73,3 +73,4 @@ export { PasswordForm } from './UserProfile/PasswordForm/PasswordForm';
 export { UsersTable } from './UsersTable';
 export { UsersToolbar } from './UsersToolbar';
 export { UsersTopWidgets } from './UsersTopWidgets';
+export { WishlistCounter } from './WishlistCounter/WishlistCounter';

--- a/src/hooks/useWishlistProducts.ts
+++ b/src/hooks/useWishlistProducts.ts
@@ -1,51 +1,47 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import {
   type UserResponse,
-  type UserWishlistItem,
   wishlistService,
 } from '@/services/wishlist.service';
+import { useWishlistStore } from '@/store/useWishlistStore';
 import type { User } from '@/types/user';
 
 const EMPTY_WISHLIST_IDS = new Set<string>();
+
 type ExtendedUser = User & UserResponse;
 
 export const useWishlistProducts = () => {
   const { isAuth } = useAuth();
-  const [ids, setIds] = useState<Set<string>>(() => new Set());
-  const [user, setUser] = useState<ExtendedUser | null>(null);
-  const [wishlistItems, setWishlistItems] = useState<UserWishlistItem[]>([]);
 
+  const wishlistItems = useWishlistStore((state) => state.items);
+  const setWishlistItems = useWishlistStore((state) => state.setItems);
+  const removeWishlistItem = useWishlistStore((state) => state.removeItem);
+  const clearWishlistItems = useWishlistStore((state) => state.clearItems);
+
+  const [user, setUser] = useState<ExtendedUser | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    if (!isAuth) return;
+  const wishlistIds = useMemo(() => {
+    if (!isAuth) return EMPTY_WISHLIST_IDS;
 
-    const fetchWishlist = async () => {
-      try {
-        const user = await wishlistService.getMe();
-
-        setIds(new Set(user.wishlist?.map((item) => item.productId) ?? []));
-      } catch (err) {
-        console.error('Failed to fetch wishlist', err);
-      }
-    };
-
-    void fetchWishlist();
-  }, [isAuth]);
+    return new Set(wishlistItems.map((item) => item.productId));
+  }, [isAuth, wishlistItems]);
 
   useEffect(() => {
     if (!isAuth) {
       setUser(null);
-      setWishlistItems([]);
+      clearWishlistItems();
       return;
     }
 
     const loadWishlist = async () => {
       try {
         setIsLoading(true);
+
         const userData = await wishlistService.getMe();
+
         setUser(userData as ExtendedUser);
         setWishlistItems(userData.wishlist || []);
       } catch (error) {
@@ -54,8 +50,9 @@ export const useWishlistProducts = () => {
         setIsLoading(false);
       }
     };
+
     void loadWishlist();
-  }, [isAuth]);
+  }, [isAuth, setWishlistItems, clearWishlistItems]);
 
   const handleRemoveItemClick = async (
     e: React.MouseEvent<HTMLButtonElement>,
@@ -63,20 +60,22 @@ export const useWishlistProducts = () => {
   ) => {
     e.stopPropagation();
 
+    const previousItems = wishlistItems;
+
+    removeWishlistItem(productId);
+
     try {
       await wishlistService.removeFromWishlist(productId);
-      setWishlistItems((prev) =>
-        prev.filter((item) => item.productId !== productId),
-      );
     } catch (error) {
+      setWishlistItems(previousItems);
       console.error('Failed to remove item:', error);
     }
   };
 
   return {
-    wishlistIds: isAuth ? ids : EMPTY_WISHLIST_IDS,
-    isAuth: isAuth,
-    wishlistItems: wishlistItems,
+    wishlistIds,
+    isAuth,
+    wishlistItems,
     isLoading,
     user,
     setWishlistItems,

--- a/src/store/useWishlistStore.ts
+++ b/src/store/useWishlistStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+
+import type { UserWishlistItem } from '@/services/wishlist.service';
+
+type WishlistState = {
+  items: UserWishlistItem[];
+  setItems: (items: UserWishlistItem[]) => void;
+  addItem: (item: UserWishlistItem) => void;
+  removeItem: (productId: string) => void;
+  clearItems: () => void;
+};
+
+export const useWishlistStore = create<WishlistState>((set) => ({
+  items: [],
+
+  setItems: (items) => set({ items }),
+
+  addItem: (item) =>
+    set((state) => {
+      const alreadyExists = state.items.some(
+        (wishlistItem) => wishlistItem.productId === item.productId,
+      );
+
+      if (alreadyExists) return state;
+
+      return {
+        items: [...state.items, item],
+      };
+    }),
+
+  removeItem: (productId) =>
+    set((state) => ({
+      items: state.items.filter((item) => item.productId !== productId),
+    })),
+
+  clearItems: () => set({ items: [] }),
+}));


### PR DESCRIPTION
- Added WishlistCounter component for displaying the number of wishlist items
- Integrated wishlist counter into desktop Navbar and mobile drawer
- Added shared wishlist store for synchronized wishlist state
- Updated HeartButton to optimistically update wishlist state on add/remove
- Updated useWishlistProducts to sync backend wishlist data with the shared store
- Added and updated tests for wishlist counter behavior