### PR TITLE
Fix/471 inactive or draft products remain visible wishlist

### DIFF
--- a/src/components/HeartButton/HeartButton.test.tsx
+++ b/src/components/HeartButton/HeartButton.test.tsx
@@ -1,20 +1,21 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ROUTES } from '@/constants';
 import { wishlistService } from '@/services/wishlist.service';
 import { useWishlistStore } from '@/store/useWishlistStore';
+import { render, screen, userEvent, waitFor } from '@/utils/test-utils';
 
 import { HeartButton } from './HeartButton';
 
 const mockNavigate = vi.fn();
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
 
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-let mockIsAuth = false;
+let mockIsAuth = true;
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ isAuth: mockIsAuth }),
 }));
@@ -41,125 +42,112 @@ const mockProduct = {
   image: 'test.jpg',
 };
 
+const wishlistItemFromMock = {
+  productId: mockProduct.id,
+  title: mockProduct.title,
+  price: mockProduct.price,
+  image: mockProduct.image,
+};
+
 describe('HeartButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAuth = true;
     useWishlistStore.setState({ items: [] });
+
+    vi.mocked(wishlistService.addToWishlist).mockResolvedValue({
+      id: 'u1',
+      email: 'a@b.c',
+      wishlist: [],
+    });
+    vi.mocked(wishlistService.removeFromWishlist).mockResolvedValue({
+      id: 'u1',
+      email: 'a@b.c',
+      wishlist: [],
+    });
   });
 
-  it('renders with correct styles when isFavorite is true', () => {
-    render(<HeartButton product={mockProduct} isFavorite={true} />);
-
-    const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', 'Remove from wishlist');
-
-    const icon = button.querySelector('svg');
-    expect(icon).toHaveClass('stroke-red-600');
-  });
-
-  it('calls addToWishlist when clicked and not favorite', async () => {
+  it('renders add state when not favorite', () => {
     render(<HeartButton product={mockProduct} isFavorite={false} />);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
-    expect(wishlistService.addToWishlist).toHaveBeenCalledWith({
-      productId: mockProduct.id,
-      title: mockProduct.title,
-      price: mockProduct.price,
-      image: mockProduct.image,
-    });
-
-    await waitFor(() => {
-      const icon = button.querySelector('svg');
-      expect(icon).toHaveClass('stroke-red-600');
-    });
-
-    expect(mockShowMessage).toHaveBeenCalledWith(
-      'success',
-      'Added',
-      'Product added to wishlist',
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Add to wishlist',
+    );
+    expect(screen.getByRole('button').querySelector('svg')).toHaveClass(
+      'stroke-gray-400',
     );
   });
 
-  it('updates wishlist store when adding product to wishlist', () => {
+  it('renders remove state when favorite', () => {
+    render(<HeartButton product={mockProduct} isFavorite />);
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Remove from wishlist',
+    );
+    expect(screen.getByRole('button').querySelector('svg')).toHaveClass(
+      'stroke-red-600',
+    );
+  });
+
+  it('optimistically updates store, calls addToWishlist with product id, then shows success', async () => {
+    const user = userEvent.setup();
     render(<HeartButton product={mockProduct} isFavorite={false} />);
 
-    const button = screen.getByRole('button');
+    await user.click(screen.getByRole('button'));
 
-    fireEvent.click(button);
+    expect(useWishlistStore.getState().items).toEqual([wishlistItemFromMock]);
+    expect(wishlistService.addToWishlist).toHaveBeenCalledWith(mockProduct.id);
 
-    expect(useWishlistStore.getState().items).toEqual([
-      {
-        productId: mockProduct.id,
-        title: mockProduct.title,
-        price: mockProduct.price,
-        image: mockProduct.image,
-      },
-    ]);
+    await waitFor(() => {
+      expect(mockShowMessage).toHaveBeenCalledWith(
+        'success',
+        'Added',
+        'Product added to wishlist',
+      );
+    });
   });
 
-  it('updates wishlist store when removing product from wishlist', () => {
-    useWishlistStore.setState({
-      items: [
-        {
-          productId: mockProduct.id,
-          title: mockProduct.title,
-          price: mockProduct.price,
-          image: mockProduct.image,
-        },
-      ],
-    });
+  it('optimistically clears store, calls removeFromWishlist with product id, then shows success', async () => {
+    const user = userEvent.setup();
+    useWishlistStore.setState({ items: [wishlistItemFromMock] });
 
-    render(<HeartButton product={mockProduct} isFavorite={true} />);
+    render(<HeartButton product={mockProduct} isFavorite />);
 
-    const button = screen.getByRole('button');
-
-    fireEvent.click(button);
+    await user.click(screen.getByRole('button'));
 
     expect(useWishlistStore.getState().items).toEqual([]);
-  });
-
-  it('calls removeFromWishlist when clicked and is favorite', async () => {
-    render(<HeartButton product={mockProduct} isFavorite={true} />);
-
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
     expect(wishlistService.removeFromWishlist).toHaveBeenCalledWith(
       mockProduct.id,
     );
 
     await waitFor(() => {
-      const icon = button.querySelector('svg');
-      expect(icon).toHaveClass('stroke-gray-400');
+      expect(mockShowMessage).toHaveBeenCalledWith(
+        'success',
+        'Removed',
+        'Product removed from wishlist',
+      );
     });
-
-    expect(mockShowMessage).toHaveBeenCalledWith(
-      'success',
-      'Removed',
-      'Product removed from wishlist',
-    );
   });
 
-  it('reverts state on service failure', async () => {
+  it('rolls back favorite and store when add fails for authenticated user', async () => {
+    const user = userEvent.setup();
     vi.mocked(wishlistService.addToWishlist).mockRejectedValueOnce(
       new Error('Wishlist unavailable'),
     );
 
     render(<HeartButton product={mockProduct} isFavorite={false} />);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
-    const icon = button.querySelector('svg');
-    expect(icon).toHaveClass('stroke-red-600');
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
-      expect(icon).toHaveClass('stroke-gray-400');
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Add to wishlist',
+      );
     });
-
+    expect(useWishlistStore.getState().items).toEqual([]);
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockShowMessage).toHaveBeenCalledWith(
       'error',
@@ -168,23 +156,8 @@ describe('HeartButton', () => {
     );
   });
 
-  it('rolls back wishlist store on add failure', async () => {
-    vi.mocked(wishlistService.addToWishlist).mockRejectedValueOnce(
-      new Error('Wishlist unavailable'),
-    );
-
-    render(<HeartButton product={mockProduct} isFavorite={false} />);
-
-    const button = screen.getByRole('button');
-
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(useWishlistStore.getState().items).toEqual([]);
-    });
-  });
-
-  it('navigates to login on failure when guest', async () => {
+  it('navigates to login when add fails and user is not authenticated', async () => {
+    const user = userEvent.setup();
     mockIsAuth = false;
     vi.mocked(wishlistService.addToWishlist).mockRejectedValueOnce(
       new Error('Unauthorized'),
@@ -192,43 +165,78 @@ describe('HeartButton', () => {
 
     render(<HeartButton product={mockProduct} isFavorite={false} />);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(ROUTES.LOGIN);
     });
   });
 
-  it('disables button during loading state', async () => {
+  it('restores wishlist item when remove fails', async () => {
+    const user = userEvent.setup();
+    useWishlistStore.setState({ items: [wishlistItemFromMock] });
+    vi.mocked(wishlistService.removeFromWishlist).mockRejectedValueOnce(
+      new Error('Network error'),
+    );
+
+    render(<HeartButton product={mockProduct} isFavorite />);
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(useWishlistStore.getState().items).toEqual([wishlistItemFromMock]);
+    });
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Remove from wishlist',
+    );
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      'error',
+      'Wishlist Error',
+      'Network error',
+    );
+  });
+
+  it('disables the button while the wishlist request is in flight', async () => {
+    const user = userEvent.setup();
     vi.mocked(wishlistService.addToWishlist).mockImplementation(
-      () => new Promise((res) => setTimeout(res, 50)),
+      () => new Promise((resolve) => setTimeout(resolve, 50)),
     );
 
     render(<HeartButton product={mockProduct} isFavorite={false} />);
 
     const button = screen.getByRole('button');
-    fireEvent.click(button);
+    const clickPromise = user.click(button);
 
-    expect(button).toBeDisabled();
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+
+    await clickPromise;
 
     await waitFor(() => {
       expect(button).not.toBeDisabled();
     });
   });
 
-  it('syncs local favorite state when isFavorite prop changes', () => {
+  it('syncs visible favorite state when isFavorite prop changes', () => {
     const { rerender } = render(
       <HeartButton product={mockProduct} isFavorite={false} />,
     );
 
-    let button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', 'Add to wishlist');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Add to wishlist',
+    );
 
     rerender(<HeartButton product={mockProduct} isFavorite />);
 
-    button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', 'Remove from wishlist');
-    expect(button.querySelector('svg')).toHaveClass('stroke-red-600');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Remove from wishlist',
+    );
+    expect(screen.getByRole('button').querySelector('svg')).toHaveClass(
+      'stroke-red-600',
+    );
   });
 });

--- a/src/components/HeartButton/HeartButton.tsx
+++ b/src/components/HeartButton/HeartButton.tsx
@@ -66,7 +66,7 @@ export const HeartButton = ({
 
         showMessage('success', 'Removed', 'Product removed from wishlist');
       } else {
-        await wishlistService.addToWishlist(wishlistItem);
+        await wishlistService.addToWishlist(product.id);
 
         showMessage('success', 'Added', 'Product added to wishlist');
       }

--- a/src/hooks/useCartSync.test.ts
+++ b/src/hooks/useCartSync.test.ts
@@ -3,96 +3,164 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '@/hooks/useAuth';
 import { cartService } from '@/services/cartService';
+import { productService } from '@/services/productService';
 import { useCartStore } from '@/store/useCartStore';
+import type { CartResponse } from '@/types/cart.types';
 
 import { useCartSync } from './useCartSync';
 
 vi.mock('@/hooks/useAuth');
 vi.mock('@/services/cartService');
+vi.mock('@/services/productService');
 vi.mock('@/store/useCartStore');
 
+type MockCartLine = {
+  product: {
+    id?: string;
+    _id?: string;
+    title: string;
+    price: number;
+    status: 'active';
+  };
+  quantity: number;
+};
+
 describe('useCartSync', () => {
+  let cartItems: MockCartLine[];
+  const setCart = vi.fn((next: MockCartLine[]) => {
+    cartItems = next;
+  });
+
+  const buildMockItems = (): MockCartLine[] => [
+    {
+      product: {
+        id: 'prod-1',
+        title: 'Product 1',
+        price: 100,
+        status: 'active' as const,
+      },
+      quantity: 2,
+    },
+  ];
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    cartItems = buildMockItems();
+    setCart.mockImplementation((next: MockCartLine[]) => {
+      cartItems = next;
+    });
+
+    const storeApi = {
+      get items() {
+        return cartItems;
+      },
+      setCart,
+    };
+
+    vi.mocked(useCartStore).mockImplementation(((selector?: unknown) => {
+      if (typeof selector === 'function') {
+        return (selector as (s: typeof storeApi) => unknown)(storeApi);
+      }
+      return storeApi;
+    }) as typeof useCartStore);
+
+    vi.mocked(useCartStore).getState = vi.fn(
+      () =>
+        ({
+          items: cartItems,
+          setCart,
+        }) as unknown as ReturnType<(typeof useCartStore)['getState']>,
+    );
+
+    vi.mocked(productService.getById).mockImplementation(
+      async (id: string) => ({
+        id,
+        title: 'P',
+        price: 1,
+        status: 'active',
+      }),
+    );
+
+    vi.mocked(cartService.updateCart).mockResolvedValue({
+      userId: 'test-user',
+      items: [],
+      total: 0,
+    } as CartResponse);
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  const mockItems = [
-    {
-      product: { id: 'prod-1', name: 'Product 1', price: 100 },
-      quantity: 2,
-    },
-  ];
-
   it('should not sync on initial mount', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     renderHook(() => useCartSync());
 
     vi.advanceTimersByTime(1000);
     expect(cartService.updateCart).not.toHaveBeenCalled();
+    expect(productService.getById).not.toHaveBeenCalled();
   });
 
   it('should not sync if not authenticated', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: false,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { rerender } = renderHook(() => useCartSync());
 
-    // Trigger items change
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...mockItems, { product: { id: 'prod-2' }, quantity: 1 }],
-    } as unknown as ReturnType<typeof useCartStore>);
+    cartItems = [
+      ...buildMockItems(),
+      {
+        product: {
+          id: 'prod-2',
+          title: 'Product 2',
+          price: 50,
+          status: 'active' as const,
+        },
+        quantity: 1,
+      },
+    ];
     rerender();
 
     vi.advanceTimersByTime(1000);
     expect(cartService.updateCart).not.toHaveBeenCalled();
+    expect(productService.getById).not.toHaveBeenCalled();
   });
 
   it('should sync after debounce when items change and authenticated', async () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { rerender } = renderHook(() => useCartSync());
 
-    // Initial mount skip
     expect(cartService.updateCart).not.toHaveBeenCalled();
 
-    // Change items
-    const newItems = [
-      ...mockItems,
+    cartItems = [
+      ...buildMockItems(),
       {
-        product: { id: 'prod-2', name: 'Product 2', price: 50 },
+        product: {
+          id: 'prod-2',
+          title: 'Product 2',
+          price: 50,
+          status: 'active' as const,
+        },
         quantity: 1,
       },
     ];
-    vi.mocked(useCartStore).mockReturnValue({
-      items: newItems,
-    } as unknown as ReturnType<typeof useCartStore>);
     rerender();
 
-    vi.advanceTimersByTime(500);
+    await vi.advanceTimersByTimeAsync(500);
     expect(cartService.updateCart).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(500);
+    await vi.advanceTimersByTimeAsync(500);
 
+    expect(productService.getById).toHaveBeenCalledWith('prod-1');
+    expect(productService.getById).toHaveBeenCalledWith('prod-2');
     expect(cartService.updateCart).toHaveBeenCalledWith([
       { productId: 'prod-1', quantity: 2 },
       { productId: 'prod-2', quantity: 1 },
@@ -103,57 +171,48 @@ describe('useCartSync', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    const itemsWithUnderscoreId = [
-      {
-        product: { _id: 'prod-mongo-1', name: 'Product 1', price: 100 },
-        quantity: 1,
-      },
-    ];
-    vi.mocked(useCartStore).mockReturnValue({
-      items: itemsWithUnderscoreId,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { rerender } = renderHook(() => useCartSync());
 
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...itemsWithUnderscoreId],
-    } as unknown as ReturnType<typeof useCartStore>);
+    cartItems = [
+      {
+        product: {
+          _id: 'prod-mongo-1',
+          title: 'Product 1',
+          price: 100,
+          status: 'active' as const,
+        },
+        quantity: 1,
+      },
+    ];
     rerender();
 
-    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(1000);
 
+    expect(productService.getById).toHaveBeenCalledWith('prod-mongo-1');
     expect(cartService.updateCart).toHaveBeenCalledWith([
       { productId: 'prod-mongo-1', quantity: 1 },
     ]);
   });
 
-  it('should debounce multiple changes', () => {
+  it('should debounce multiple changes', async () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { rerender } = renderHook(() => useCartSync());
 
-    // Change 1
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...mockItems],
-    } as unknown as ReturnType<typeof useCartStore>);
+    cartItems = [...cartItems];
     rerender();
-    vi.advanceTimersByTime(500);
+    await vi.advanceTimersByTimeAsync(500);
 
-    // Change 2
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...mockItems],
-    } as unknown as ReturnType<typeof useCartStore>);
+    cartItems = [...cartItems];
     rerender();
-    vi.advanceTimersByTime(500);
+    await vi.advanceTimersByTimeAsync(500);
 
     expect(cartService.updateCart).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(500);
+    await vi.advanceTimersByTimeAsync(500);
     expect(cartService.updateCart).toHaveBeenCalledTimes(1);
   });
 
@@ -162,23 +221,17 @@ describe('useCartSync', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
     vi.mocked(cartService.updateCart).mockRejectedValue(
       new Error('Network error'),
     );
 
     const { rerender } = renderHook(() => useCartSync());
 
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...mockItems],
-    } as unknown as ReturnType<typeof useCartStore>);
+    cartItems = [...cartItems];
     rerender();
 
-    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(1000);
 
-    // We need to wait for the promise inside setTimeout
     await vi.waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(
         'Failed to sync cart to backend:',
@@ -193,22 +246,13 @@ describe('useCartSync', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { unmount, rerender } = renderHook(() => useCartSync());
 
-    // Trigger sync
-    vi.mocked(useCartStore).mockReturnValue({
-      items: [...mockItems],
-    } as unknown as ReturnType<typeof useCartStore>);
     rerender();
 
-    // Timer should be set
     unmount();
 
-    // Advance time - sync should not be called because timer was cleared
     vi.advanceTimersByTime(1000);
     expect(cartService.updateCart).not.toHaveBeenCalled();
   });
@@ -217,16 +261,58 @@ describe('useCartSync', () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuth: true,
     } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useCartStore).mockReturnValue({
-      items: mockItems,
-    } as unknown as ReturnType<typeof useCartStore>);
 
     const { unmount } = renderHook(() => useCartSync());
 
-    // No changes triggered, so no timer set
     unmount();
 
-    // No errors should be thrown, and no calls should be made
     expect(cartService.updateCart).not.toHaveBeenCalled();
+  });
+
+  it('should remove inactive products from cart and omit them from sync', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuth: true,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    vi.mocked(productService.getById).mockImplementation(async (id: string) => {
+      if (id === 'prod-2') {
+        return {
+          id,
+          title: 'P2',
+          price: 50,
+          status: 'inactive',
+        };
+      }
+      return { id, title: 'P1', price: 100, status: 'active' };
+    });
+
+    const { rerender } = renderHook(() => useCartSync());
+
+    cartItems = [
+      ...buildMockItems(),
+      {
+        product: {
+          id: 'prod-2',
+          title: 'Product 2',
+          price: 50,
+          status: 'active' as const,
+        },
+        quantity: 1,
+      },
+    ];
+    rerender();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(setCart).toHaveBeenCalled();
+
+    expect(setCart).toHaveBeenCalledWith([
+      {
+        product: expect.objectContaining({ id: 'prod-1' }),
+        quantity: 2,
+      },
+    ]);
+    expect(cartService.updateCart).toHaveBeenCalledWith([
+      { productId: 'prod-1', quantity: 2 },
+    ]);
   });
 });

--- a/src/hooks/useCartSync.ts
+++ b/src/hooks/useCartSync.ts
@@ -2,7 +2,12 @@ import { useEffect, useRef } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { cartService } from '@/services/cartService';
+import { productService } from '@/services/productService';
 import { useCartStore } from '@/store/useCartStore';
+import type { CartItem } from '@/types/cart.types';
+
+const lineProductId = (item: CartItem) =>
+  String(item.product.id || item.product._id);
 
 export const useCartSync = () => {
   const { isAuth } = useAuth();
@@ -24,12 +29,41 @@ export const useCartSync = () => {
 
     debounceTimer.current = setTimeout(async () => {
       try {
-        const payload = items.map((item) => ({
-          productId: String(item.product.id || item.product._id),
-          quantity: item.quantity,
-        }));
+        const snapshot = useCartStore.getState().items;
+        const ids = [...new Set(snapshot.map(lineProductId))];
 
-        await cartService.updateCart(payload);
+        const activeIds = new Set(
+          (
+            await Promise.all(
+              ids.map(async (id) => {
+                try {
+                  const p = await productService.getById(id);
+                  return String(p.status).toLowerCase() === 'active'
+                    ? id
+                    : null;
+                } catch {
+                  return null;
+                }
+              }),
+            )
+          ).filter((id): id is string => id !== null),
+        );
+
+        const pruned =
+          ids.length === 0
+            ? snapshot
+            : snapshot.filter((item) => activeIds.has(lineProductId(item)));
+
+        if (pruned.length !== snapshot.length) {
+          useCartStore.getState().setCart(pruned);
+        }
+
+        await cartService.updateCart(
+          pruned.map((item) => ({
+            productId: lineProductId(item),
+            quantity: item.quantity,
+          })),
+        );
       } catch (error) {
         console.error('Failed to sync cart to backend:', error);
       }

--- a/src/services/wishlist.service.ts
+++ b/src/services/wishlist.service.ts
@@ -16,8 +16,8 @@ export interface UserResponse {
 export const wishlistService = {
   getMe: (): Promise<UserResponse> => apiClient.get<UserResponse>('/users/me'),
 
-  addToWishlist: (product: UserWishlistItem): Promise<UserResponse> =>
-    apiClient.patch<UserResponse>('/users/me/wishlist', product),
+  addToWishlist: (productId: string): Promise<UserResponse> =>
+    apiClient.patch<UserResponse>('/users/me/wishlist', { productId }),
 
   removeFromWishlist: (productId: string): Promise<UserResponse> =>
     apiClient.delete<UserResponse>(`/users/me/wishlist/${productId}`),


### PR DESCRIPTION
- useCartSync: Fetches product status before /cart; keeps only active lines, updates the store, then syncs.
- Wishlist: addToWishlist(productId) + { productId } in PATCH; HeartButton updated.
- Tests: useCartSync + HeartButton adjusted for the above.