### PR TITLE
fix(486): heart icon over filter on shop page

### DIFF
--- a/src/components/HeartButton/HeartButton.tsx
+++ b/src/components/HeartButton/HeartButton.tsx
@@ -98,7 +98,7 @@ export const HeartButton = ({
       type="button"
       onClick={handleToggle}
       disabled={isLoading}
-      className="absolute top-3 right-3 z-20 flex h-10 w-10 items-center justify-center rounded-full border border-gray-100 bg-white shadow-sm transition-all hover:scale-110 active:scale-90 disabled:opacity-70 dark:border-neutral-700 dark:bg-neutral-800"
+      className="absolute top-3 right-3 flex h-10 w-10 items-center justify-center rounded-full border border-gray-100 bg-white shadow-sm transition-all hover:scale-110 active:scale-90 disabled:opacity-70 dark:border-neutral-700 dark:bg-neutral-800"
       aria-label={isFavorite ? 'Remove from wishlist' : 'Add to wishlist'}
     >
       <Heart

--- a/src/components/ShopFilters/ShopFilters.tsx
+++ b/src/components/ShopFilters/ShopFilters.tsx
@@ -115,7 +115,7 @@ export function ShopFilters() {
     });
   };
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+    <div className="relative z-40 flex flex-col gap-4 sm:flex-row sm:items-end">
       <div className={DROPDOWN_WRAPPER_CLASS}>
         <Dropdown
           label="Categories"


### PR DESCRIPTION
Fixed a visual bug where the heart icon on the product card overlapped the filter dropdown menus (`Categories` and `Price`).