### PR TITLE
fix(492): adjust theme change on contact page

### DIFF
--- a/src/components/EngineerCard/EngineerCard.tsx
+++ b/src/components/EngineerCard/EngineerCard.tsx
@@ -14,7 +14,7 @@ export const EngineerCard: React.FC<EngineerCardProps> = ({
 }) => {
   return (
     <div className="group flex cursor-pointer flex-col items-center text-center">
-      <div className="mb-5 aspect-square w-full overflow-hidden rounded-2xl bg-gray-50 shadow-sm transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl">
+      <div className="mb-5 aspect-square w-full overflow-hidden rounded-2xl bg-gray-50 shadow-sm transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl dark:bg-gray-800">
         {photoUrl ? (
           <img
             src={photoUrl}
@@ -31,7 +31,7 @@ export const EngineerCard: React.FC<EngineerCardProps> = ({
       </div>
 
       <div className="mb-4">
-        <h3 className="text-lg font-bold text-gray-800 transition-colors duration-300 group-hover:text-blue-600">
+        <h3 className="text-lg font-bold text-gray-800 transition-colors duration-300 group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
           {name}
         </h3>
       </div>

--- a/src/pages/Contact/Contact.tsx
+++ b/src/pages/Contact/Contact.tsx
@@ -6,14 +6,14 @@ import { ENGINEERS } from '@/constants/engineers';
 
 export const Contact: React.FC = () => {
   return (
-    <div className="min-h-screen bg-white">
-      <section className="border-b border-gray-200 bg-white">
+    <div className="min-h-screen bg-white transition-colors duration-300 dark:bg-black">
+      <section className="border-b border-gray-200 bg-white transition-colors duration-300 dark:border-gray-800 dark:bg-black">
         <div className="mx-auto max-w-3xl px-6 pt-12 pb-6 text-center">
-          <h1 className="mb-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            Our Best Engineers
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-gray-900 transition-colors duration-300 sm:text-5xl dark:text-white">
+            Our Best Engineers Our Best Engineers
           </h1>
 
-          <p className="mb-6 text-lg leading-relaxed text-gray-600">
+          <p className="mb-6 text-lg leading-relaxed text-gray-600 transition-colors duration-300 dark:text-gray-400">
             A passionate group of engineers building the future of technology.
             Reach out - we're always happy to connect.
           </p>


### PR DESCRIPTION
Resolves bug #492 where headings and repository labels became invisible in dark mode. Theme switching has been configured on the Contact page.