### PR TITLE
fix(483): show category validation error in product form

### DIFF
--- a/src/components/Dropdown/CategoryDropdown.tsx
+++ b/src/components/Dropdown/CategoryDropdown.tsx
@@ -19,6 +19,9 @@ export const CategoryDropdown = ({
   hasBorder = true,
   multiple = true,
   disabled = false,
+  required = false,
+  error = false,
+  helperText,
 }: DropdownProps) => {
   const [open, setOpen] = useState(false);
 
@@ -67,7 +70,12 @@ export const CategoryDropdown = ({
         nativeLabel={false}
         render={<div />}
       >
-        {label}
+        {label}{' '}
+        {required && (
+          <span aria-hidden="true" className="font-bold text-red-600">
+            *
+          </span>
+        )}
       </Field.Label>
       <Select.Root
         multiple={multiple}
@@ -78,9 +86,14 @@ export const CategoryDropdown = ({
         onOpenChange={setOpen}
       >
         <Select.Trigger
-          className={clsx(styles.Select, selectClassName)}
+          className={clsx(
+            styles.Select,
+            error && '!border-red-600 focus-visible:!ring-red-600',
+            selectClassName,
+          )}
           data-border={hasBorder}
           data-disabled={disabled || undefined}
+          aria-invalid={error || undefined}
         >
           <Select.Value className="hidden" />
           <span className="truncate">{content}</span>
@@ -113,6 +126,11 @@ export const CategoryDropdown = ({
           </Select.Positioner>
         </Select.Portal>
       </Select.Root>
+      {helperText && (
+        <p className="mt-1 text-xs text-red-600" role="alert">
+          {helperText}
+        </p>
+      )}
     </Field.Root>
   );
 };

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -16,4 +16,6 @@ export interface DropdownProps {
   disabled?: boolean;
   required?: boolean;
   closeOnSelect?: boolean;
+  error?: boolean;
+  helperText?: string;
 }

--- a/src/components/ProductForm/ProductForm.tsx
+++ b/src/components/ProductForm/ProductForm.tsx
@@ -413,6 +413,9 @@ export const ProductForm: React.FC<ProductFormProps> = ({
                     : []
                 }
                 placeholder="No category selected"
+                required
+                error={!!errors.categories}
+                helperText={errors.categories?.message}
                 onChange={(selected) => {
                   const newValue = selected.map((opt) => opt.value).join(', ');
                   field.onChange(newValue);


### PR DESCRIPTION
- Added error and helperText support to CategoryDropdown
- Displayed a red validation message when no category is selected
- Added required indicator for the Categories field
- Highlighted the dropdown border when validation fails

<img width="747" height="521" alt="image" src="https://github.com/user-attachments/assets/cccbc9b4-2b4b-4145-aa22-d0e1d9e94c6b" />

Resolves https://github.com/UA-5399-React/docs/issues/483
